### PR TITLE
Changes the behavior for the PlanOperation::distribute() method

### DIFF
--- a/src/bin/units_access/hash_build.cpp
+++ b/src/bin/units_access/hash_build.cpp
@@ -97,8 +97,8 @@ TEST_F(HashBuildTest, merge_two_tables_test) {
   auto hash = std::dynamic_pointer_cast<SingleAggregateHashTable >(hb.getResultHashTable());
 
   //test to merge two tables
-  auto t1 = std::make_shared<TableRangeView>(t, 0, 4);
-  auto t2 = std::make_shared<TableRangeView>(t, 5, 9);
+  auto t1 = std::make_shared<TableRangeView>(t, 0, 5);
+  auto t2 = std::make_shared<TableRangeView>(t, 5, 10);
   
   HashBuild hb1;
   hb1.addInput(t1);

--- a/src/bin/units_storage/tablerangeview_tests.cpp
+++ b/src/bin/units_storage/tablerangeview_tests.cpp
@@ -16,7 +16,7 @@ TEST_F(TableRangeViewTests, init_pc) {
   {
     hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
 
-    TableRangeView *trv = new TableRangeView(t, 0, t->size()-1);
+    TableRangeView *trv = new TableRangeView(t, 0, t->size());
     ASSERT_EQ(t->size(), trv->size());
 
     size_t row = 2;
@@ -39,7 +39,7 @@ TEST_F(TableRangeViewTests, pc_using_factory) {
 
   auto trv = TableRangeViewFactory::createView(t, start, end);
 
-  ASSERT_EQ(trv->size(), (end-start+1));
+  ASSERT_EQ(trv->size(), (end-start));
 
   ValueId i = trv->getValueId(column, row-start);
   ValueId i2 = t->getValueId(column,row);

--- a/src/lib/access/GroupByScan.cpp
+++ b/src/lib/access/GroupByScan.cpp
@@ -74,9 +74,9 @@ void GroupByScan::splitInput() {
     distribute(hashTables[0]->numKeys(), first, last);
 
     if ((_indexed_field_definition.size() + _named_field_definition.size()) == 1)
-      hashTables[0] = std::dynamic_pointer_cast<SingleAggregateHashTable>(hashTables[0])->view(first, last + 1);
+      hashTables[0] = std::dynamic_pointer_cast<SingleAggregateHashTable>(hashTables[0])->view(first, last);
     else
-      hashTables[0] = std::dynamic_pointer_cast<AggregateHashTable>(hashTables[0])->view(first, last + 1);
+      hashTables[0] = std::dynamic_pointer_cast<AggregateHashTable>(hashTables[0])->view(first, last);
   }
 }
 

--- a/src/lib/access/PlanOperation.cpp
+++ b/src/lib/access/PlanOperation.cpp
@@ -156,13 +156,12 @@ void _PlanOperation::distribute(
     const u_int64_t numberOfElements,
     u_int64_t &first,
     u_int64_t &last) const {
+
   const u_int64_t
-      elementsPerPart     = numberOfElements / _count,
-      remainingElements   = numberOfElements - elementsPerPart * _count,
-      extraElements       = _part <= remainingElements ? _part : remainingElements,
-      partsExtraElement   = _part < remainingElements ? 1 : 0;
-  first                   = elementsPerPart * _part + extraElements;
-  last                    = first + elementsPerPart + partsExtraElement - 1;
+      elementsPerPart     = numberOfElements / _count;
+
+  first = elementsPerPart * _part;
+  last = _part + 1 == _count ? numberOfElements : elementsPerPart * (_part + 1);
 }
 
 void _PlanOperation::refreshInput() {

--- a/src/lib/storage/TableRangeView.cpp
+++ b/src/lib/storage/TableRangeView.cpp
@@ -23,7 +23,7 @@ size_t TableRangeView::getStart() const{
 }
 
 size_t TableRangeView::size() const {
-  return _end-_start+1;
+  return _end-_start;
 }
 
 void TableRangeView::setValueId(const size_t column, const size_t row, const ValueId valueId){


### PR DESCRIPTION
Now the out paramers will be start and end with end be one after
the acutal element so it can be used as in traditional while x < end
comparisons
