### PR TITLE
Implementing ScriptPlan Operations for HYRISE

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -10,6 +10,7 @@ export IMH_PROJECT_PATH := $(shell pwd)$(TOP)
 # Set up conservative settings
 PRODUCTION ?= 0
 USE_GOOGLE_PROFILER ?= 0
+USE_V8 ?= 0
 MANUAL_PERF_IMPRO ?= 0
 COVERAGE_TESTING ?= 0
 PAPI_TRACE ?= 0
@@ -105,6 +106,18 @@ endif
 ifeq ($(USE_BACKWARD), 1)
 	BUILD_FLAGS += -D BACKWARD_HAS_BFD -D USE_BACKWARD
 	LINKER_FLAGS += -lbfd
+endif
+
+ifeq ($(USE_V8), 1)
+	BUILD_FLAGS += -D WITH_V8
+	LINKER_FLAGS += -lv8
+	PROJECT_INCLUDE += $(V8_BASE_DIRECTORY)/include
+	ifeq ($(PRODUCTION), 1)
+		LINKER_DIR += $(V8_BASE_DIRECTORY)/out/x64.release/obj.target/tools/gyp
+	else
+		LINKER_DIR += $(V8_BASE_DIRECTORY)/out/x64.debug/obj.target/tools/gyp
+	endif
+	
 endif
 
 JSON_PATH	:=	$(IMH_PROJECT_PATH)/third_party/jsoncpp

--- a/docs/query_execution.rst
+++ b/docs/query_execution.rst
@@ -20,4 +20,5 @@ experiments with different settings.
     queryexecution/available_operators
     queryexecution/parallelization
     queryexecution/json_plan_operations
+    queryexecution/v8ops
 

--- a/docs/queryexecution/v8ops.rst
+++ b/docs/queryexecution/v8ops.rst
@@ -1,0 +1,90 @@
+.. _v8ops:
+
+*********************
+Integrating Google V8
+*********************
+
+Hyrise comes with the possibility to implement plan operations in JavaScript
+instead of C++ to ease the prototypical development. Of course the performance
+of these plan operations will not reach a highly optimized C++ code, but can
+help to asses the algorithmic performance of sample operations.
+
+This document gives an overview how the integration between V8 and HYRISE is
+achieved and how the interface between JavaScript and C++ is defined.
+
+
+Using JavaScript for Plan Operations
+====================================
+
+Googles V8 is integrated as a separate and independent component that will be
+included and linked during compile time. Currently, we propose to download the
+most recent version of V8 from their website and compile manually. To enable
+JavaScript plan operations you have to set the following variables in the
+``settings.mk`` file::
+
+	USE_V8 = 1
+	V8_BASE_DIRECTORY=path/to/v8/base
+
+Now, the ScriptPlan operation is enabled and allows to write new plan
+operations in JavaScript.
+
+Once you started HYRISE you can call plan operations that are stored in plain
+text JavaScript files that are available to the server. The environment
+variable ``HYRISE_SCRIPT_PATH`` determines the base folder where the server
+expects to find those files. If the variable is not set, int points to the
+directory from where the server was launched.
+
+Defining a new Plan Operation
+-----------------------------
+
+The minmal plan operation defines a script that defines the following function::
+
+	function hyrise_run_op(input) {
+	}
+
+The variable ``input`` defines an array that contains all references to input
+tables of the plan operation. The requirement is that the function will return
+a single table as output.
+
+API for the Plan Operation
+--------------------------
+
+In general, the idea is to offer the same API that is known from the
+``AbstractTable`` interface to the JS side. However, there are some
+limitations to this approach. The biggest problem is creating lot's of
+intermediate results is very time consuming and will break the advantage of
+using JS.
+
+The most important operations on a table are:
+
+* ``getAttributeVectors()`` - equivalent to the version of the AbstractTable.
+   Intended to directly access the underlaying storage of the table.
+* ``valueId(col, row)`` - returns the value ID struct with valueId and tableId
+* ``ValueIdV(col, row)`` - only returns the value ID value
+* ``resize(num)`` - resize the table if possible, throw exception otherwise
+* ``setValueInt(col, row val)``
+* ``setValueFloat(col, row val)``
+* ``setValueString(col, row val)``
+* ``getValueInt(col, row val)``
+* ``getValueFloat(col, row val)``
+* ``getValueString(col, row val)``
+
+The following other functions are globally available:
+
+* ``copyStructureModifiable(table)``
+* ``createPointerCalculator(table, fields)``
+* ``buildVerticalTable(tab, tab)`` - concatenate two tables and build a vertical table
+* ``include(file)`` - include a file and make all functions globally available
+* ``log(string)`` - log string to the HYRISE logging facilities
+
+To create a custom output table the global function ``buildTable(spec,
+groups)`` should be used. A simple example to build a table would be::
+
+    buildTable([
+		{"type": "INTEGER", "name": "company_id"},
+		{"type": "STRING", "name": "company_name"}
+		],[2]);
+
+This example creates a two column table with the given attributes named by the
+first argument and the number of groups identified by the second parameter
+array.

--- a/settings.mk.default
+++ b/settings.mk.default
@@ -2,6 +2,7 @@
 
 PRODUCTION := 0
 USE_PROFILER := 0
+USE_V8 := 0
 COVERAGE_TESTING := 0
 VAMPIR_TRACE := 0
 PAPI_TRACE := 0
@@ -15,3 +16,7 @@ WITH_MYSQL := 0
 
 # COMPILER - Use a flag to customize your compiler
 # COMPILER:= g++experimentalfilter
+
+# If V8 is used you have to set the path where to find the
+# snapshot build
+# V8_BASE_DIRECTORY=

--- a/src/bin/units_access/ops_script.cpp
+++ b/src/bin/units_access/ops_script.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#include "testing/test.h"
+
+#ifdef WITH_V8
+
+#include "helper.h"
+#include <io/shortcuts.h>
+#include <helper/Settings.h>
+#include <access/ScriptOperation.h>
+#include <testing/TableEqualityTest.h>
+
+namespace hyrise {
+namespace access {
+
+class ScriptOperationTests : public AccessTest {
+public:
+	ScriptOperationTests() {
+		auto s = Settings::getInstance();
+		s->setScriptPath("./test/script");
+		tab = Loader::shortcuts::load("test/index_test.tbl");
+	}
+
+	hyrise::storage::c_atable_ptr_t tab;
+};
+
+TEST_F(ScriptOperationTests, pointer_calculator) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("hello");
+	op.execute();
+
+	auto reference = Loader::shortcuts::load("test/reference/ops_script_pc_ref.tbl");
+	auto result = op.getResultTable();
+	EXPECT_RELATION_EQ(result, reference);
+
+}
+
+TEST_F(ScriptOperationTests, copy_structure_modifiable) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("copy_structure");
+	op.execute();
+
+	auto reference = Loader::shortcuts::load("test/reference/ops_script_mutable_ref.tbl");
+	auto result = op.getResultTable();
+	EXPECT_RELATION_EQ(result, reference);
+}
+
+TEST_F(ScriptOperationTests, cant_set_values_on_input_table) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("no_set_values");
+	EXPECT_ANY_THROW(op.execute());
+}
+
+TEST_F(ScriptOperationTests, include_working) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("test_with_include");
+	op.execute();
+}
+
+TEST_F(ScriptOperationTests, include_working_wrong_file) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("test_with_include_bad");
+	EXPECT_ANY_THROW(op.execute());
+}
+
+TEST_F(ScriptOperationTests, build_table) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("build_table");
+	op.execute();
+
+	auto reference = Loader::shortcuts::load("test/tables/companies.tbl");
+	auto result = op.getResultTable();
+	EXPECT_RELATION_EQ(result, reference);
+}
+
+TEST_F(ScriptOperationTests, build_table_wrong) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("build_table_bad");
+	EXPECT_ANY_THROW(op.execute());
+}
+
+TEST_F(ScriptOperationTests, build_vertical_table) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("build_vtab");
+	op.execute();
+
+	auto reference = Loader::shortcuts::load("test/tables/companies.tbl");
+	auto result = op.getResultTable();
+	EXPECT_RELATION_EQ(result, reference);
+}
+
+TEST_F(ScriptOperationTests, get_attribute_vectors_scan) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("get_attribute_vectors_scan");
+	op.execute();
+
+	auto reference = Loader::shortcuts::load("test/reference/ops_script_pc_ref.tbl");
+	auto result = op.getResultTable();
+	EXPECT_RELATION_EQ(result, reference);
+}
+
+TEST_F(ScriptOperationTests, get_attribute_vectors_scan_range) {
+	ScriptOperation op;
+	op.addInput(tab);
+	op.setScriptName("get_attribute_vectors_scan_range");
+	op.execute();
+
+	auto reference = Loader::shortcuts::load("test/reference/ops_script_pc_ref.tbl");
+	auto result = op.getResultTable();
+	EXPECT_RELATION_EQ(result, reference);
+}
+
+}}
+
+#endif

--- a/src/lib/access/ScriptOperation.cpp
+++ b/src/lib/access/ScriptOperation.cpp
@@ -1,0 +1,670 @@
+
+
+#include "access/ScriptOperation.h"
+#include <storage/PointerCalculator.h>
+#include <storage/MutableVerticalTable.h>
+#include <storage/TableBuilder.h>
+#include <storage/FixedLengthVector.h>
+
+#include <helper/Settings.h>
+#include <helper/types.h>
+
+#ifdef WITH_V8
+#include <v8.h>
+#endif
+
+#include <cstdio>
+#include <functional>
+
+namespace hyrise { namespace access { 
+
+namespace {
+  log4cxx::LoggerPtr _logger(log4cxx::Logger::getLogger("hyrise.access"));
+  auto _ = QueryParser::registerPlanOperation<ScriptOperation>("ScriptOperation");
+}
+
+ScriptOperation::ScriptOperation() {
+
+}
+
+#ifdef WITH_V8
+
+template<typename T>
+v8::Local<v8::Object> wrapAttributeVector(std::shared_ptr<const T> table, size_t internal);
+
+// This is the context data that we use in the isolate data per process.
+// Basically it contains a map of all available tables to the plan operation
+// with given keys. The key is the offset in this table. The first tables in
+// this list are always the input tables of the plan operation
+struct IsolateContextData {
+  std::vector<hyrise::storage::c_atable_ptr_t> tables;
+};
+
+
+
+template<typename T>
+void releaseTableSharedPtr(v8::Isolate* isolate, v8::Persistent<v8::Value> persistentObj, void* pData) {
+  auto pspNative = reinterpret_cast<std::shared_ptr<const T>*>(pData);
+  delete pspNative;
+  // Manually dispose of the Persistent handle
+  persistentObj.Dispose(isolate);
+  persistentObj.Clear();
+}
+
+
+/// This is a helper function that frees allocated objects that were
+/// created using new. 
+template<typename T>
+void deleteAllocated(v8::Isolate* isolate, v8::Persistent<v8::Value> persitentObj, void* data) {
+  auto native = reinterpret_cast<T*>(data);
+  delete native;
+  persitentObj.Dispose(isolate);
+  persitentObj.Clear();
+}
+
+
+/// Helper function that wraps the current local handle in a
+/// persistent handle to register destructors and embedd native data
+v8::Persistent<v8::Object> makePersistent(v8::Isolate *isolate, v8::Handle<v8::Object> object, void *embedded, v8::NearDeathCallback callback) {
+  v8::Persistent<v8::Object> persistentObj( v8::Persistent<v8::Object>::New(isolate, object));
+  persistentObj.MakeWeak(isolate, embedded, callback);
+  return persistentObj;
+}
+
+
+v8::Handle<v8::Value> LogMessage(const v8::Arguments& args) {
+  v8::String::Utf8Value str(args[0]);
+  LOG4CXX_DEBUG(_logger, *str);
+  return v8::Undefined();
+}
+
+// This function is used to read a JS file from disk into a std::string object.
+//
+// @param name The name / relative path of the file
+// @param suffix The suffix of the file, that defaults to ".j"
+std::string readScript(const std::string &name, const std::string &suffix = ".js") {
+  FILE* file = fopen((Settings::getInstance()->getScriptPath() + "/" + name + suffix).c_str(), "rb");
+  if (file == NULL) throw std::runtime_error("Could not find file " + name);
+
+  fseek(file, 0, SEEK_END);
+  int size = ftell(file);
+  rewind(file);
+
+  char* chars = new char[size + 1];
+  chars[size] = '\0';
+  for (int i = 0; i < size;) {
+    int read = static_cast<int>(fread(&chars[i], 1, size - i, file));
+    i += read;
+  }
+  fclose(file);
+  std::string result(chars, size);
+  delete[] chars;
+  return result;
+}
+
+// Implementation of the helper method that allows to include other JavaScript
+// file read from local files and compile and run them into the VM
+v8::Handle<v8::Value> Include(const v8::Arguments& args) {
+    for (int i = 0; i < args.Length(); i++) {
+        v8::String::Utf8Value str(args[i]);
+
+        std::string js_file;
+        try {
+          js_file = readScript(*str);
+        } catch (std::exception &e) {
+          return v8::ThrowException(v8::String::New(e.what()));
+        }
+
+        if(js_file.length() > 0) {
+            v8::Handle<v8::String> source = v8::String::New(js_file.c_str());
+            v8::Handle<v8::Script> script = v8::Script::Compile(source);
+            return script->Run();
+        }
+    }
+    return v8::Undefined();
+}
+
+
+// These are the wrapped functions of the abstract table
+v8::Handle<v8::Value> TableGetSize(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  void* ptr = wrap->Value();
+  size_t value = static_cast<AbstractTable*>(ptr)->size();
+  return handle_scope.Close(v8::Integer::New(value));
+}
+
+
+// Implementation that returns number of columns of the table
+v8::Handle<v8::Value> TableGetColumnCount(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  void* ptr = wrap->Value();
+  size_t value = static_cast<AbstractTable*>(ptr)->columnCount();
+  return handle_scope.Close(v8::Integer::New(value));
+}
+
+// Simple Converter form std::string to v8::String
+struct StringToV8String {
+  static v8::Handle<v8::String> New(std::string a) {
+    return v8::String::New(a.c_str());
+  }
+};
+
+// Templated method to allow easy wrapping of the getValue<type> method from
+// the table
+template<typename In, typename Out>
+v8::Handle<v8::Value> TableGetValue(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  void* ptr = wrap->Value();
+  auto value = static_cast<AbstractTable*>(ptr)->getValue<In>(args[0]->Uint32Value(), args[1]->Uint32Value());
+  return handle_scope.Close(Out::New(value));
+}
+
+// Helper function that checks if the object has a property set that is called
+// _isModifiable. This property defines if the table is modifiable or not
+bool IsModifiable(const v8::Local<v8::Object> &ext) {
+  return ext->Get(v8::String::New("_isModifiable"))->ToBoolean()->Value();
+}
+
+// methods to allow easy wrapping of the setValue<type> method from
+// the table
+v8::Handle<v8::Value> TableSetValueInt(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  if(!IsModifiable(args.This())) {
+    return v8::ThrowException(v8::String::New("Table is not modifiable."));
+  }
+  void* ptr = wrap->Value();
+  static_cast<AbstractTable*>(ptr)->setValue<hyrise_int_t>(args[0]->Uint32Value(), args[1]->Uint32Value(),args[2]->Int32Value());
+  return handle_scope.Close(v8::Undefined());
+}
+
+v8::Handle<v8::Value> TableSetValueFloat(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  if(!IsModifiable(args.This())) {
+    return v8::ThrowException(v8::String::New("Table is not modifiable."));
+  }
+  void* ptr = wrap->Value();
+  static_cast<AbstractTable*>(ptr)->setValue<hyrise_float_t>(args[0]->Uint32Value(), args[1]->Uint32Value(),v8::Local<v8::Number>::Cast(args[2])->Value());
+  return handle_scope.Close(v8::Undefined());
+}
+
+v8::Handle<v8::Value> TableSetValueString(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  if(!IsModifiable(args.This())) {
+    return v8::ThrowException(v8::String::New("Table is not modifiable."));
+  }
+  void* ptr = wrap->Value();
+  v8::String::Utf8Value u(args[2]->ToString());
+  static_cast<AbstractTable*>(ptr)->setValue<hyrise_string_t>(args[0]->Uint32Value(), args[1]->Uint32Value(),hyrise_string_t(*u));
+  return handle_scope.Close(v8::Undefined());
+}
+
+// Implementation of the function that calls AbstractTable->resize() This
+// function is required for all cases where new rows are appended to the table,
+// if resize is not called the table will not know how many rows it should
+// allocate
+v8::Handle<v8::Value> TableResize(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  if(!IsModifiable(args.This())) {
+    return v8::ThrowException(v8::String::New("Table is not modifiable."));
+  }
+  void* ptr = wrap->Value();
+  auto tab = static_cast<AbstractTable*>(ptr);
+  auto casted = dynamic_cast<MutableVerticalTable*>(tab);
+  if (casted) {
+    casted->resize(args[0]->Uint32Value());
+  } else {
+    auto casted2 = dynamic_cast<Table<>*>(tab);
+    casted2->resize(args[0]->Uint32Value());
+  }
+  
+  return handle_scope.Close(v8::Undefined());
+}
+
+// Returns an object of the value id
+v8::Handle<v8::Value> TableGetValueId(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  void* ptr = wrap->Value();
+  auto vid = static_cast<AbstractTable*>(ptr)->getValueId(args[0]->Uint32Value(), args[1]->Uint32Value());
+  
+  v8::Handle<v8::Object> templ = v8::Object::New();
+  templ->Set(v8::String::New("valueId"), v8::Integer::New(vid.valueId));
+  templ->Set(v8::String::New("tableId"), v8::Integer::New(vid.table));
+
+  return templ;
+}
+
+// Returns the value ID of the value id
+v8::Handle<v8::Value> TableGetValueIdV(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  void* ptr = wrap->Value();
+  auto vid = static_cast<AbstractTable*>(ptr)->getValueId(args[0]->Uint32Value(), args[1]->Uint32Value()).valueId;
+  return v8::Number::New(vid);
+}
+
+// Returns the value ID of the value id
+v8::Handle<v8::Value> TableGetValueIdVRange(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  
+  size_t col = args[0]->ToInteger()->Value();
+  size_t row = args[1]->ToInteger()->Value();
+  size_t stop =  args[2]->ToInteger()->Value();
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  void* ptr = wrap->Value();
+
+  auto tab = static_cast<AbstractTable*>(ptr);
+  auto data = v8::Object::New();
+
+  auto vids = new std::vector<value_id_t>;
+  for(size_t i=row, j=0; i < stop; ++i, ++j) {
+    auto vid = tab->getValueId(col, i).valueId;
+    vids->push_back(vid);
+  }
+
+  // We wrap the data in a persistent object to be able to free the vids once we are done
+  data->SetIndexedPropertiesToExternalArrayData( &(vids->at(0)), v8::kExternalUnsignedIntArray, (stop-row));
+  auto persistent = makePersistent(isolate, data, vids, deleteAllocated<std::vector<value_id_t>>);
+  return persistent;
+}
+
+
+v8::Handle<v8::Value> AttributeVectorGetSize(const v8::Arguments& args) {
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  auto ptr = static_cast<AbstractAttributeVector*>(wrap->Value());
+  auto casted = dynamic_cast<FixedLengthVector<value_id_t>*>(ptr);
+  size_t value = casted->size();
+  return v8::Integer::New(value);
+}
+
+v8::Handle<v8::Value> AttributeVectorGet(const v8::Arguments& args) {
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  auto ptr = static_cast<AbstractAttributeVector*>(wrap->Value());
+  auto casted = dynamic_cast<FixedLengthVector<value_id_t>*>(ptr);
+
+  auto col = args[0]->ToInteger()->Value();
+  auto row = args[1]->ToInteger()->Value();
+
+  value_id_t value = casted->get(col, row);
+  return v8::Integer::New(value);
+}
+
+v8::Handle<v8::Value> AttributeVectorGetRange(const v8::Arguments& args) {
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  auto ptr = static_cast<AbstractAttributeVector*>(wrap->Value());
+  auto casted = dynamic_cast<FixedLengthVector<value_id_t>*>(ptr);
+
+  size_t col = args[0]->ToInteger()->Value();
+  size_t row = args[1]->ToInteger()->Value();
+  size_t stop = args[2]->ToInteger()->Value();
+
+  auto data = v8::Object::New();
+
+  std::vector<value_id_t> vids;
+  for(size_t i=row; i < stop; ++i) {
+    auto vid = casted->get(col, i);
+    vids.push_back(vid);
+  }
+
+  // FIXME: we have to make sure that data has no longer lifespan than data
+  data->SetIndexedPropertiesToExternalArrayData( &vids[0], v8::kExternalUnsignedIntArray, (stop-row));
+  return data;
+}
+
+
+    
+
+// Represents the Internal id of the table in the input list of the plan
+// operation
+v8::Handle<v8::Value> GetInternalId(v8::Local<v8::String> property, const v8::AccessorInfo &info) {
+  return v8::Local<v8::Integer>::Cast(info.Data());
+}
+
+
+template<typename T>
+v8::Local<v8::Object> wrapAttributeVector(std::shared_ptr<T> table, size_t internal) {
+
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Handle<v8::ObjectTemplate> templ = v8::ObjectTemplate::New();
+  templ->SetInternalFieldCount(1);
+
+  templ->Set(v8::String::New("size"), v8::FunctionTemplate::New(AttributeVectorGetSize));
+  templ->Set(v8::String::New("get"), v8::FunctionTemplate::New(AttributeVectorGet));
+  templ->Set(v8::String::New("getRange"), v8::FunctionTemplate::New(AttributeVectorGetRange));
+
+  templ->SetAccessor(v8::String::New("_internalId"), GetInternalId, nullptr, v8::Integer::New(internal));
+
+  auto obj = templ->NewInstance();
+  obj->SetInternalField(0, v8::External::New(table.get()));
+  return handle_scope.Close(obj);
+}
+
+
+v8::Handle<v8::Value> TableGetAttributeVectors(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  auto wrap = v8::Local<v8::External>::Cast(args.This()->GetInternalField(0));
+  void* ptr = wrap->Value();
+  auto tab = static_cast<AbstractTable*>(ptr);
+
+  auto attr_vectors = tab->getAttributeVectors(args[0]->ToInteger()->Value());
+  auto result = v8::Array::New(attr_vectors.size());
+
+  size_t i=0;
+  for(auto &av : attr_vectors) {
+    auto obj = v8::Object::New();
+    obj->Set(v8::String::New("attribute_vector"), wrapAttributeVector<AbstractAttributeVector>(av.attribute_vector, i));
+    obj->Set(v8::String::New("attribute_offset"), v8::Number::New(av.attribute_offset));
+    result->Set(i++, obj);
+  }
+  return result;
+}
+
+
+// Basic function to wrap an abstract table and expose the main methods, the
+// most important methods are to access the number of fields, size and the
+// valueId and values at a given set of column row coordinates
+template<typename T>
+v8::Local<v8::Object> wrapTable(std::shared_ptr<const T> table, size_t internal) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Handle<v8::ObjectTemplate> templ = v8::ObjectTemplate::New();
+  templ->SetInternalFieldCount(1);
+
+  // Set wrapped methods
+  templ->Set(v8::String::New("size"), v8::FunctionTemplate::New(TableGetSize));
+  templ->Set(v8::String::New("columnCount"), v8::FunctionTemplate::New(TableGetColumnCount));
+  templ->Set(v8::String::New("valueId"), v8::FunctionTemplate::New(TableGetValueId));
+  templ->Set(v8::String::New("valueIdV"), v8::FunctionTemplate::New(TableGetValueIdV));
+  templ->Set(v8::String::New("valueIdVRange"), v8::FunctionTemplate::New(TableGetValueIdVRange));
+  templ->Set(v8::String::New("getValueInt"), v8::FunctionTemplate::New(TableGetValue<hyrise_int_t, v8::Number>));
+  templ->Set(v8::String::New("getValueFloat"), v8::FunctionTemplate::New(TableGetValue<hyrise_float_t, v8::Number>));
+  templ->Set(v8::String::New("getValueString"), v8::FunctionTemplate::New(TableGetValue<hyrise_string_t, StringToV8String>));
+  
+  templ->Set(v8::String::New("setValueInt"), v8::FunctionTemplate::New(TableSetValueInt));
+  templ->Set(v8::String::New("setValueFloat"), v8::FunctionTemplate::New(TableSetValueFloat));
+  templ->Set(v8::String::New("setValueString"), v8::FunctionTemplate::New(TableSetValueString));
+  templ->Set(v8::String::New("resize"), v8::FunctionTemplate::New(TableResize));
+
+  templ->Set(v8::String::New("getAttributeVectors"), v8::FunctionTemplate::New(TableGetAttributeVectors));
+
+  templ->SetAccessor(v8::String::New("_internalId"), GetInternalId, nullptr, v8::Integer::New(internal));
+
+  auto obj = templ->NewInstance();
+  obj->Set(v8::String::New("_isModifiable"), v8::Boolean::New(false));
+  obj->SetInternalField(0, v8::External::New(const_cast<T*>(table.get())));
+
+  auto persistentObj = makePersistent(isolate, obj, new std::shared_ptr<const T>(table), releaseTableSharedPtr<T>);
+  return handle_scope.Close(persistentObj);
+}
+
+
+// Create a pointer calculator based on the input, the function has two
+// arguments, first the table and second the position list
+v8::Handle<v8::Value> createPointerCalculator(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  IsolateContextData *isoContext = static_cast<IsolateContextData*>(isolate->GetData());
+
+  // The base table
+  auto object = v8::Local<v8::Object>::Cast(args[0]);
+  auto internal = object->Get(v8::String::New("_internalId"))->Uint32Value();
+
+  // Get the JS Array and build a vector
+  auto positions = v8::Local<v8::Array>::Cast(args[1]);
+  auto size = positions->Length();
+
+  auto pos = new pos_list_t;
+  for(size_t i=0; i < size; ++i) {
+    pos->push_back(positions->Get(v8::Integer::New(i))->Uint32Value());
+  }
+
+  // Create a new table based from the position list and input table
+  auto result = std::make_shared<PointerCalculator>(isoContext->tables[internal], pos);
+  isoContext->tables.push_back(result);
+  auto obj = wrapTable<PointerCalculator>(result, isoContext->tables.size()-1);
+  return handle_scope.Close(obj);
+}
+
+// Create an empty modifiable based on the input, the function has two
+// arguments, first the table and second the position list
+v8::Handle<v8::Value> CopyStructureModifiable(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  IsolateContextData *isoContext = static_cast<IsolateContextData*>(isolate->GetData());
+
+  // The base table
+  auto object = v8::Local<v8::Object>::Cast(args[0]);
+  auto internal = object->Get(v8::String::New("_internalId"))->Uint32Value();
+
+  // Create a new table based from the position list and input table
+  auto result = isoContext->tables[internal]->copy_structure_modifiable();
+  isoContext->tables.push_back(result);
+  auto obj = wrapTable<AbstractTable>(result, isoContext->tables.size()-1);
+  obj->Set(v8::String::New("_isModifiable"), v8::Boolean::New(true));
+
+  return handle_scope.Close(obj);
+}
+
+// Build a new table using the table builder object
+//
+// The first arguments are a list of the field names with types and names, the
+// second argument are the groups of attributes
+v8::Handle<v8::Value> BuildTable(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  IsolateContextData *isoContext = static_cast<IsolateContextData*>(isolate->GetData());
+
+  if (!args[0]->IsArray() && !args[1]->IsArray()) {
+    return v8::ThrowException(v8::String::New("Arguments must be two arrays with field decls and groups"));
+  }
+
+  auto fields = v8::Local<v8::Array>::Cast(args[0]);
+  auto groups = v8::Local<v8::Array>::Cast(args[1]);
+
+  TableBuilder::param_list list;
+  for(size_t i=0; i < fields->Length(); ++i ) {
+    auto tmp = v8::Local<v8::Object>::Cast(fields->Get(i));
+    list.append().set_type(*v8::String::Utf8Value(tmp->Get(v8::String::New("type")))).set_name(
+      *v8::String::Utf8Value(tmp->Get(v8::String::New("name"))));
+  }
+
+  for(size_t i=0; i < groups->Length(); ++i ) {
+    auto tmp = v8::Local<v8::Integer>::Cast(groups->Get(i));
+    list.appendGroup(tmp->Value());
+  }
+
+  
+  hyrise::storage::atable_ptr_t  result = TableBuilder::build(list);
+  isoContext->tables.push_back(result);
+  auto obj = wrapTable<AbstractTable>(result, isoContext->tables.size()-1);
+  obj->Set(v8::String::New("_isModifiable"), v8::Boolean::New(true));
+
+  return handle_scope.Close(obj);
+}
+
+// Create a new vertical table based on the number of arguments in the input
+// list. We use the internal id of the object to lookup all tables in the 
+// global table list.
+v8::Handle<v8::Value> BuildVerticalTable(const v8::Arguments& args) {
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  IsolateContextData *isoContext = static_cast<IsolateContextData*>(isolate->GetData());
+  std::vector<hyrise::storage::atable_ptr_t> tabs;
+  for(int i=0; i < args.Length(); ++i) {
+    // The base table
+    auto object = v8::Local<v8::Object>::Cast(args[i]);
+    auto internal = object->Get(v8::String::New("_internalId"))->Uint32Value();
+    // FIXME
+    tabs.push_back(std::const_pointer_cast<AbstractTable>(isoContext->tables[internal]));
+  }
+
+  // Create a new table based from the position list and input table
+  auto result = std::make_shared<MutableVerticalTable>(tabs);
+  isoContext->tables.push_back(result);
+  auto obj = wrapTable<AbstractTable>(result, isoContext->tables.size()-1);
+  obj->Set(v8::String::New("_isModifiable"), v8::Boolean::New(false));
+
+  return handle_scope.Close(obj);
+}
+
+// The goal of the result helpers is to provide the necessary functions to
+// present a usable result. This includes basically the following
+// possibilities:
+//   * create a PC with a pos List
+//   * create a new modifiable table based on the old table meta data
+//   * create a new modifiable table using the table builder
+//   * create a combination as a vertical table
+void ScriptOperation::createResultHelpers(v8::Persistent<v8::Context> &context) {
+  auto global = context->Global();
+
+  global->Set(v8::String::New("createPointerCalculator"), v8::FunctionTemplate::New(createPointerCalculator)->GetFunction());
+  global->Set(v8::String::New("copyStructureModifiable"), v8::FunctionTemplate::New(CopyStructureModifiable)->GetFunction());
+  global->Set(v8::String::New("buildTable"), v8::FunctionTemplate::New(BuildTable)->GetFunction());
+  global->Set(v8::String::New("buildVerticalTable"), v8::FunctionTemplate::New(BuildVerticalTable)->GetFunction());
+  global->Set(v8::String::New("include"), v8::FunctionTemplate::New(Include)->GetFunction());
+  global->Set(v8::String::New("log"), v8::FunctionTemplate::New(LogMessage)->GetFunction());
+}
+
+// Helper method that wraps the input of the plan operation into table objects
+// that provide the necessary fields in the JS world. The most important
+// methods are wrapped and available for callers in JS
+v8::Handle<v8::Array> ScriptOperation::prepareInputs() {
+
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Handle<v8::Array> result = v8::Array::New(input.size());
+  // Fill out the values
+  for(size_t i=0; i < input.size(); ++i) {
+    // FIXME evil wrapper handling for our const inputs
+    result->Set(i, wrapTable<AbstractTable>(input.getTable(i), i));
+  }
+  
+  // Return the value through Close.
+  return handle_scope.Close(result);
+}
+
+
+#endif
+
+void ScriptOperation::executePlanOperation() {
+
+#ifdef WITH_V8
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  if (isolate == nullptr)
+  {
+    isolate = v8::Isolate::New();
+    isolate->Enter();
+  }
+  
+
+  // Set the data in the isolate context
+  auto isoContext = new IsolateContextData();
+  for( const auto& t : input.allOf<AbstractTable>()) {
+    isoContext->tables.push_back(t);
+  }
+  isolate->SetData(isoContext);
+
+
+  // Create a stack-allocated handle scope.
+  v8::HandleScope handle_scope(isolate);
+
+  // Create a new context.
+  v8::Persistent<v8::Context> context = v8::Context::New();
+  
+  // Enter the created context for compiling and
+  // running the script. 
+  v8::Context::Scope context_scope(context);
+
+  // Create a string containing the JavaScript source code.
+  auto content = readScript(_scriptName);
+  if (content.size() == 0) {
+    throw std::runtime_error("Script is empty, cannot run empty script: " + _scriptName);
+  }
+
+  v8::Handle<v8::String> source = v8::String::New(content.c_str(), content.size());
+
+  // Add Helper Functions
+  createResultHelpers(context);
+
+
+  // Compile the source code. 
+  {
+    v8::TryCatch trycatch;
+    v8::Handle<v8::Script> script = v8::Script::Compile(source);
+    if (script.IsEmpty()) {
+      throw std::runtime_error(*v8::String::Utf8Value(trycatch.Exception()));
+    }
+    auto check = script->Run();
+    if (check.IsEmpty()) {
+      throw std::runtime_error(*v8::String::Utf8Value(trycatch.Exception()));
+    }
+
+    // Once the source is compiled there must be a method available whis is
+    // called hyrise_run_op
+    v8::Local<v8::Function> fun = v8::Local<v8::Function>::Cast(context->Global()->Get(v8::String::New("hyrise_run_op")));
+    if (fun->IsFunction()) {
+      // Call the plan op with the inputs we converted
+      v8::Handle<v8::Value> argv[] = {prepareInputs()};
+      auto result = v8::Local<v8::Object>::Cast(fun->Call(fun, 1, argv));
+      if (result.IsEmpty()) {
+        throw std::runtime_error(*v8::String::Utf8Value(trycatch.Exception()));
+      }
+      // Unwrap the data and extract the shared_ptr for the result
+      size_t internal = result->Get(v8::String::New("_internalId"))->Uint32Value();
+      addResult(isoContext->tables[internal]);
+    }
+  }
+
+  // free the isolation context data we use
+  delete isoContext;
+
+  // Dispose the persistent context.
+  context.Dispose(isolate);
+#endif 
+
+}
+
+std::shared_ptr<_PlanOperation> ScriptOperation::parse(Json::Value &data) {
+  auto op = std::make_shared<ScriptOperation>();
+  op->setScriptName(data["script"].asString());
+  return op;
+}
+
+}}
+

--- a/src/lib/access/ScriptOperation.h
+++ b/src/lib/access/ScriptOperation.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#ifndef SRC_LIB_ACCESS_SCRIPTOPERATION_H_
+#define SRC_LIB_ACCESS_SCRIPTOPERATION_H_
+
+
+#include "access/PlanOperation.h"
+
+#ifdef WITH_V8
+#include <v8.h>
+#endif
+
+namespace hyrise {
+namespace access {
+
+/// This is a simple scriptable plan operation that allows to write the
+/// operation itself in JavaScript instead of C++ for rapid prototyping
+class ScriptOperation : public _PlanOperation {
+
+private:
+
+  // The Script Name to execute
+  std::string _scriptName;
+
+public:
+  
+  ScriptOperation();
+  
+  void executePlanOperation();
+
+  static std::shared_ptr<_PlanOperation> parse(Json::Value &data);
+
+  inline void setScriptName(std::string n) { _scriptName = n; }
+
+private:
+
+#ifdef WITH_V8
+  // Convert the input to an JS Array
+  v8::Handle<v8::Array> prepareInputs();
+
+  void createResultHelpers(v8::Persistent<v8::Context> &context);
+#endif
+  
+};
+
+}
+}
+
+#endif /* SRC_LIB_ACCESS_SCRIPTOPERATION_H_ */

--- a/src/lib/helper/Settings.cpp
+++ b/src/lib/helper/Settings.cpp
@@ -1,5 +1,14 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "Settings.h"
+#include "Environment.h"
+
+Settings::Settings() : threadpoolSize(1) {
+
+  // Initiate the class based on Enviroment Variables
+  setDBPath(getEnv("HYRISE_DB_PATH", ""));
+  setScriptPath(getEnv("HYRISE_SCRIPT_PATH", ""));
+
+}
 
 size_t Settings::getThreadpoolSize() const {
   return this->threadpoolSize;

--- a/src/lib/helper/Settings.h
+++ b/src/lib/helper/Settings.h
@@ -3,16 +3,31 @@
 #define SRC_LIB_HELPER_SETTINGS_H_
 
 #include <cstddef>
+#include <string>
+
+#define ADD_MEMBER(type, member) private: \
+  type _##member; \
+  public: \
+  type get##member() const { return _##member;} \
+  void set##member(const type nm ) { _##member = nm;}\
+
+
 
 /*  Singleton data container class for global settings.
     Use SettingsOperation to manipulate global settings as long as units
     implementing certain decisions are missing. */
+
 class Settings {
+  
   size_t threadpoolSize;
-  Settings() :
-      threadpoolSize(1)
-  {}
+
+  ADD_MEMBER(std::string, ScriptPath);
+  ADD_MEMBER(std::string, DBPath);
+
+  Settings();
+
  public:
+
   ~Settings() {}
   static Settings *getInstance() {
     static Settings *instance = nullptr;

--- a/src/lib/io/StorageManager.cpp
+++ b/src/lib/io/StorageManager.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "helper/stringhelpers.h"
+#include "helper/Environment.h"
 #include "io/CSVLoader.h"
 #include "storage/AbstractTable.h"
 #include "storage/TableBuilder.h"
@@ -108,12 +109,7 @@ std::mutex instance_mtx;
 void StorageManager::setupSystem() {
   std::lock_guard<std::mutex> lock(instance_mtx);
   if (!_initialized) {
-    char *data_path;
-    data_path = getenv("HYRISE_DB_PATH");
-    if (data_path != nullptr)
-      _root_path = std::string(data_path);
-    else
-      _root_path = "";
+    _root_path = getEnv("HYRISE_DB_PATH", "");
     // add the statistics table
     addStorageTable(SYS_STATISTICS, buildStatisticsTable());
     _initialized = true;

--- a/test/autojson/ops_script_simple.json
+++ b/test/autojson/ops_script_simple.json
@@ -1,0 +1,17 @@
+{
+	"operators" : {
+		"reference" : {
+			"type": "TableLoad",
+            "table": "reference",
+            "filename": "tables/companies.tbl"
+		},
+		"script" : {
+			"type" : "ScriptOperation",
+			"script": "build_vtab"
+		}
+	},
+
+	"edges" : [
+	["script", "script"]
+	]
+}

--- a/test/reference/ops_script_mutable_ref.tbl
+++ b/test/reference/ops_script_mutable_ref.tbl
@@ -1,0 +1,5 @@
+col_0|col_1|col_2|col_3|col_4|col_5|col_6|col_7|col_8|col_9
+INTEGER|FLOAT|STRING|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER
+0_R | 1_R | 1_R | 1_R | 1_R | 1_R | 1_R | 1_R | 2_C | 3_C 
+===
+1 | 2.0 | Hallo | 1 | 2 | 3 | 4 | 5 | 6 | 7

--- a/test/reference/ops_script_pc_ref.tbl
+++ b/test/reference/ops_script_pc_ref.tbl
@@ -1,0 +1,7 @@
+col_0|col_1|col_2|col_3|col_4|col_5|col_6|col_7|col_8|col_9
+INTEGER|FLOAT|STRING|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER
+0_R | 1_R | 1_R | 1_R | 1_R | 1_R | 1_R | 1_R | 2_C | 3_C 
+===
+0|1.1|2|3|4|5|6|7|8|9
+20|21.1|22|23|24|25|26|27|28|29
+40|41.1|42|43|44|45|46|47|48|49

--- a/test/script/base.js
+++ b/test/script/base.js
@@ -1,0 +1,3 @@
+function buildTable(fields, groups) {
+	
+}

--- a/test/script/build_table.js
+++ b/test/script/build_table.js
@@ -1,0 +1,19 @@
+function hyrise_run_op(input) {
+	var result = buildTable([
+		{"type": "INTEGER", "name": "company_id"},
+		{"type": "STRING", "name": "company_name"}
+		],[2]);
+
+	result.resize(4);
+	result.setValueInt(0,0,1);
+	result.setValueInt(0,1,2);
+	result.setValueInt(0,2,3);
+	result.setValueInt(0,3,4);
+
+	result.setValueString(1,0,"Apple Inc");
+	result.setValueString(1,1,"Microsoft");
+	result.setValueString(1,2,"SAP AG");
+	result.setValueString(1,3,"Oracle");
+
+	return result;
+}

--- a/test/script/build_table_bad.js
+++ b/test/script/build_table_bad.js
@@ -1,0 +1,16 @@
+function hyrise_run_op(input) {
+	var result = buildTable();
+
+	result.resize(4);
+	result.setValueInt(0,0,1);
+	result.setValueInt(0,1,2);
+	result.setValueInt(0,2,3);
+	result.setValueInt(0,3,4);
+
+	result.setValueString(1,0,"Apple Inc");
+	result.setValueString(1,1,"Microsoft");
+	result.setValueString(1,2,"SAP AG");
+	result.setValueString(1,3,"Oracle");
+
+	return result;
+}

--- a/test/script/build_vtab.js
+++ b/test/script/build_vtab.js
@@ -1,0 +1,25 @@
+function hyrise_run_op(input) {
+	var a = buildTable([
+		{"type": "INTEGER", "name": "company_id"},
+		],[1]);
+
+	var b = buildTable([
+		{"type": "STRING", "name": "company_name"}
+		],[1]);
+
+	a.resize(4);
+	a.setValueInt(0,0,1);
+	a.setValueInt(0,1,2);
+	a.setValueInt(0,2,3);
+	a.setValueInt(0,3,4);
+
+	b.resize(4);
+	b.setValueString(0,0,"Apple Inc");
+	b.setValueString(0,1,"Microsoft");
+	b.setValueString(0,2,"SAP AG");
+	b.setValueString(0,3,"Oracle");
+
+	var result = buildVerticalTable(a, b);
+
+	return result;
+}

--- a/test/script/copy_structure.js
+++ b/test/script/copy_structure.js
@@ -1,0 +1,15 @@
+function hyrise_run_op(input) {
+	var x = copyStructureModifiable(input[0]);
+	x.resize(1);
+	x.setValueInt(0,0, 1);
+	x.setValueFloat(1,0, 2.0);
+	x.setValueString(2,0, "Hallo");
+	x.setValueInt(3,0, 1);
+	x.setValueInt(4,0, 2);
+	x.setValueInt(5,0, 3);
+	x.setValueInt(6,0, 4);
+	x.setValueInt(7,0, 5);
+	x.setValueInt(8,0, 6);
+	x.setValueInt(9,0, 7);
+	return x;
+}

--- a/test/script/get_attribute_vectors_scan.js
+++ b/test/script/get_attribute_vectors_scan.js
@@ -1,0 +1,17 @@
+function hyrise_run_op(input) {
+
+	var avs =input[0].getAttributeVectors(0);
+
+	var av0 = avs[0].attribute_vector;
+	var of0 = avs[0].attribute_offset;
+	var size = av0.size();
+
+	var pos = []
+	for(var i=0; i < size; ++i) {
+		var tmp = av0.get(of0, i);
+		if ( tmp < 5 && tmp % 2 == 0)
+			pos.push(i);
+	}
+
+	return createPointerCalculator(input[0], pos);
+}

--- a/test/script/get_attribute_vectors_scan_range.js
+++ b/test/script/get_attribute_vectors_scan_range.js
@@ -1,0 +1,36 @@
+function hyrise_run_op(input) {
+
+	var avs =input[0].getAttributeVectors(0);
+
+	var av0 = avs[0].attribute_vector;
+	var of0 = avs[0].attribute_offset;
+	var size = av0.size();
+
+	log(av0.size());
+
+	var i =0;
+	var batch = 2;
+
+	var pos = [];
+
+	while(i < size ) {
+		var upper = i + batch;
+
+		if (upper > size) {
+			upper = size;
+			batch = upper - i;
+		}
+
+		var d = av0.getRange(of0, i, upper);
+		for(var j=0; j < batch; ++j) {
+			var tmp = d[j];
+			if ( tmp < 5 && tmp % 2 == 0)
+				pos.push(i+j);
+			
+		}
+
+		i = upper;
+	}
+
+	return createPointerCalculator(input[0], pos);
+}

--- a/test/script/hello.js
+++ b/test/script/hello.js
@@ -1,0 +1,4 @@
+function hyrise_run_op(input) {
+	var x = createPointerCalculator(input[0], [0,2,4]);
+	return x;
+}

--- a/test/script/no_set_values.js
+++ b/test/script/no_set_values.js
@@ -1,0 +1,3 @@
+function hyrise_run_op(input) {
+	input[0].setValueInt(0,0,0);
+}

--- a/test/script/simple.js
+++ b/test/script/simple.js
@@ -1,0 +1,1 @@
+function test() { return 42; }

--- a/test/script/test_with_include.js
+++ b/test/script/test_with_include.js
@@ -1,0 +1,7 @@
+include("simple")
+
+function hyrise_run_op(input) {
+	var x = copyStructureModifiable(input[0]);
+	test();
+	return x;
+}

--- a/test/script/test_with_include_bad.js
+++ b/test/script/test_with_include_bad.js
@@ -1,0 +1,7 @@
+include("simple_bad")
+
+function hyrise_run_op(input) {
+	var x = copyStructureModifiable(input[0]);
+	test();
+	return x;
+}


### PR DESCRIPTION
Adds the possibility to write plan operations in JavaScript instead of C++
for easier prototyping. To enable this feature see the documentation and
accompanying unit tests in src/bin/units_access/ops_script.cpp. Attention
this feature is still in beta.
