### PR TITLE
Add precompiled headers to improve build speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,6 @@ hyrise_server.port
 TAGS
 
 third_party/llvm*
-
+src/lib/*.gch
 
 test/advertising/data.txt

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ include config.mk
 lib_dir = $(build_dir)/lib
 bin_dir = $(build_dir)/bin
 
+phase1 := $(build_dir)/phase1
+
 # library dependencies
 lib_storage := $(lib_dir)/storage
 lib_access  := $(lib_dir)/access
@@ -57,7 +59,7 @@ bin_dummy := $(bin_dir)/dummy
 binaries :=  $(server_hyrise) $(bin_dummy)
 # list all build targets
 
-tgts :=  $(libraries) $(binaries) $(all_test_suites) $(regression_suite) $(regression_datagen)
+tgts :=  $(libraries) $(binaries) $(all_test_suites) $(regression_suite) $(regression_datagen) $(phase1)
 
 .PHONY: all $(tgts) tags test test_basic hudson_build hudson_test $(all_test_binaries) doxygen docs
 
@@ -69,6 +71,7 @@ $(tgts):
 
 # dependencies betweeen binaries and libraries
 
+$(libraries): $(phase1)
 $(lib_ebb):
 $(lib_helper):
 $(lib_memory):

--- a/build/phase1/Makefile
+++ b/build/phase1/Makefile
@@ -1,0 +1,1 @@
+include $(IMH_PROJECT_PATH)/footer.mk

--- a/footer.mk
+++ b/footer.mk
@@ -30,9 +30,12 @@ linker_dir_flags = $(addprefix -L, $(linker_dirs))
 
 makefiles := $(shell find $(BUILD_DIR) -type f -name Makefile) $(IMH_PROJECT_PATH)/*.mk
 
+precompiled_header_source ?= $(IMH_PROJECT_PATH)/src/lib/stdlib.hpp
+precompiled_header ?= $(precompiled_header_source).gch
+
 VPATH := $(src_dir)
 
-all:: $(lib) $(bin)
+all:: $(precompiled_header) $(lib) $(bin)
 
 $(bin): $(objects)
 	$(call echo_cmd,BINARY $@) $(LD) -o $@ $(objects) $(LINKER_FLAGS) $(BINARY_LINKER_FLAGS) $(lib_dependencies) $(linker_dir_flags)
@@ -40,20 +43,17 @@ $(bin): $(objects)
 $(lib): $(objects) 
 	$(call echo_cmd,LINK $@) $(LD) $(SHARED_LIB) -o $@ $(objects) $(LINKER_FLAGS) $(lib_dependencies) $(linker_dir_flags)
 
-%.o: %.cpp $(makefiles)
-	$(call echo_cmd,CXX $<) $(CXX) $(CXX_BUILD_FLAGS) $(include_flags) -c -o $@ $< 
+%.o: %.cpp $(makefiles) $(precompiled_header)
+	$(call echo_cmd,CXX $<) $(CXX) -MMD -MP $(CXX_BUILD_FLAGS) $(include_flags) -Winvalid-pch -include $(precompiled_header_source) -c -o $@ $< 
 
 %.o: %.c $(makefiles)
-	$(call echo_cmd,CC $<) $(CC) $(CC_BUILD_FLAGS) $(include_flags) -c -o $@ $< 
-
-%.d : %.cpp
-	$(call echo_cmd,DEP $<) $(CXX) -MF"$@" -MM $(CXX_BUILD_FLAGS) $(CXX_DEBUG) $(include_flags) "$<"
-
-%.d : %.c
-	$(call echo_cmd,DEP $<) $(CXX) -MF"$@" -MM $(CC_BUILD_FLAGS) $(CC_DEBUG) $(include_flags) "$<"
+	$(call echo_cmd,CC $<) $(CC) -MMD -MP $(CC_BUILD_FLAGS) $(include_flags) -c -o $@ $< 
 
 clean::
-	-$(call echo_cmd,CLEAN $(bin)$(lib)) $(RM) -rf $(src_dir)/*.d $(src_dir)/*.o $(objects) $(dependencies) $(bin) $(lib)
+	-$(call echo_cmd,CLEAN $(bin)$(lib)) $(RM) -rf $(src_dir)/*.d $(src_dir)/*.o $(objects) $(dependencies) $(bin) $(lib) $(precompiled_header)
+
+$(precompiled_header): $(precompiled_header_source) $(makefiles)
+	$(call echo_cmd,PRECOMPILING $<) $(CXX) $(CXX_BUILD_FLAGS) $(include_flags) $(precompiled_header_source)
 
 ifneq "$(MAKECMDGOALS)" "clean"
     -include $(dependencies)

--- a/src/lib/access/JoinScan.h
+++ b/src/lib/access/JoinScan.h
@@ -9,6 +9,7 @@
 #include "access/predicates.h"
 #include "helper/types.h"
 
+
 /// Defines the std::string appended to columns when renaming is necessary
 #define RENAMED_COLUMN_APPENDIX_LEFT "_0"
 #define RENAMED_COLUMN_APPENDIX_RIGHT "_1"

--- a/src/lib/stdlib.hpp
+++ b/src/lib/stdlib.hpp
@@ -1,0 +1,23 @@
+#ifndef PCH_STDLIB_H
+#define PCH_STDLIB_H
+
+#include <vector>
+#include <string>
+#include <memory>
+#include <functional>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <array>
+#include <algorithm>
+#include <set>
+#include <cstdint>
+#include <iostream>
+#include <atomic>
+#include <thread>
+#include "boost/mpl/vector.hpp"
+#include "boost/mpl/map.hpp"
+#include "boost/lexical_cast.hpp"
+#include "gtest/gtest.h"
+
+#endif

--- a/src/lib/storage/GroupValue.cpp
+++ b/src/lib/storage/GroupValue.cpp
@@ -7,6 +7,8 @@
 #include "storage/hash_functor.h"
 #include "storage/storage_types_helper.h"
 
+#include "boost/functional/hash.hpp"
+
 u_int64_t GroupValue::hash_vids(const ValueIdList &vids) {
   u_int64_t h = FNV1_64_INIT;
   for(const ValueId& v: vids) {

--- a/src/lib/storage/OrderIndifferentDictionary.h
+++ b/src/lib/storage/OrderIndifferentDictionary.h
@@ -15,8 +15,6 @@
 #include <memory>
 #include <limits.h>
 
-#include <boost/unordered_map.hpp>
-#include <boost/functional/hash.hpp>
 #include <map>
 
 // FIXME should be aware of allocator


### PR DESCRIPTION
This adds a new first build stage "phase1" which consists
of precompiling `stdlib.hpp` in src/lib as a general header
that is then force -included into all .cpp compilations.

This severely reduces i/o seek times for the standard library
and large-ish parts of boost and should in turn drastically reduce
HYRISE compile time.
