### PR TITLE
Improving CCACHE usage, disable cleaning of precompiled headers

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -48,6 +48,9 @@ HYRISE_MYSQL_PASS ?= root
 OSTYPE = $(shell uname | tr '[A-Z]' '[a-z]')
 export build_dir ?= build
 
+# to properly use included headers
+CCACHE_SLOPPINESS := time_macros
+
 # OS switches
 ifneq (,$(findstring linux,$(OSTYPE)))
 	LIB_EXTENSION := so
@@ -117,7 +120,6 @@ ifeq ($(USE_V8), 1)
 	else
 		LINKER_DIR += $(V8_BASE_DIRECTORY)/out/x64.debug/obj.target/tools/gyp
 	endif
-	
 endif
 
 JSON_PATH	:=	$(IMH_PROJECT_PATH)/third_party/jsoncpp

--- a/footer.mk
+++ b/footer.mk
@@ -50,7 +50,7 @@ $(lib): $(objects)
 	$(call echo_cmd,CC $<) $(CC) -MMD -MP $(CC_BUILD_FLAGS) $(include_flags) -c -o $@ $< 
 
 clean::
-	-$(call echo_cmd,CLEAN $(bin)$(lib)) $(RM) -rf $(src_dir)/*.d $(src_dir)/*.o $(objects) $(dependencies) $(bin) $(lib) $(precompiled_header)
+	-$(call echo_cmd,CLEAN $(bin)$(lib)) $(RM) -rf $(src_dir)/*.d $(src_dir)/*.o $(objects) $(dependencies) $(bin) $(lib) #$(precompiled_header)
 
 $(precompiled_header): $(precompiled_header_source) $(makefiles)
 	$(call echo_cmd,PRECOMPILING $<) $(CXX) $(CXX_BUILD_FLAGS) $(include_flags) $(precompiled_header_source)


### PR DESCRIPTION
Due to recompilation of the precompiled header, ccache incorrectly assumes that its contents changed. Thus, this patch disables cleaning precompiled headers (they only need to change when they are actually changed or makefiles are touched, anyways).
