### PR TITLE
Adding Test Uncommited Helper

### DIFF
--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -1,0 +1,3 @@
+test_uncommited: unit_test_params = --minimal
+test_uncommited:
+	$(MAKE) `python tools/test_uncommited.py`

--- a/tools/test_uncommited.py
+++ b/tools/test_uncommited.py
@@ -1,0 +1,20 @@
+import re
+import subprocess
+
+
+git_call = "git ls-files --modified --others --exclude-standard"
+
+modules = ["access", "helper", "io", "layouter", "net", "memory", "storage", "taskscheduler"]
+
+result = subprocess.Popen(git_call.split(" "), stdout=subprocess.PIPE)
+files =  map(lambda x: x.strip(), result.stdout.read().split("\n"))
+
+tests = set()
+
+for f in files:
+	# Check libaries
+	for m in modules:
+		if re.match("src/lib/%s" % m, f):
+			tests.add("build/units_%s" % m)
+
+print(" ".join(tests))


### PR DESCRIPTION
This is a small helper script that will only run those unit tests with files
that were modified since the last push.

make test_uncommited

executes this command. This idea is more or less take from the rails
test:uncommited rake command. The module checking is done in the small
python script that maps the source paths agains the current module list.
