### PR TITLE
JSON Table (WIP)

### DIFF
--- a/src/bin/units_access/ops_json_table.cpp
+++ b/src/bin/units_access/ops_json_table.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#include "testing/test.h"
+#include "helper.h"
+#include "testing/TableEqualityTest.h"
+
+#include "access/JsonTable.h"
+
+#include <storage/Store.h>
+#include "io/shortcuts.h"
+
+
+namespace hyrise {
+namespace access {
+
+class JsonTableTest : public AccessTest {
+
+protected:
+
+  std::string _good_file;
+  std::string _good_file_store;
+
+  JsonTableTest(): _good_file("test/json/build_table_good.json"), _good_file_store("test/json/build_table_good_store.json") {
+  }
+
+};
+
+TEST_F(JsonTableTest, simple_test) {
+
+  JsonTable op;
+
+  op.setNames({"A", "B", "C"});
+  op.setTypes({"INTEGER", "STRING", "FLOAT"});
+  op.setGroups({3});
+
+  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+
+  op.execute();
+  auto result = op.getResultTable();
+
+  EXPECT_RELATION_SCHEMA_EQ(t, result);
+}
+
+TEST_F(JsonTableTest, simple_test_with_data) {
+
+  JsonTable op;
+
+  op.setNames({"company_id", "company_name"});
+  op.setTypes({"INTEGER", "STRING"});
+  op.setGroups({1,1});
+  op.setData({ {"1", "Apple Inc"}, {"2", "Microsoft"}, {"3", "SAP AG"}, {"4", "Oracle"}  });
+
+  auto t = Loader::shortcuts::load("test/tables/companies.tbl");
+
+  op.execute();
+  auto result = op.getResultTable();
+
+  EXPECT_RELATION_EQ(t, result);
+}
+
+
+
+TEST_F(JsonTableTest, builder_should_raise_in_case_of_errors_wrong_groups) {
+
+  JsonTable op;
+
+  op.setNames({"A", "B", "C"});
+  op.setTypes({"INTEGER", "STRING", "FLOAT"});
+  op.setGroups({3,3,3,3,3,3});
+
+  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  ASSERT_ANY_THROW(op.execute());
+}
+
+TEST_F(JsonTableTest, builder_should_raise_in_case_of_errors_wrong_type) {
+
+  JsonTable op;
+
+  op.setNames({"A", "B", "C"});
+  op.setTypes({"ISNTEGER", "STRING", "FLOAT"});
+  op.setGroups({3,3,3});
+
+  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  ASSERT_ANY_THROW(op.execute());
+}
+
+TEST_F(JsonTableTest, load_and_create_from_json) {
+  auto data = loadFromFile(_good_file);
+  auto result = executeAndWait(data);
+
+  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  EXPECT_RELATION_SCHEMA_EQ(t, result);
+
+  EXPECT_TRUE(std::dynamic_pointer_cast<const Store>(result) == nullptr);
+}
+
+TEST_F(JsonTableTest, load_and_create_from_json_store) {
+  auto data = loadFromFile(_good_file_store);
+  auto result = executeAndWait(data);
+
+  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  EXPECT_RELATION_SCHEMA_EQ(t, result);
+  EXPECT_TRUE(std::dynamic_pointer_cast<const Store>(result) != nullptr);
+}
+
+}
+}

--- a/src/lib/access/JsonTable.cpp
+++ b/src/lib/access/JsonTable.cpp
@@ -1,0 +1,132 @@
+#include "boost/lexical_cast.hpp"
+
+#include "JsonTable.h"
+
+
+#include <helper/types.h>
+#include <helper/vector_helpers.h>
+
+#include <storage/meta_storage.h>
+#include <storage/Store.h>
+#include <storage/TableBuilder.h>
+
+
+#include <algorithm>
+#include <iterator>
+#include <functional>
+
+namespace hyrise { namespace access	{
+	
+namespace {
+  auto _ = QueryParser::registerPlanOperation<JsonTable>("JsonTable");
+}
+
+JsonTable::JsonTable() : _useStoreFlag(false) {
+	
+}
+
+struct set_string_value_functor {
+
+	typedef void value_type;
+
+	hyrise::storage::atable_ptr_t tab;
+	size_t col;
+	size_t row;
+	std::string val;
+
+	set_string_value_functor(hyrise::storage::atable_ptr_t& t): tab(t), col(0), row(0) {
+	}
+
+	inline void set(size_t c, size_t r, std::string& v) {
+		row =r; col = c; val = v;
+	}
+
+	template<typename T>
+	inline value_type operator()() {
+		tab->setValue(col, row, boost::lexical_cast<T>(val));
+	}
+
+};
+
+void JsonTable::executePlanOperation() {
+
+	TableBuilder::param_list list;
+
+	for(size_t i=0, attr_size = _names.size(); i < attr_size; ++i)
+		list.append().set_name(_names[i]).set_type(_types[i]);
+	
+	for(size_t i=0, groups_size = _groups.size(); i < groups_size; ++i)
+		list.appendGroup(_groups[i]);
+
+
+	hyrise::storage::atable_ptr_t result = TableBuilder::build(list);
+	if (_useStoreFlag) {
+		auto tmp = std::make_shared<Store>(TableBuilder::build(list));
+		tmp->setDefaultMerger();
+		result = tmp;
+	}
+
+	// Add the rows if any
+	size_t rows = _data.size();
+	if (rows > 0 ) {
+		result->resize(rows);
+
+
+		set_string_value_functor fun(result);
+		hyrise::storage::type_switch<hyrise_basic_types> ts;
+
+		for(size_t i=0; i < rows; ++i) {
+			auto row = _data[i];
+			if (row.size() != _names.size())
+				throw std::runtime_error("Mismatch in provided data and number of columns in table!");
+
+			for(size_t j=0, rs = row.size(); j < rs; ++j) {
+				fun.set(j, i, row[j]);
+				ts(result->typeOfColumn(j), fun);
+			}
+		}
+	}
+
+	addResult(result);
+}
+
+std::shared_ptr<_PlanOperation> JsonTable::parse(Json::Value &data) {
+	auto result = std::make_shared<JsonTable>();
+
+	result->_names = collect(data["names"], [](const Json::Value& v) { return v.asString();});
+	result->_types = collect(data["types"], [](const Json::Value& v) { return v.asString();});
+	result->_groups = collect(data["groups"], [](const Json::Value& v) { return v.asUInt();});
+
+	if (data.isMember("data")) {
+		result->_data = collect(data["data"], [](Json::Value& v){
+			return collect(v, [](Json::Value& c){ return c.asString(); });
+		});
+	}
+
+	if (data.isMember("useStore")) {
+		result->setUseStore(data["useStore"].asBool());
+	}
+
+	return result;
+}
+
+void JsonTable::setData(const std::vector<std::vector<std::string>> d) {
+	_data = d;
+}
+
+void JsonTable::setNames(const std::vector<std::string> data) {
+	_names = data;
+}
+
+void JsonTable::setTypes(const std::vector<std::string> data) {
+	_types = data;
+}
+
+void JsonTable::setGroups(const std::vector<unsigned> data) {
+	_groups = data;
+}
+
+void JsonTable::setUseStore(const bool v) {
+	_useStoreFlag = v;
+}
+}}

--- a/src/lib/access/JsonTable.h
+++ b/src/lib/access/JsonTable.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#ifndef SRC_LIB_ACCESS_JSONTABLE_H_
+#define SRC_LIB_ACCESS_JSONTABLE_H_
+
+#include "access/PlanOperation.h"
+
+
+namespace hyrise {
+namespace access {
+
+
+/**
+* Create a new Table based on a Json Plan Operation
+* 
+* This class provides a simple to use interface to the functionality that is
+* provided by the TableBuilder class. 
+*
+*/
+class JsonTable : public _PlanOperation {
+
+	std::vector<std::string> _names;
+	std::vector<std::string> _types;
+	std::vector<unsigned> _groups;
+  std::vector<std::vector<std::string>> _data;
+
+	bool _useStoreFlag;
+
+public:
+
+	JsonTable();
+
+  void executePlanOperation();
+
+  static std::shared_ptr<_PlanOperation> parse(Json::Value &data);
+
+  // set the names to be used as attribute names in the table
+  void setNames(const std::vector<std::string> names);
+
+  // set the types
+  void setTypes(const std::vector<std::string> types);
+
+  // set the atribute grouping
+  void setGroups(const std::vector<unsigned> groups);
+
+  void setUseStore(const bool);
+
+  void setData(const std::vector<std::vector<std::string>> data);
+
+};
+
+}
+}
+
+#endif // SRC_LIB_ACCESS_JSONTABLE_H_

--- a/src/lib/storage/Store.cpp
+++ b/src/lib/storage/Store.cpp
@@ -208,6 +208,11 @@ void Store::setMerger(TableMerger *_merger) {
   merger = _merger;
 }
 
+void Store::setDefaultMerger() {
+  auto merger = new TableMerger(new LogarithmicMergeStrategy(0), new SequentialHeapMerger());
+  setMerger(merger);
+}
+
 
 void Store::setDelta(hyrise::storage::atable_ptr_t _delta) {
   delta = _delta;

--- a/src/lib/storage/Store.h
+++ b/src/lib/storage/Store.h
@@ -106,6 +106,8 @@ public:
    */
   void setMerger(TableMerger *_merger);
 
+  void setDefaultMerger();
+
   /**
    * Sets the delta table.
    *

--- a/src/lib/storage/TableDiff.cpp
+++ b/src/lib/storage/TableDiff.cpp
@@ -98,7 +98,8 @@ bool TableDiff::rowsMatched() const {
 
 
 TableDiff TableDiff::diffTables(const AbstractTable* const left,
-                                const AbstractTable* const right) {
+                                const AbstractTable* const right,
+                                const bool schema_only) {
   TableDiff diff;
 
   std::vector<bool>
@@ -119,27 +120,28 @@ TableDiff TableDiff::diffTables(const AbstractTable* const left,
     if (diff.fields[i] != FieldCorrect)
       mapFields.erase(i);
   
-  //compare rows
-  for (size_t line_left = 0; line_left < left->size(); ++line_left) {
-    bool foundMatch = false;
-    for (size_t line_right = 0; line_right < right->size(); ++line_right) {
-      // let's not check lines that have already been marked as seen
-      if (seen_right[line_right])
-        continue;
+  if (!schema_only) {
+    //compare rows
+    for (size_t line_left = 0; line_left < left->size(); ++line_left) {
+      bool foundMatch = false;
+      for (size_t line_right = 0; line_right < right->size(); ++line_right) {
+        // let's not check lines that have already been marked as seen
+        if (seen_right[line_right])
+          continue;
 
-      if (line_equal(left, right, line_left, line_right, mapFields)) {
-        seen_right[line_right] = true;
-        if (line_left != line_right)
-          diff.falsePositionRows[line_left]=line_right;
-        foundMatch = true;
-        break;
+        if (line_equal(left, right, line_left, line_right, mapFields)) {
+          seen_right[line_right] = true;
+          if (line_left != line_right)
+            diff.falsePositionRows[line_left]=line_right;
+          foundMatch = true;
+          break;
+        }
+      }
+      if (!foundMatch) {
+        diff.wrongRows.push_back(line_left);
       }
     }
-    if (!foundMatch) {
-      diff.wrongRows.push_back(line_left);
-    }
   }
-
   return diff;
 }
 

--- a/src/lib/storage/TableDiff.h
+++ b/src/lib/storage/TableDiff.h
@@ -27,7 +27,8 @@ public:
   bool rowsMatchedSorted() const;
 
   static TableDiff diffTables(const AbstractTable* const left,
-                              const AbstractTable* const right);
+                              const AbstractTable* const right,
+                              const bool schema_only = true);
 
 
   std::vector<FieldCorrectness> fields;

--- a/src/lib/testing/TableEqualityTest.h
+++ b/src/lib/testing/TableEqualityTest.h
@@ -26,15 +26,25 @@ typedef const hyrise::storage::c_atable_ptr_t& tblptr;
 ::testing::AssertionResult RelationEquals(const char *left_exp,
                                           const char *right_exp,
                                           tblptr left,
-                                          tblptr right);
+                                          tblptr right,
+                                          bool schema_only = false);
 
 ::testing::AssertionResult RelationNotEquals(const char *left_exp,
                                              const char *right_exp,
                                              tblptr left,
-                                             tblptr right);
+                                             tblptr right,
+                                             bool schema_only = false);
 
 #define EXPECT_RELATION_EQ(a,b) EXPECT_PRED_FORMAT2(RelationEquals, a, b)
 #define EXPECT_RELATION_NEQ(a,b) EXPECT_PRED_FORMAT2(RelationNotEquals, a, b)
+
+::testing::AssertionResult SchemaEquals(const char *left_exp,
+                                          const char *right_exp,
+                                          tblptr left,
+                                          tblptr right);
+
+#define EXPECT_RELATION_SCHEMA_EQ(a,b) EXPECT_PRED_FORMAT2(SchemaEquals, a, b)
+
 
 ::testing::AssertionResult SortedRelationEquals(const char *left_exp,
                                           const char *right_exp,

--- a/static/webq/js/hyrise.js
+++ b/static/webq/js/hyrise.js
@@ -57,13 +57,14 @@ function runQuery() {
 			}
 
 			// Do the dot transformation
+			d = JSON.parse(d);
 			var performance = parsePerformanceData(d["performanceData"]);
 
 			$("#msg").append(" " + totalTime(d["performanceData"]) + "ms");
 
 			var svg = Viz(toDot(JSON.parse($("#txtquery").val()), performance), "svg");
 			if (svg) {
-				$("#query_plan").html(svg);
+			  $("#query_plan").html(svg);
 			}
 
 			$("#result_view").show();

--- a/test/autojson/json_table_load.json
+++ b/test/autojson/json_table_load.json
@@ -1,0 +1,26 @@
+{
+    "operators": {
+        "-1" : {
+            "type": "TableLoad",    
+            "table": "reference",
+            "filename" : "tables/revenue.tbl" 
+        },
+        "0": {
+            "type": "JsonTable",    
+            "names": ["year", "quarter", "amount"],
+            "types" : ["INTEGER", "INTEGER", "INTEGER"],
+            "groups" : [1,1,1],
+            "data" : [
+                ["2009","1","2000"],
+                ["2009","2","2500"],
+                ["2009","3","3000"],
+                ["2009","4","4000"],
+                ["2010","1","2400"],
+                ["2010","2","2800"],
+                ["2010","3","3200"],
+                ["2010","4","3600"]
+            ]            
+        }
+    },
+    "edges" : [["0", "0"]]
+}

--- a/test/json/build_table_good.json
+++ b/test/json/build_table_good.json
@@ -1,0 +1,11 @@
+{
+  "operators": {
+  	"0" : {
+  		"type" : "JsonTable",
+  		"names" : ["A", "B", "C"],
+  		"types" : ["INTEGER", "STRING", "FLOAT"],
+  		"groups" : [3]
+  	}
+  },
+  "edges" : [["0", "0"]]
+}

--- a/test/json/build_table_good_store.json
+++ b/test/json/build_table_good_store.json
@@ -1,0 +1,12 @@
+{
+  "operators": {
+  	"0" : {
+  		"type" : "JsonTable",
+  		"names" : ["A", "B", "C"],
+  		"types" : ["INTEGER", "STRING", "FLOAT"],
+  		"groups" : [3],
+  		"useStore" : true
+  	}
+  },
+  "edges" : [["0", "0"]]
+}


### PR DESCRIPTION
Adding the possibility to specify tables directly from JSON without
specifying the header. Supports the following notation:

```
"0" : {
    "type" : "JsonTable",
    "names" : ["A", "B", "C"],
    "types" : ["INTEGER", "STRING", "FLOAT"],
    "groups" : [3],
    "useStore" : true
}
```

Follows the same properties as the TableBuilder class that is used below. Furthermore,
it has the useStore flag to indicate if the result should be a Store class with the
default Merge set.
