### PR TITLE
Eradicate boost headers from hyrise headers

### DIFF
--- a/src/lib/access/AggregateFunctions.cpp
+++ b/src/lib/access/AggregateFunctions.cpp
@@ -1,10 +1,91 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "AggregateFunctions.h"
-
+#include <storage/meta_storage.h>
 #include "json.h"
 
 namespace hyrise {
 namespace storage {
+
+struct sum_aggregate_functor {
+  typedef void value_type;
+
+  const hyrise::storage::c_atable_ptr_t& input;
+  hyrise::storage::atable_ptr_t& target;
+  pos_list_t *rows;
+  field_t sourceField;
+  std::string targetColumn;
+  size_t targetRow;
+
+  sum_aggregate_functor(const hyrise::storage::c_atable_ptr_t& i,
+                        hyrise::storage::atable_ptr_t& t,
+                        pos_list_t *forRows,
+                        field_t sourceF,
+                        std::string column,
+                        size_t toRow): input(i), target(t), rows(forRows), sourceField(sourceF), targetColumn(column), targetRow(toRow) {};
+
+  template <typename R>
+  void operator()() {
+    R result = 0;
+
+    if (rows != nullptr) {
+      for (const auto& currentRow: *rows) {
+        result += input->getValue<R>(sourceField, currentRow);
+      }
+    } else {
+      size_t input_size = input->size();
+
+      for (size_t i = 0; i < input_size; ++i) {
+        result += input->getValue<R>(sourceField, i);
+      }
+    }
+
+    target->setValue<R>(targetColumn, targetRow, result);
+  }
+};
+
+struct average_aggregate_functor {
+  typedef void value_type;
+
+  const hyrise::storage::c_atable_ptr_t& input;
+  hyrise::storage::atable_ptr_t& target;
+  pos_list_t *rows;
+  field_t sourceField;
+  std::string targetColumn;
+  size_t targetRow;
+
+  average_aggregate_functor(const hyrise::storage::c_atable_ptr_t& i,
+                            hyrise::storage::atable_ptr_t& t,
+                            pos_list_t *forRows,
+                            field_t sourceF,
+                            std::string column,
+                            size_t toRow): input(i), target(t), rows(forRows), sourceField(sourceF), targetColumn(column), targetRow(toRow) {};
+
+  template <typename R>
+  void operator()();
+};
+
+template<typename R>
+void average_aggregate_functor::operator()() {
+  R sum = 0;
+  int count = 0;
+
+  if (rows != NULL) {
+    for (const auto& currentRow: *rows) {
+      sum += input->getValue<R>(sourceField, currentRow);
+    }
+    count = rows->size();
+  } else {
+    size_t input_size = input->size();
+
+    for (size_t i = 0; i < input_size; ++i) {
+      sum += input->getValue<R>(sourceField, i);
+    }
+    count = input->size();
+  }
+
+  target->setValue<float>(targetColumn, targetRow, ((float)sum / count));
+}
+
 template<>
 void average_aggregate_functor::operator()<std::string>() {
   throw std::runtime_error("Cannot calculate average for column of StringType");
@@ -45,17 +126,44 @@ void AggregateFun::walk(const AbstractTable &table) {
   }
 }
 
+
+void SumAggregateFun::processValuesForRows(const hyrise::storage::c_atable_ptr_t& t, pos_list_t *rows, hyrise::storage::atable_ptr_t& target, size_t targetRow) {
+  hyrise::storage::sum_aggregate_functor fun(t, target, rows, _field, columnName(t->nameOfColumn(_field)), targetRow);
+  hyrise::storage::type_switch<hyrise_basic_types> ts;
+  ts(_datatype, fun);
+}
+
+
 AggregateFun *SumAggregateFun::parse(const Json::Value &f) {
   if (f["field"].isNumeric()) return new SumAggregateFun(f["field"].asUInt());
   else if (f["field"].isString()) return new SumAggregateFun(f["field"].asString());
   else throw std::runtime_error("Could not parse json");
 };
 
+void CountAggregateFun::processValuesForRows(const hyrise::storage::c_atable_ptr_t& t, pos_list_t *rows, hyrise::storage::atable_ptr_t& target, size_t targetRow) {
+    size_t count;
+
+    if (rows != nullptr) {
+      count = rows->size();
+    } else {
+      count = t->size();
+    }
+
+    target->setValue<hyrise_int_t>(columnName(t->nameOfColumn(_field)), targetRow, count);
+  }
+
 AggregateFun *CountAggregateFun::parse(const Json::Value &f) {
   if (f["field"].isNumeric()) return new CountAggregateFun(f["field"].asUInt());
   else if (f["field"].isString()) return new CountAggregateFun(f["field"].asString());
   else throw std::runtime_error("Could not parse json");
 };
+
+void AverageAggregateFun::processValuesForRows(const hyrise::storage::c_atable_ptr_t& t, pos_list_t *rows, hyrise::storage::atable_ptr_t& target, size_t targetRow) { 
+    hyrise::storage::average_aggregate_functor fun(t, target, rows, _field, columnName(t->nameOfColumn(_field)), targetRow);
+    hyrise::storage::type_switch<hyrise_basic_types> ts;
+    ts(_datatype, fun);
+}
+
 
 AggregateFun *AverageAggregateFun::parse(const Json::Value &f) {
   if (f["field"].isNumeric()) return new AverageAggregateFun(f["field"].asUInt());

--- a/src/lib/access/GroupByScan.h
+++ b/src/lib/access/GroupByScan.h
@@ -6,36 +6,6 @@
 #include "access/AggregateFunctions.h"
 
 namespace hyrise {
-namespace storage {
-
-/// helper construct to avoid excessive use
-/// of switch case in executePlanOperation
-/// uses templated type_switch in src/lib/storage/meta_storage.h
-/// and calls the the correct templated operator implemented below
-struct write_group_functor {
-public:
-  typedef void value_type;
-  write_group_functor(const c_atable_ptr_t &t,
-                      atable_ptr_t &tg,
-                      const pos_t sourceRow,
-                      const field_t column,
-                      const pos_t toRow);
-
-  template <typename R>
-  void operator()();
-
-private:
-  const c_atable_ptr_t &_input;
-  atable_ptr_t &_target;
-  pos_t _sourceRow;
-  field_t _columnNr;
-  pos_t _row;
-};
-
-}
-}
-
-namespace hyrise {
 namespace access {
 
 class GroupByScan : public ParallelizablePlanOperation {

--- a/src/lib/io/GenericCSV.cpp
+++ b/src/lib/io/GenericCSV.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <istream>
@@ -10,8 +11,6 @@
 
 #include <string.h>
 #include <libcsv/csv.h>
-
-
 
 
 param_member_impl(csv::params, unsigned char, Delimiter);

--- a/src/lib/layouter/base.cpp
+++ b/src/lib/layouter/base.cpp
@@ -1177,7 +1177,7 @@ subset_t merge_subsets(subset_t base, std::vector<subset_t> &mapping) {
   return result;
 }
 
-typedef boost::unordered_map<std::string, double> cache_t;
+typedef std::unordered_map<std::string, double> cache_t;
 
 // Intermediate Result Structure to capture cost and mappings
 struct _intermediate {
@@ -1244,7 +1244,7 @@ std::vector<subset_t> CandidateLayouter::externalCombineCandidates(std::vector<s
   return result;
 }
 
-std::vector<subset_t> CandidateLayouter::candidateMergePath(subset_t initial, subset_t rest, std::vector<subset_t> &mapping, boost::unordered_map<std::string, double> &_cache) {
+std::vector<subset_t> CandidateLayouter::candidateMergePath(subset_t initial, subset_t rest, std::vector<subset_t> &mapping, std::unordered_map<std::string, double> &_cache) {
   std::vector<subset_t> result;
   do {
 

--- a/src/lib/layouter/base.h
+++ b/src/lib/layouter/base.h
@@ -14,8 +14,6 @@
 #include <vector>
 #include <algorithm>
 
-#include <boost/unordered_map.hpp>
-
 namespace layouter {
 
 class Query;
@@ -313,7 +311,7 @@ class CandidateLayouter: public BaseLayouter {
 
   std::vector< std::set<unsigned> > _candidateList;
 
-  std::vector<subset_t> candidateMergePath(subset_t initial, subset_t rest, std::vector<subset_t> &mapping, boost::unordered_map<std::string, double> &_cache);
+  std::vector<subset_t> candidateMergePath(subset_t initial, subset_t rest, std::vector<subset_t> &mapping, std::unordered_map<std::string, double> &_cache);
 
  public:
   CandidateLayouter();

--- a/src/lib/stdlib.hpp
+++ b/src/lib/stdlib.hpp
@@ -15,9 +15,6 @@
 #include <iostream>
 #include <atomic>
 #include <thread>
-#include "boost/mpl/vector.hpp"
-#include "boost/mpl/map.hpp"
-#include "boost/lexical_cast.hpp"
-#include "gtest/gtest.h"
+//#include "gtest/gtest.h"
 
 #endif

--- a/src/lib/storage.h
+++ b/src/lib/storage.h
@@ -3,7 +3,6 @@
 #define SRC_LIB_STORAGE_H_
 
 #include <storage/storage_types.h>
-#include <storage/meta_storage.h>
 #include <storage/ColumnMetadata.h>
 #include <storage/Table.h>
 #include <storage/RawTable.h>
@@ -24,4 +23,5 @@
 #include <storage/InvertedIndex.h>
 #include <storage/HashTable.h>
 #include <storage/AbstractHashTable.h>
+
 #endif  // SRC_LIB_STORAGE_H_

--- a/src/lib/storage/FixedLengthVector.h
+++ b/src/lib/storage/FixedLengthVector.h
@@ -4,6 +4,7 @@
 
 
 #include <cerrno>
+#include <cstring>
 #include <cmath>
 
 #include <atomic>

--- a/src/lib/storage/HashTable.cpp
+++ b/src/lib/storage/HashTable.cpp
@@ -1,0 +1,10 @@
+#include "storage/HashTable.h"
+
+#include "storage/meta_storage.h"
+#include "storage/hash_functor.h"
+
+size_t hash_value(const hyrise::storage::c_atable_ptr_t &source, const size_t &f, const ValueId &vid) {
+  hyrise::storage::hash_functor<size_t> fun(source.get(), f, vid);
+  hyrise::storage::type_switch<hyrise_basic_types> ts;
+  return ts(source->typeOfColumn(f), fun);
+}

--- a/src/lib/storage/HashTable.h
+++ b/src/lib/storage/HashTable.h
@@ -6,14 +6,13 @@
 #include <set>
 #include <unordered_map>
 #include <memory>
+#include <sstream>
 
 #include "helper/types.h"
 #include "helper/checked_cast.h"
 
 #include "storage/AbstractHashTable.h"
 #include "storage/AbstractTable.h"
-#include "storage/meta_storage.h"
-#include "storage/hash_functor.h"
 #include "storage/storage_types.h"
 
 template<class MAP, class KEY> class HashTableView;
@@ -28,11 +27,7 @@ typedef value_id_t aggregate_single_key_t;
 // Single Hashed Value
 typedef size_t join_single_key_t;
 
-static size_t hash_value(const hyrise::storage::c_atable_ptr_t &source, const size_t &f, const ValueId &vid) {
-  hyrise::storage::hash_functor<size_t> fun(source.get(), f, vid);
-  hyrise::storage::type_switch<hyrise_basic_types> ts;
-  return ts(source->typeOfColumn(f), fun);
-}
+size_t hash_value(const hyrise::storage::c_atable_ptr_t &source, const size_t &f, const ValueId &vid);
 
 template <typename HashResult>
 inline typename HashResult::value_type extract(const hyrise::storage::c_atable_ptr_t &table,

--- a/src/lib/storage/RawTable.cpp
+++ b/src/lib/storage/RawTable.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "RawTable.h"
 
+#include "storage/meta_storage.h"
+#include "storage/ColumnMetadata.h"
+
 namespace hyrise { namespace storage {
 
 namespace rawtable {

--- a/src/lib/storage/RawTable.h
+++ b/src/lib/storage/RawTable.h
@@ -2,15 +2,16 @@
 #ifndef SRC_LIB_STORAGE_RAWTABLE_H_
 #define SRC_LIB_STORAGE_RAWTABLE_H_
 
+#include <cstring>
+#include <cstdint>
+
 #include <stdexcept>
 #include <vector>
 
-#include <stdint.h>
-
 #include "storage/storage_types.h"
-#include "storage/meta_storage.h"
+
 #include "storage/AbstractTable.h"
-#include "storage/ColumnMetadata.h"
+
 
 
 namespace hyrise { namespace storage { namespace rawtable {

--- a/src/lib/storage/TableGenerator.cpp
+++ b/src/lib/storage/TableGenerator.cpp
@@ -8,8 +8,7 @@
 #include <limits>
 #include <stdint.h>
 
-#include <boost/random.hpp>
-#include <boost/random/mersenne_twister.hpp>
+#include <random>
 
 #include <helper/types.h>
 
@@ -19,8 +18,6 @@
 #include <storage/SequentialHeapMerger.h>
 #include <storage/TableMerger.h>
 #include <helper/Progress.h>
-
-
 
 TableGenerator::TableGenerator(bool quiet) : _quiet(quiet), _steps(50), _prepareSize(0) {
 }
@@ -38,7 +35,8 @@ void TableGenerator::prepare(size_t p) {
 
   _prepareSize = p;
 
-  boost::uniform_int<int64_t> dist(0, std::numeric_limits<int64_t>::max());
+  std::mt19937 gen;
+  std::uniform_int_distribution<int64_t> dist(0, std::numeric_limits<int64_t>::max());
 
   // First, generate all random numbers we need, this is blazing
   // fast

--- a/src/lib/storage/TableGenerator.h
+++ b/src/lib/storage/TableGenerator.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <set>
 
-#include <boost/random.hpp>
+
 
 #include "AbstractTable.h"
 
@@ -82,7 +82,7 @@ class TableGenerator {
   // Stores the prepared values
   std::set<int64_t> _values;
 
-  boost::mt19937 gen;
+  //std::mt19937 gen;
 
   void start(size_t rows, size_t cols, size_t total);
   void increment();

--- a/src/lib/storage/meta_storage.h
+++ b/src/lib/storage/meta_storage.h
@@ -10,6 +10,15 @@
 
 #include "storage/storage_types.h"
 
+#include "boost/mpl/vector.hpp"
+//#include "boost/mpl/map.hpp"
+
+// This are the basic types used in HYRISE, the enum above can
+// be used to directly offset into the list at compile time
+typedef boost::mpl::vector<hyrise_int_t, hyrise_float_t, hyrise_string_t> hyrise_basic_types;
+
+
+
 namespace hyrise {
 namespace storage {
 

--- a/src/lib/storage/storage_types.h
+++ b/src/lib/storage/storage_types.h
@@ -8,10 +8,6 @@
 #include <stdint.h>
 #include <ostream>
 
-#include "boost/mpl/vector.hpp"
-#include "boost/mpl/map.hpp"
-
-#include <boost/lexical_cast.hpp>
 
 #define STORAGE_XSTR(x) STORAGE_STR(x)
 #define STORAGE_STR(x) #x
@@ -42,10 +38,6 @@ typedef int64_t hyrise_int_t;
 typedef float hyrise_float_t;
 typedef std::string hyrise_string_t;
 
-// This are the basic types used in HYRISE, the enum above can
-// be used to directly offset into the list at compile time
-typedef boost::mpl::vector<hyrise_int_t, hyrise_float_t, hyrise_string_t> hyrise_basic_types;
-
 typedef unsigned int value_id_t;
 typedef unsigned char table_id_t;
 
@@ -70,8 +62,6 @@ class ValueId {
   ValueId() { }
   ValueId(value_id_t _valueId, table_id_t _table) : valueId(_valueId), table(_table) { }
 
-  ~ValueId() {
-  }
 
   bool operator==(ValueId &o) {
     return valueId == o.valueId && table == o.table;


### PR DESCRIPTION
- Move type switches (which ultimately depend on boost::mpl) into
  implementation files
- Move all type_switch related logic into meta_storage.h
