### PR TITLE
Feature/updates to querying in tx

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -68,7 +68,7 @@ LINKER_FLAGS +=
 ifeq ($(PRODUCTION), 1)
 	BUILD_FLAGS += -O3 -fbranch-target-load-optimize -frerun-cse-after-loop -D EXPENSIVE_TESTS -D PRODUCTION
 else
-	BUILD_FLAGS += -O0 -D EXPENSIVE_ASSERTIONS
+	BUILD_FLAGS += -O0 -D EXPENSIVE_ASSERTIONS -fno-inline -g3 -ggdb
 endif
 
 # Specify the allocator using a linker flag

--- a/src/bin/units_access/tx_tests.cpp
+++ b/src/bin/units_access/tx_tests.cpp
@@ -502,7 +502,7 @@ TEST_F(TransactionTests, update_and_merge) {
 TEST_F(TransactionTests, delete_rollback) {
   auto writeCtx = tx::TransactionManager::beginTransaction();
   auto pc = PointerCalculator::create(linxxxs, new pos_list_t({0}));
-  ASSERT_EQ(tx::UNKNOWN, linxxxs->tid(0));
+  ASSERT_EQ(tx::START_TID, linxxxs->tid(0));
 
   DeleteOp del;
   del.setTXContext(writeCtx);
@@ -510,7 +510,7 @@ TEST_F(TransactionTests, delete_rollback) {
   del.execute();
 
   tx::TransactionManager::rollbackTransaction(writeCtx.tid);
-  ASSERT_EQ(tx::UNKNOWN, linxxxs->tid(0));
+  ASSERT_EQ(tx::START_TID, linxxxs->tid(0));
 }
 
 }}

--- a/src/lib/access/AggregateFunctions.cpp
+++ b/src/lib/access/AggregateFunctions.cpp
@@ -69,7 +69,7 @@ void average_aggregate_functor::operator()() {
   R sum = 0;
   int count = 0;
 
-  if (rows != NULL) {
+  if (rows != nullptr) {
     for (const auto& currentRow: *rows) {
       sum += input->getValue<R>(sourceField, currentRow);
     }
@@ -82,7 +82,6 @@ void average_aggregate_functor::operator()() {
     }
     count = input->size();
   }
-
   target->setValue<float>(target->numberOfColumn(targetColumn), targetRow, ((float)sum / count));
 }
 

--- a/src/lib/access/GroupByScan.cpp
+++ b/src/lib/access/GroupByScan.cpp
@@ -78,10 +78,10 @@ void GroupByScan::setupPlanOperation() {
 
 void GroupByScan::executePlanOperation() {
   if ((_field_definition.size() != 0) && (input.numberOfHashTables() >= 1)) {
-    if (_field_definition.size() == 1)
-      return executeGroupBy<SingleAggregateHashTable, aggregate_single_hash_map_t, aggregate_single_key_t>();
-    else
-      return executeGroupBy<AggregateHashTable, aggregate_hash_map_t, aggregate_key_t>();
+      if (_field_definition.size() == 1)
+        return executeGroupBy<SingleAggregateHashTable, aggregate_single_hash_map_t, aggregate_single_key_t>();
+      else
+        return executeGroupBy<AggregateHashTable, aggregate_hash_map_t, aggregate_key_t>();      
   } else {
     auto resultTab = createResultTableLayout();
     resultTab->resize(1);
@@ -179,6 +179,7 @@ void GroupByScan::writeGroupResult(storage::atable_ptr_t &resultTab,
 template<typename HashTableType, typename MapType, typename KeyType>
 void GroupByScan::executeGroupBy() {
   auto resultTab = createResultTableLayout();
+
   auto groupResults = getInputHashTable();
   // Allocate some memory for the result tab and resize the table
   resultTab->resize(groupResults->numKeys());
@@ -205,7 +206,8 @@ void GroupByScan::executeGroupBy() {
     }
     writeGroupResult(resultTab, pos_list, row);
     row++;
-  }
+  } 
+
   this->addResult(resultTab);
 }
 

--- a/src/lib/access/InsertScan.cpp
+++ b/src/lib/access/InsertScan.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#include <set>
+
 #include "access/InsertScan.h"
 #include "access/system/ResponseTask.h"
 

--- a/src/lib/access/MergeTable.cpp
+++ b/src/lib/access/MergeTable.cpp
@@ -59,7 +59,7 @@ void MergeStore::executePlanOperation() {
   auto t = checked_pointer_cast<const storage::Store>(getInputTable());
   auto store = std::const_pointer_cast<storage::Store>(t);
   store->merge();
-  output.add(store);
+  addResult(store);
 }
 
 std::shared_ptr<PlanOperation> MergeStore::parse(Json::Value& data) {

--- a/src/lib/access/TableScan.cpp
+++ b/src/lib/access/TableScan.cpp
@@ -20,8 +20,16 @@ void TableScan::setupPlanOperation() {
 }
 
 void TableScan::executePlanOperation() {
-  pos_list_t* positions = _expr->match(0, getInputTable()->size());
-  addResult(PointerCalculator::create(getInputTable(), positions));
+
+  // When the input is 0, dont bother trying to generate results
+  pos_list_t* positions = nullptr;
+  if (getInputTable()->size() > 0) 
+    positions = _expr->match(0, getInputTable()->size());
+  else 
+    positions = new pos_list_t();
+
+  const auto& result = PointerCalculator::create(getInputTable(), positions);
+  addResult(result);
 }
 
 std::shared_ptr<PlanOperation> TableScan::parse(Json::Value& data) {

--- a/src/lib/access/storage/TableIO.cpp
+++ b/src/lib/access/storage/TableIO.cpp
@@ -1,0 +1,57 @@
+#include "TableIO.h"
+
+#include <helper/Settings.h>
+
+#include <io/CSVLoader.h>
+#include <io/EmptyLoader.h>
+#include <io/Loader.h>
+#include <io/shortcuts.h>
+#include <io/TableDump.h>
+
+#include <storage/Store.h>
+
+#include <helper/checked_cast.h>
+
+namespace hyrise { namespace access  {
+
+namespace {
+  auto _ = QueryParser::registerPlanOperation<DumpTable>("DumpTable");
+  auto _2 = QueryParser::registerPlanOperation<LoadDumpedTable>("LoadDumpedTable");
+}
+
+void DumpTable::executePlanOperation() {
+
+  const auto& c_tab = checked_pointer_cast<const storage::Store>(getInputTable(0));
+
+  // First merge to avoid trouble
+  const auto& tab = std::const_pointer_cast<storage::Store>(c_tab);
+  tab->merge();
+  storage::SimpleTableDump dump(Settings::getInstance()->getDBPath());
+  dump.dump(_name, tab);
+
+  // No Output here
+}
+
+std::shared_ptr<PlanOperation> DumpTable::parse(Json::Value& data) {
+  const auto& pop = std::make_shared<DumpTable>();
+  pop->_name = data["name"].asString();
+  return pop;
+}
+
+void LoadDumpedTable::executePlanOperation() {
+  hyrise::storage::TableDumpLoader input(Settings::getInstance()->getDBPath(), _name);
+  CSVHeader header(Settings::getInstance()->getDBPath() + "/" + _name + "/header.dat", CSVHeader::params().setCSVParams(csv::HYRISE_FORMAT));
+
+  hyrise::storage::atable_ptr_t  t = Loader::load(Loader::params().setInput(input).setHeader(header));
+  addResult(checked_pointer_cast<storage::Store>(t));
+}
+
+std::shared_ptr<PlanOperation> LoadDumpedTable::parse(Json::Value& data) {
+  const auto& pop = std::make_shared<LoadDumpedTable>();
+  pop->_name = data["name"].asString();
+  return pop;
+}
+
+
+
+}}

--- a/src/lib/access/storage/TableIO.h
+++ b/src/lib/access/storage/TableIO.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#ifndef SRC_LIB_ACCESS_TABLEIO_H
+#define SRC_LIB_ACCESS_TABLEIO_H
+
+#include "access/system/PlanOperation.h"
+
+namespace hyrise {
+namespace access {
+
+class DumpTable : public PlanOperation {
+
+  std::string _name;
+
+public:
+  virtual ~DumpTable() = default;
+
+  void executePlanOperation();
+  static std::shared_ptr<PlanOperation> parse(Json::Value &data);
+
+};
+
+class LoadDumpedTable : public PlanOperation {
+
+  std::string _name;
+
+public:
+  virtual ~LoadDumpedTable() = default;
+
+  void executePlanOperation();
+  static std::shared_ptr<PlanOperation> parse(Json::Value &data);
+
+};
+
+}
+}
+
+#endif /* SRC_LIB_ACCESS_TABLEIO_H */

--- a/src/lib/access/system/OperationData-Impl.h
+++ b/src/lib/access/system/OperationData-Impl.h
@@ -1,6 +1,7 @@
 #ifndef SRC_LIB_ACCESS_OPERATIONDATA_IMPL_H_
 #define SRC_LIB_ACCESS_OPERATIONDATA_IMPL_H_
 
+#include <algorithm>
 #include "access/system/OperationData.h"
 
 namespace hyrise { namespace access {

--- a/src/lib/access/tx/ValidatePositions.cpp
+++ b/src/lib/access/tx/ValidatePositions.cpp
@@ -1,6 +1,7 @@
 #include "ValidatePositions.h"
 
 #include <storage/PointerCalculator.h>
+#include <storage/Store.h>
 #include <access/system/QueryParser.h>
 #include <io/TransactionManager.h>
 
@@ -17,16 +18,30 @@ namespace {
 
 void ValidatePositions::executePlanOperation() {
   LOG4CXX_DEBUG(logger, "Validating Positions with: " << _txContext.tid << "(tid) and " << _txContext.lastCid << "(lCID)");
-  const auto& tab = checked_pointer_cast<const PointerCalculator>(getInputTable(0));
-  const auto& store = tab->getActualTable();
-	auto pc = std::const_pointer_cast<PointerCalculator>(tab);
-  pc->validate(_txContext.tid, _txContext.lastCid);
 
-  // Get Modifications
-  const auto& modifications = hyrise::tx::TransactionManager::getInstance()[_txContext.tid];
-  if (modifications.hasDeleted(store))
-    pc->remove(modifications.getDeleted(store));
-	addResult(getInputTable(0));
+  // Allow to operate directly on the store
+  if (std::dynamic_pointer_cast<const storage::Store>(getInputTable(0))) {
+
+    const auto& tab = checked_pointer_cast<const storage::Store>(getInputTable(0));
+    auto pc = tab->buildValidPositions(_txContext.lastCid, _txContext.tid);
+    addResult(std::make_shared<PointerCalculator>(tab, new pos_list_t(std::move(pc))));
+
+  } else {
+    // If it's no store it has to be a pointer calculator otherwise there is
+    // no data structure to work with
+    const auto& tab = checked_pointer_cast<const PointerCalculator>(getInputTable(0));
+    const auto& store = tab->getActualTable();
+    auto pc = std::const_pointer_cast<PointerCalculator>(tab);
+    pc->validate(_txContext.tid, _txContext.lastCid);
+
+    // Get Modifications
+    const auto& modifications = hyrise::tx::TransactionManager::getInstance()[_txContext.tid];
+    if (modifications.hasDeleted(store))
+      pc->remove(modifications.getDeleted(store));
+    addResult(getInputTable(0));
+  }
+
+  
 }
 
 std::shared_ptr<PlanOperation> ValidatePositions::parse(Json::Value &data) {

--- a/src/lib/helper/locking.h
+++ b/src/lib/helper/locking.h
@@ -1,6 +1,7 @@
 #ifndef SRC_LIB_HELPER_LOCKING_H_
 #define SRC_LIB_HELPER_LOCKING_H_
 
+#include <thread>
 #include <atomic>
 
 namespace hyrise { namespace locking {

--- a/src/lib/helper/vector_helpers.h
+++ b/src/lib/helper/vector_helpers.h
@@ -1,6 +1,7 @@
 #ifndef SRC_LIB_HELPERS_VECTOR_HELPERS_H_
 #define SRC_LIB_HELPERS_VECTOR_HELPERS_H_
 
+#include <algorithm>
 #include <functional>
 #include <numeric>
 #include <iterator>

--- a/src/lib/io/GenericCSV.cpp
+++ b/src/lib/io/GenericCSV.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <istream>
 #include <stdexcept>
+#include <memory>
 
 #include <string.h>
 #include <libcsv/csv.h>

--- a/src/lib/io/TableDump.h
+++ b/src/lib/io/TableDump.h
@@ -93,7 +93,7 @@ public:
                                       const Loader::params &args);
 
   bool needs_store_wrap() {
-    return false;
+    return true;
   }
 
   TableDumpLoader *clone() const {

--- a/src/lib/io/TransactionManager.cpp
+++ b/src/lib/io/TransactionManager.cpp
@@ -3,6 +3,8 @@
 #include <cassert>
 #include <limits>
 #include <stdexcept>
+#include <map>
+
 
 #include "helper/make_unique.h"
 #include "helper/checked_cast.h"
@@ -52,7 +54,8 @@ void TXModifications::_handle(locking::Spinlock& mtx, map_t& data, const storage
 }
 
 TransactionManager::TransactionManager() :
-    _transactionCount(ATOMIC_VAR_INIT(0)) {}
+    _transactionCount(ATOMIC_VAR_INIT(tx::START_TID)),
+    _commitId(ATOMIC_VAR_INIT(tx::UNKNOWN_CID)) {}
 
 TransactionManager& TransactionManager::getInstance() {
   static TransactionManager tm;

--- a/src/lib/io/TransactionManager.h
+++ b/src/lib/io/TransactionManager.h
@@ -2,7 +2,9 @@
 #ifndef SRC_LIB_IO_TRANSACTIONMANAGER_H_
 #define SRC_LIB_IO_TRANSACTIONMANAGER_H_
 
+#include <algorithm>
 #include <atomic>
+#include <map>
 #include <mutex>
 #include <unordered_map>
 

--- a/src/lib/layouter/base.h
+++ b/src/lib/layouter/base.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <unordered_map>
 
 namespace layouter {
 

--- a/src/lib/storage/AbstractAttributeVector.h
+++ b/src/lib/storage/AbstractAttributeVector.h
@@ -2,6 +2,8 @@
 #ifndef SRC_LIB_STORAGE_ABSTRACTATTRIBUTEVECTOR_H_
 #define SRC_LIB_STORAGE_ABSTRACTATTRIBUTEVECTOR_H_
 
+#include <cstddef>
+
 class AbstractAttributeVector {
  public:
 

--- a/src/lib/storage/AbstractTable.h
+++ b/src/lib/storage/AbstractTable.h
@@ -36,6 +36,7 @@ typedef struct {
   std::shared_ptr<AbstractAttributeVector> attribute_vector;
   size_t attribute_offset;
 } attr_vector_offset_t;
+
 typedef std::vector<attr_vector_offset_t> attr_vectors_t;
 
 class StorageException : public std::runtime_error {

--- a/src/lib/storage/MutableVerticalTable.cpp
+++ b/src/lib/storage/MutableVerticalTable.cpp
@@ -226,7 +226,7 @@ atable_ptr_t MutableVerticalTable::copy() const {
   return new_table;
 }
 
-const attr_vectors_t MutableVerticalTable::getAttributeVectors(size_t column) const {
+const attr_vectors_t MutableVerticalTable::getAttributeVectors(size_t column) const {  
   return containerAt(column)->getAttributeVectors(offset_in_container[column]);
 }
 

--- a/src/lib/storage/TableBuilder.cpp
+++ b/src/lib/storage/TableBuilder.cpp
@@ -49,13 +49,19 @@ hyrise::storage::atable_ptr_t TableBuilder::build(param_list args, const bool co
   checkParams(args);
 
   std::vector<hyrise::storage::atable_ptr_t> base;
-  size_t begin, end;
-  begin = 0;
+  auto offset = args.params().begin();
+
+  // For each group calculate the offset that is used to extract the columns
   for (size_t g = 0; g < args.groups().size(); ++g) {
+
     // Calculate the upper bound for the current layout
-    end = args.groups().size() > g + 1 ? args.groups()[g + 1] : args.size();
-    base.push_back(createTable(args.params().begin() + begin, args.params().begin() + end, compressed));
-    begin = end;
+    auto end = offset;
+    auto tmp = args.groups()[g];
+    while(tmp-- != 0)
+      ++end;
+
+    base.push_back(createTable(offset, end, compressed));
+    offset = end;
   }
 
   return std::move(std::make_shared<MutableVerticalTable>(base));

--- a/test/autojson/group_by_chained.json
+++ b/test/autojson/group_by_chained.json
@@ -1,0 +1,70 @@
+{
+    "operators": {
+        "sref" : {
+            "type": "SetTable",    
+            "name": "reference"            
+        },
+        "bref": {
+            "type": "JsonTable",    
+            "names": ["status", "AVG(COUNT(left))"],
+            "types" : ["INTEGER", "FLOAT"],
+            "groups" : [1,1],
+            "useStore": true,
+            "data" : [
+                ["0", "1"],
+                ["1", "2.33333325"]
+            ]            
+        },
+        "0": {
+            "type": "JsonTable",    
+            "names": ["left", "right", "status"],
+            "types" : ["INTEGER", "INTEGER", "INTEGER"],
+            "groups" : [1,1,1],
+            "useStore": true,
+            "data" : [
+                ["1","2","1"],
+                ["1","3","1"],
+                ["1","4","0"],
+                ["2","1","1"],
+                ["2","3","1"],
+                ["3","1","1"],
+                ["3","4","1"],
+                ["3","5","1"]
+            ]            
+        },
+        "hash" : {
+            "type" : "HashBuild",
+            "key" : "groupby",
+            "fields" : [0,2]
+        },
+        "group" : {
+            "type": "GroupByScan",
+            "fields" : [0,2],
+            "functions": [
+                {"type": 1, "field": 0}
+            ]
+        },
+        "hash2" : {
+            "type" : "HashBuild",
+            "key" : "groupby",
+            "fields" : [1]
+        },
+        "group2" : {
+            "type": "GroupByScan",
+            "fields": [1],
+            "functions": [
+                {"type": 2, "field": 2, "as": "avg"}
+            ]
+        }
+    },
+    "edges" : [
+        ["bref", "sref"],
+        ["sref", "0"],
+        ["0", "hash"],
+        ["hash", "group"],
+        ["0", "group"],
+        ["group", "hash2"],
+        ["hash2", "group2"],
+        ["group", "group2"]
+    ]
+}

--- a/test/autojson/group_by_wihtout_hash.json
+++ b/test/autojson/group_by_wihtout_hash.json
@@ -1,0 +1,46 @@
+{
+    "operators": {
+        "sref" : {
+            "type": "SetTable",    
+            "name": "reference"            
+        },
+        "bref": {
+            "type": "JsonTable",    
+            "names": ["COUNT(amount)"],
+            "types" : ["INTEGER"],
+            "groups" : [1],
+            "useStore": true,
+            "data" : [
+                ["8"]
+            ]            
+        },
+        "0": {
+            "type": "JsonTable",    
+            "names": ["year", "quarter", "amount"],
+            "types" : ["INTEGER", "INTEGER", "INTEGER"],
+            "groups" : [1,1,1],
+            "useStore": true,
+            "data" : [
+                ["2009","1","2000"],
+                ["2009","2","2500"],
+                ["2009","3","3000"],
+                ["2009","4","4000"],
+                ["2010","1","2400"],
+                ["2010","2","2800"],
+                ["2010","3","3200"],
+                ["2010","4","3600"]
+            ]            
+        },
+        "group" : {
+            "type": "GroupByScan",
+            "functions": [
+                {"type": 1, "field": "amount"}
+            ]
+        }
+    },
+    "edges" : [
+        ["bref", "sref"],
+        ["sref", "0"],
+        ["0", "group"]
+    ]
+}

--- a/test/autojson/group_by_without_hash_with_validate.json
+++ b/test/autojson/group_by_without_hash_with_validate.json
@@ -1,0 +1,51 @@
+{
+    "operators": {
+        "sref" : {
+            "type": "SetTable",    
+            "name": "reference"            
+        },
+        "bref": {
+            "type": "JsonTable",    
+            "names": ["AVG(amount)"],
+            "types" : ["FLOAT"],
+            "groups" : [1],
+            "useStore": true,
+            "data" : [
+                ["2937.5"]
+            ]            
+        },
+        "0": {
+            "type": "JsonTable",    
+            "names": ["year", "quarter", "amount"],
+            "types" : ["INTEGER", "INTEGER", "INTEGER"],
+            "groups" : [1,1,1],
+            "useStore": true,
+            "mergeStore":true,
+            "data" : [
+                ["2009","1","2000"],
+                ["2009","2","2500"],
+                ["2009","3","3000"],
+                ["2009","4","4000"],
+                ["2010","1","2400"],
+                ["2010","2","2800"],
+                ["2010","3","3200"],
+                ["2010","4","3600"]
+            ]            
+        },
+        "vp" : {
+            "type" : "ValidatePositions"
+        },
+        "group" : {
+            "type": "GroupByScan",
+            "functions": [
+                {"type": 2, "field": "amount"}
+            ]
+        }
+    },
+    "edges" : [
+        ["bref", "sref"],
+        ["sref", "0"],
+        ["0", "vp"],
+        ["vp", "group"]
+    ]
+}

--- a/test/autojson/json_table_load_dump_load.json
+++ b/test/autojson/json_table_load_dump_load.json
@@ -1,0 +1,39 @@
+{
+    "operators": {
+        "-1" : {
+            "type": "TableLoad",    
+            "table": "reference",
+            "filename" : "tables/revenue.tbl" 
+        },
+        "0": {
+            "type": "JsonTable",    
+            "names": ["year", "quarter", "amount"],
+            "types" : ["INTEGER", "INTEGER", "INTEGER"],
+            "groups" : [1,1,1],
+            "useStore": true,
+            "mergeStore": true,
+            "data" : [
+                ["2009","1","2000"],
+                ["2009","2","2500"],
+                ["2009","3","3000"],
+                ["2009","4","4000"],
+                ["2010","1","2400"],
+                ["2010","2","2800"],
+                ["2010","3","3200"],
+                ["2010","4","3600"]
+            ]            
+        },
+        "1" : {
+            "type" : "DumpTable",
+            "name" : "dump"
+        },
+        "2" : {
+            "type": "LoadDumpedTable",
+            "name" : "dump"
+        }
+    },
+    "edges" : [
+    ["0", "1"],
+    ["1", "2"]
+    ]
+}

--- a/test/autojson/load_insert_merge_find.json
+++ b/test/autojson/load_insert_merge_find.json
@@ -1,0 +1,64 @@
+{
+    "operators": {
+        "sref" : {
+            "type": "SetTable",    
+            "name": "reference"            
+        },
+        "bref": {
+            "type": "JsonTable",    
+            "names": ["left", "right", "status"],
+            "types" : ["INTEGER", "INTEGER", "INTEGER"],
+            "groups" : [1,1,1],
+            "useStore": true,
+            "data" : [                
+                ["1","4","1"]
+            ]            
+        },
+        "0": {
+            "type": "JsonTable",    
+            "names": ["left", "right", "status"],
+            "types" : ["INTEGER", "INTEGER", "INTEGER"],
+            "groups" : [1,1,1],
+            "useStore": true            
+        },
+        "set" : {
+            "type" : "SetTable",
+            "name" : "check"
+        },
+        "insert" : {
+            "type" : "InsertScan",
+            "data" : [
+                [1,4,1],
+                [1,5,0],
+                [2,12,9]
+            ]
+        },
+        "commit": {
+            "type" : "Commit"
+        },
+        "barrier" : {
+            "type" : "GetTable",
+            "name" : "check"
+        },
+        "merge" : {
+            "type": "MergeStore"
+        },
+        "search" : {
+          "type" : "TableScan",
+          "expression" : "hyrise::Store_FLV_F1_EQ_INT",
+          "withDelta" : true,
+          "f1": 2,
+          "v_f1" : 1
+      }
+    },
+    "edges" : [
+        ["bref", "sref"],
+        ["sref", "0"],
+        ["0", "set"],
+        ["0", "insert"],
+        ["insert", "commit"],
+        ["commit", "barrier"],
+        ["barrier", "merge"],
+        ["merge", "search"]
+    ]
+}


### PR DESCRIPTION
- ValidatePositions can now be used with Stores
- GroupByScan without Hashing for ops without grouping
- Fixing bug in tablebuilder that would build a wrong layout, but correct view on top of it
- Fixing default merge settings in Store, to not use compression
- Made the code compiling without precompiled headers by including the necessary includes
