### PR TITLE
Move boost::uuid into wrapper class, improve build speed by 20%

### DIFF
--- a/src/lib/helper/stringhelpers.h
+++ b/src/lib/helper/stringhelpers.h
@@ -5,15 +5,6 @@
 #include <string>
 #include <sstream>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
-
-namespace std {
-  inline std::string to_string(const boost::uuids::uuid& u) {
-    return boost::uuids::to_string(u);
-  }
-}
 
 void inline splitString(std::vector<std::string> &result,
                         const std::string &s,

--- a/src/lib/helper/unique_id.cpp
+++ b/src/lib/helper/unique_id.cpp
@@ -1,0 +1,25 @@
+#include "unique_id.h"
+
+#include "boost/uuid/uuid.hpp"
+#include "boost/uuid/uuid_io.hpp"
+#include "boost/uuid/uuid_generators.hpp"
+
+unique_id::unique_id(type val) : value(val) {
+  static_assert(sizeof(unique_id::type) == sizeof(boost::uuids::uuid),
+                "Sizes need to match for this wrapper to work");
+}
+
+unique_id unique_id::create() {
+  auto uuid = boost::uuids::random_generator()();
+  type value;
+  std::copy(uuid.begin(), uuid.end(), value.begin());
+  return unique_id(value);
+}
+
+namespace std {
+string to_string(const unique_id& id) {
+  const auto& as_uuid = *(reinterpret_cast<const boost::uuids::uuid*>(id.value.data()));
+  return boost::uuids::to_string(as_uuid);
+}
+
+}

--- a/src/lib/helper/unique_id.h
+++ b/src/lib/helper/unique_id.h
@@ -1,0 +1,27 @@
+#ifndef HYRISE_UNIQUE_ID_H_
+#define HYRISE_UNIQUE_ID_H_
+
+#include <cstdint>
+#include <array>
+
+// forward declare unique_id, so we can write a to_string
+// specialization to later on befriend it
+struct unique_id;
+
+namespace std {
+string to_string(const unique_id& id);
+};
+
+struct unique_id {
+ public:
+  unique_id() = default;
+  static unique_id create();
+  bool is_nil() { return value.empty(); }
+ private:
+  friend std::string std::to_string(const unique_id&);
+  typedef std::array<std::uint8_t, 16> type;
+  unique_id(type);
+  type value;
+};
+
+#endif

--- a/src/lib/storage/AbstractTable.cpp
+++ b/src/lib/storage/AbstractTable.cpp
@@ -309,13 +309,13 @@ void AbstractTable::debugStructure(size_t level) const {
   std::cout << std::string(level, '\t') << "AbstractTable " << this << std::endl;
 }
 
-boost::uuids::uuid AbstractTable::getUuid() const {
+unique_id AbstractTable::getUuid() const {
   return _uuid;
 }
 
-void AbstractTable::setUuid(boost::uuids::uuid u) {
+void AbstractTable::setUuid(unique_id u) {
   if (u.is_nil()) {
-    _uuid = boost::uuids::random_generator()();
+    _uuid = unique_id::create();
   }
   _uuid = u;
 }

--- a/src/lib/storage/AbstractTable.h
+++ b/src/lib/storage/AbstractTable.h
@@ -17,15 +17,11 @@
 
 #include "helper/types.h"
 #include "helper/locking.h"
+#include "helper/unique_id.h"
 
 #include "storage/AbstractResource.h"
 #include "storage/BaseDictionary.h"
 #include "storage/storage_types.h"
-
-#include <boost/lexical_cast.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 
 class ColumnMetadata;
@@ -119,7 +115,7 @@ public:
   virtual const ColumnMetadata *metadataAt(size_t column, size_t row = 0, table_id_t table_id = 0) const = 0;
 
   /**
-   * Returs a list of references to metadata of this table. 
+   * Returs a list of references to metadata of this table.
    *
    * The list is newly created for all calls to this method, but the
    * references stay the same. Thus calling this method incurrs a
@@ -295,7 +291,7 @@ public:
       /*if (map->isOrdered()) {
         throw std::runtime_error("Cannot insert value in an ordered dictionary");
       } else {
-        
+
       }*/
     } else {
       // TODO: We should document that INT_MAX is an invalid document ID
@@ -515,7 +511,7 @@ public:
    */
   virtual hyrise::storage::atable_ptr_t copy() const = 0;
 
-  /** 
+  /**
   * get underlying attribute vectors for column
   *
   * This method returns a struct containing the reference to the attribute
@@ -526,14 +522,13 @@ public:
 
   virtual void debugStructure(size_t level=0) const;
 
-  boost::uuids::uuid getUuid() const;
+  unique_id getUuid() const;
 
-  void setUuid(boost::uuids::uuid u = boost::uuids::nil_uuid());
+  void setUuid(unique_id = unique_id());
 
  private:
-  // Global unique identifier for this object  
-  boost::uuids::uuid _uuid = boost::uuids::nil_uuid();
+  // Global unique identifier for this object
+  unique_id _uuid;
 };
 
 #endif  // SRC_LIB_STORAGE_ABSTRACTTABLE_H_
-


### PR DESCRIPTION
For one, including boost in public headers is a discouraged practice for multiple reasons anyway. Also, this reduces the compile time by a whopping 20%.

> make -j 7  846.30s user 73.74s system 562% cpu 2:43.64 total
> After removal of boost::uuid
> make -j 7  574.92s user 56.96s system 547% cpu 1:55.33 total
