### PR TITLE
Adds minor MVCC updates

### DIFF
--- a/src/bin/perf_regression/InsertScan.cpp
+++ b/src/bin/perf_regression/InsertScan.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#include <gtest/gtest-bench.h>
+#include <gtest/gtest.h>
+#include <string>
+
+#include <access.h>
+#include <storage.h>
+#include <io.h>
+#include <io/EmptyLoader.h>
+#include "io/TransactionManager.h"
+#include <io/CSVLoader.h>
+#include "io/shortcuts.h"
+
+//JoinScan Benchmark similar to TPC-C Implementation of Stock-Level Transaction
+//See TPC-C Reference Chapter A.5
+
+class InsertScanBase : public ::testing::Benchmark {
+
+ protected:
+
+  hyrise::storage::atable_ptr_t data;
+  hyrise::storage::atable_ptr_t t;
+  hyrise::tx::TXContext ctx;
+  hyrise::access::InsertScan is;
+  hyrise::access::Commit c;
+
+ public:
+  void BenchmarkSetUp() {
+    data = Loader::shortcuts::load("test/test10k_12.tbl");
+    ctx = hyrise::tx::TransactionManager::getInstance().buildContext();
+
+    EmptyInput input;
+    CSVHeader header("test/test10k_12.tbl");
+    t = Loader::load(Loader::params().setInput(input).setHeader(header));
+
+    is.setTXContext(ctx);
+    is.addInput(t);
+    is.setInputData(data);
+
+    c.setTXContext(ctx);
+    c.addInput(t);
+  }
+
+  InsertScanBase() {
+    SetNumIterations(10);
+    SetWarmUp(2);
+  }
+};
+
+BENCHMARK_F(InsertScanBase, insert_single_tx_no_commit)
+  {
+    is.execute();
+  }
+
+BENCHMARK_F(InsertScanBase, insert_single_tx_commit)
+  {
+    is.execute();
+    c.execute();
+  }

--- a/src/bin/units_io/tx_tests.cpp
+++ b/src/bin/units_io/tx_tests.cpp
@@ -11,14 +11,19 @@ TEST(TX, begin_commit) {
   TXContext tx = TM::beginTransaction();
   EXPECT_GT(tx.tid, 0);
   EXPECT_EQ(tx.cid, UNKNOWN);
-  auto cid = TM::commitTransaction(tx.tid);
+  auto cid = TM::commitTransaction(tx);
   EXPECT_NE(cid, UNKNOWN);
 }
 
 TEST(TX, commit_invalid) {
+  TXContext tx = TM::beginTransaction();
+  transaction_id_t oldtid = tx.tid;
   transaction_id_t invalid = std::numeric_limits<transaction_id_t>::max();
   EXPECT_FALSE(TM::isRunningTransaction(invalid));
-  EXPECT_ANY_THROW(TM::commitTransaction(invalid));
+  tx.tid = invalid;
+  EXPECT_ANY_THROW(TM::commitTransaction(tx));
+  tx.tid = oldtid;
+  TM::commitTransaction(tx);
 }
 
 TEST(TX, active_transactions) {
@@ -26,8 +31,8 @@ TEST(TX, active_transactions) {
   auto t1 = TM::beginTransaction();
   auto t2 = TM::beginTransaction();
   EXPECT_EQ(TM::getRunningTransactionContexts().size(), 2u);
-  TM::commitTransaction(t1.tid);
-  TM::commitTransaction(t2.tid);
+  TM::commitTransaction(t1);
+  TM::commitTransaction(t2);
   EXPECT_EQ(TM::getRunningTransactionContexts().size(), 0u);
 }
 
@@ -35,7 +40,7 @@ TEST(TX, rollback_transaction) {
   auto before = TM::getInstance().getLastCommitId();
   ASSERT_EQ(TM::getRunningTransactionContexts().size(), 0u);
   auto t1 = TM::beginTransaction();
-  TM::rollbackTransaction(t1.tid);
+  TM::rollbackTransaction(t1);
   EXPECT_EQ(TM::getRunningTransactionContexts().size(), 0u);
   auto after = TM::getInstance().getLastCommitId();
   EXPECT_EQ(before, after) << "No commits are made when doing a rollback";

--- a/src/lib/access/tx/Commit.cpp
+++ b/src/lib/access/tx/Commit.cpp
@@ -10,7 +10,7 @@ namespace {
 }
 
 void Commit::executePlanOperation() {
-  tx::TransactionManager::commitTransaction(_txContext.tid);
+  tx::TransactionManager::commitTransaction(_txContext);
 }
 
 std::shared_ptr<PlanOperation> Commit::parse(Json::Value &data) {

--- a/src/lib/access/tx/Rollback.cpp
+++ b/src/lib/access/tx/Rollback.cpp
@@ -9,7 +9,7 @@ auto reg_rollb = QueryParser::registerTrivialPlanOperation<Rollback>("Rollback")
 }
 
 void Rollback::executePlanOperation() {
-  tx::TransactionManager::rollbackTransaction(_txContext.tid);
+  tx::TransactionManager::rollbackTransaction(_txContext);
 }
 
 }

--- a/src/lib/io/TransactionManager.h
+++ b/src/lib/io/TransactionManager.h
@@ -84,11 +84,11 @@ class TransactionManager {
   /// of the transaction context identified by tid
   /// \param tid transaction id to commit
   /// \returns commit id on success
-  static transaction_cid_t commitTransaction(transaction_id_t tid);
+  static transaction_cid_t commitTransaction(TXContext ctx);
 
   /// Ends a transaction by leaving all changes invisible
   /// \param tid transaction id to abort
-  static void rollbackTransaction(transaction_id_t tid);
+  static void rollbackTransaction(TXContext ctx);
 
   /// Check validity of a transaction
   /// \param tid transaction id under investigation


### PR DESCRIPTION
- adds insert performance regression test
- MVCC: If a row is inserted and deleted in the same Tx, it is now invisible to the Tx (as it should be) - fixes #172
- Remove TXManager::getLastCID() calls from loop in Store::Merge #181
- TXManager::commitTransaction should get complete context instead of commit id only - changed rollback as well #181
