### PR TITLE
Skipping reference table for autojson in query parsing

### DIFF
--- a/src/lib/access/storage/TableLoad.cpp
+++ b/src/lib/access/storage/TableLoad.cpp
@@ -90,6 +90,10 @@ void TableLoad::setTableName(const std::string &tablename) {
   _table_name = tablename;
 }
 
+const std::string TableLoad::getTableName() {
+  return _table_name;
+}
+
 void TableLoad::setFileName(const std::string &filename) {
   _file_name = filename;
 }

--- a/src/lib/access/storage/TableLoad.h
+++ b/src/lib/access/storage/TableLoad.h
@@ -22,6 +22,7 @@ public:
   static std::shared_ptr<PlanOperation> parse(Json::Value &data);
   const std::string vname();
   void setTableName(const std::string &tablename);
+  const std::string getTableName();
   void setFileName(const std::string &filename);
   void setHeaderFileName(const std::string &filename);
   void setHeaderString(const std::string &header);

--- a/src/lib/access/system/QueryParser.cpp
+++ b/src/lib/access/system/QueryParser.cpp
@@ -6,6 +6,7 @@
 #include "helper/vector_helpers.h"
 #include "access/system/PlanOperation.h"
 #include "access/system/ParallelizablePlanOperation.h"
+#include "access/storage/TableLoad.h"
 
 namespace hyrise { namespace access {
 
@@ -113,9 +114,14 @@ std::shared_ptr<Task>  QueryParser::getResultTask(
 
   for (it = task_map.begin(); it != task_map.end(); ++it) {
     currentTask = it->second;
+    
     // Also, exclude autojson reference table task
-    if (!currentTask->hasSuccessors()
-        &&  it->first.asString() != autojsonReferenceTableId) {
+    std::shared_ptr<TableLoad> tableLoad = std::dynamic_pointer_cast<TableLoad>(currentTask);
+    if (tableLoad && tableLoad->getTableName() == autojsonReferenceTableName) {
+      continue;
+    }
+
+    if (!currentTask->hasSuccessors()) {
       resultTask = currentTask;
       break;
     }

--- a/src/lib/access/system/QueryParser.h
+++ b/src/lib/access/system/QueryParser.h
@@ -13,7 +13,7 @@
 
 #include "access/system/BasicParser.h"
 
-const std::string autojsonReferenceTableId = "-1";
+const std::string autojsonReferenceTableName = "reference";
 
 class Task;
 


### PR DESCRIPTION
The reference table for autojson tests is determined by the table name 'reference' solely. The query parser should do the same and not rely on the naming of "-1" for the task. This commit fixes the issue but it also introduces a close coupling between access/system and access/storage. If that's fine, merge, otherwise; I am open to suggestions.
