### PR TITLE
More consequent namesapces in hyrise

### DIFF
--- a/src/bin/hyrise/main.cpp
+++ b/src/bin/hyrise/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
   LOG4CXX_WARN(logger, "compiled with development settings, expect substantially lower and non-representative performance");
 #endif
 
-  SharedScheduler::getInstance().init(scheduler_name, worker_threads);
+  taskscheduler::SharedScheduler::getInstance().init(scheduler_name, worker_threads);
 
   // Main Server Loop
   struct ev_loop *loop = ev_default_loop(0);

--- a/src/bin/perf_regression/GroupByScan.cpp
+++ b/src/bin/perf_regression/GroupByScan.cpp
@@ -17,7 +17,7 @@ class GroupByScanBase : public ::testing::Benchmark {
 
  protected:
 
-  StorageManager *sm;
+  io::StorageManager *sm;
   std::shared_ptr<GroupByScan> gs;
   storage::atable_ptr_t t;
   SumAggregateFun *sum;
@@ -25,7 +25,7 @@ class GroupByScanBase : public ::testing::Benchmark {
  public:
 
   void BenchmarkSetUp() {
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
 
     t = sm->getTable("order_line");
 

--- a/src/bin/perf_regression/HashJoin.cpp
+++ b/src/bin/perf_regression/HashJoin.cpp
@@ -18,7 +18,7 @@ class HashJoinBase : public ::testing::Benchmark {
 
  protected:
 
-  StorageManager *sm;
+  io::StorageManager *sm;
 
   HashBuild *hb;
   HashJoinProbe *hjp;
@@ -32,7 +32,7 @@ class HashJoinBase : public ::testing::Benchmark {
     hjp->setEvent("NO_PAPI");
     hb->setKey("join");
     hb->setEvent("NO_PAPI");
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
 
     t1 = sm->getTable("stock");
     t2 = sm->getTable("order_line");

--- a/src/bin/perf_regression/HashValueJoin.cpp
+++ b/src/bin/perf_regression/HashValueJoin.cpp
@@ -17,7 +17,7 @@ class HashValueJoinBase : public ::testing::Benchmark {
 
  protected:
 
-  StorageManager *sm;
+  io::StorageManager *sm;
   HashValueJoin<int> *hs;
   storage::c_atable_ptr_t t1;
   storage::c_atable_ptr_t t2;
@@ -27,7 +27,7 @@ class HashValueJoinBase : public ::testing::Benchmark {
     hs = new HashValueJoin<int>();
     hs->setEvent("NO_PAPI");
 
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
 
     hs->setProducesPositions(true);
 

--- a/src/bin/perf_regression/InsertScan.cpp
+++ b/src/bin/perf_regression/InsertScan.cpp
@@ -19,20 +19,20 @@ class InsertScanBase : public ::testing::Benchmark {
 
  protected:
 
-  hyrise::storage::atable_ptr_t data;
-  hyrise::storage::atable_ptr_t t;
-  hyrise::tx::TXContext ctx;
-  hyrise::access::InsertScan is;
-  hyrise::access::Commit c;
+  storage::atable_ptr_t data;
+  storage::atable_ptr_t t;
+  tx::TXContext ctx;
+  access::InsertScan is;
+  access::Commit c;
 
  public:
   void BenchmarkSetUp() {
-    data = Loader::shortcuts::load("test/test10k_12.tbl");
-    ctx = hyrise::tx::TransactionManager::getInstance().buildContext();
+    data = io::Loader::shortcuts::load("test/test10k_12.tbl");
+    ctx = tx::TransactionManager::getInstance().buildContext();
 
-    EmptyInput input;
-    CSVHeader header("test/test10k_12.tbl");
-    t = Loader::load(Loader::params().setInput(input).setHeader(header));
+    io::EmptyInput input;
+    io::CSVHeader header("test/test10k_12.tbl");
+    t = io::Loader::load(io::Loader::params().setInput(input).setHeader(header));
     is.setEvent("NO_PAPI");
     is.setTXContext(ctx);
     is.addInput(t);
@@ -81,11 +81,11 @@ std::vector<params> generateParams() {
   std::vector<params> results;
   for (std::size_t t:{1,2,4,8,16,32}) {
     for (std::size_t opt=0; opt < 3; opt++) {
-      auto data = Loader::shortcuts::load("test/test10k_12.tbl");
+      auto data = io::Loader::shortcuts::load("test/test10k_12.tbl");
       storage::atable_ptr_t tbl;
       // slightly hack-ish: opt distinguishes different insertion options
       if (opt == 0) {
-        tbl = Loader::shortcuts::load("test/test10k_12.tbl", Loader::params().setReturnsMutableVerticalTable(true));
+        tbl = io::Loader::shortcuts::load("test/test10k_12.tbl", io::Loader::params().setReturnsMutableVerticalTable(true));
       } else {
         tbl = data->copy_structure_modifiable();
         tbl->resize(opt);
@@ -112,7 +112,7 @@ TEST_P(InsertTest, concurrent_writes_single_insert) {
   auto before = std::chrono::high_resolution_clock::now();
   auto l = [&]() {
     for (std::size_t d=0;d<runs;d++) {
-      auto ctx = hyrise::tx::TransactionManager::getInstance().buildContext();
+      auto ctx = tx::TransactionManager::getInstance().buildContext();
       InsertScan is;
       is.setEvent("NO_PAPI");
       is.setTXContext(ctx);

--- a/src/bin/perf_regression/JoinScan.cpp
+++ b/src/bin/perf_regression/JoinScan.cpp
@@ -10,20 +10,23 @@
 //JoinScan Benchmark similar to TPC-C Implementation of Stock-Level Transaction
 //See TPC-C Reference Chapter A.5
 
+namespace hyrise {
+namespace access {
+
 class JoinScanBase : public ::testing::Benchmark {
 
  protected:
 
-  StorageManager *sm;
-  std::shared_ptr<hyrise::access::JoinScan> js;
-  hyrise::storage::atable_ptr_t t1;
-  hyrise::storage::atable_ptr_t t2;
+  io::StorageManager *sm;
+  std::shared_ptr<JoinScan> js;
+  storage::atable_ptr_t t1;
+  storage::atable_ptr_t t2;
 
  public:
   void BenchmarkSetUp() {
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
 
-    auto js = std::make_shared<hyrise::access::JoinScan>(hyrise::access::JoinType::EQUI);
+    auto js = std::make_shared<JoinScan>(JoinType::EQUI);
     js->setEvent("NO_PAPI");
 
     t1 = sm->getTable("order_line");
@@ -48,3 +51,6 @@ class JoinScanBase : public ::testing::Benchmark {
 
   hyrise::storage::atable_ptr_t result = js->execute();
   }*/
+
+} } // namespace hyrise::access
+

--- a/src/bin/perf_regression/Loading.cpp
+++ b/src/bin/perf_regression/Loading.cpp
@@ -6,9 +6,12 @@
 #include <io/loaders.h>
 #include <storage/AbstractTable.h>
 
+namespace hyrise {
+namespace access {
+
 class LoaderBenchmark : public ::testing::Benchmark {
  protected:
-  std::shared_ptr<AbstractTable> t;
+  std::shared_ptr<storage::AbstractTable> t;
  public:
   virtual void SetUp() {
   }
@@ -23,25 +26,28 @@ class LoaderBenchmark : public ::testing::Benchmark {
 };
 
 BENCHMARK_F(LoaderBenchmark, LoadCustomer) {
-  t = Loader::load(
-      Loader::params()
-      .setHeader(CSVHeader("benchmark_data/customer.tbl"))
-      .setInput(CSVInput("benchmark_data/customer.tbl"))
+  t = io::Loader::load(
+      io::Loader::params()
+      .setHeader(io::CSVHeader("benchmark_data/customer.tbl"))
+      .setInput(io::CSVInput("benchmark_data/customer.tbl"))
                    );
 }
 
 BENCHMARK_F(LoaderBenchmark, LoadOrder) {
-  t = Loader::load(
-      Loader::params()
-      .setHeader(CSVHeader("benchmark_data/order.tbl"))
-      .setInput(CSVInput("benchmark_data/order.tbl"))
+  t = io::Loader::load(
+      io::Loader::params()
+      .setHeader(io::CSVHeader("benchmark_data/order.tbl"))
+      .setInput(io::CSVInput("benchmark_data/order.tbl"))
                    );
 }
 
 BENCHMARK_F(LoaderBenchmark, LoadHistory) {
-  t = Loader::load(
-      Loader::params()
-      .setHeader(CSVHeader("benchmark_data/history.tbl"))
-      .setInput(CSVInput("benchmark_data/history.tbl"))
+  t = io::Loader::load(
+      io::Loader::params()
+      .setHeader(io::CSVHeader("benchmark_data/history.tbl"))
+      .setInput(io::CSVInput("benchmark_data/history.tbl"))
                    );
 }
+
+} } // namespace hyrise::access
+

--- a/src/bin/perf_regression/ProjectionScan.cpp
+++ b/src/bin/perf_regression/ProjectionScan.cpp
@@ -14,7 +14,7 @@ class ProjectionScanBase : public ::testing::Benchmark {
 
  protected:
 
-  StorageManager *sm;
+  io::StorageManager *sm;
   ProjectionScan *ps;
   storage::atable_ptr_t t;
 
@@ -23,7 +23,7 @@ class ProjectionScanBase : public ::testing::Benchmark {
     ps = new ProjectionScan();
     ps->setEvent("NO_PAPI");
 
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
 
     t = sm->getTable("district");
 

--- a/src/bin/perf_regression/SimpleTableScan.cpp
+++ b/src/bin/perf_regression/SimpleTableScan.cpp
@@ -16,7 +16,7 @@ class SimpleTableScanBase : public ::testing::Benchmark {
 
  protected:
 
-  StorageManager *sm;
+  io::StorageManager *sm;
   SimpleTableScan *ts;
   storage::c_atable_ptr_t order_line;
   storage::c_atable_ptr_t customer;
@@ -26,7 +26,7 @@ class SimpleTableScanBase : public ::testing::Benchmark {
     ts = new SimpleTableScan();
     ts->setEvent("NO_PAPI");
 
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
     order_line = sm->getTable("order_line");
     customer = sm->getTable("customer");
   }

--- a/src/bin/perf_regression/SortScan.cpp
+++ b/src/bin/perf_regression/SortScan.cpp
@@ -14,13 +14,13 @@ class SortScanBase : public ::testing::Benchmark {
 
  protected:
 
-  StorageManager *sm;
+  io::StorageManager *sm;
   SortScan *sc;
   storage::c_atable_ptr_t t;
 
  public:
   void BenchmarkSetUp() {
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
 
     sc = new SortScan();
     sc->setEvent("NO_PAPI");

--- a/src/bin/perf_regression/UnionScan.cpp
+++ b/src/bin/perf_regression/UnionScan.cpp
@@ -17,13 +17,13 @@ class UnionScanBase : public ::testing::Benchmark {
  protected:
 
   UnionAll *us;
-  StorageManager *sm;
+  io::StorageManager *sm;
   storage::c_atable_ptr_t t1;
   storage::c_atable_ptr_t t2;
 
  public:
   void BenchmarkSetUp() {
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
 
     us = new UnionAll();
     us->setEvent("NO_PAPI");

--- a/src/bin/perf_regression/scan_performance.cpp
+++ b/src/bin/perf_regression/scan_performance.cpp
@@ -22,7 +22,7 @@
 //#include "gperftools/profiler.h"
 
 namespace hyrise {
-using namespace access;
+namespace access {
 
 static const size_t BNUM_VALUES = 10000000;
 static const size_t DISTINCT_VALUES = BNUM_VALUES/100;
@@ -53,10 +53,10 @@ class ScanBench : public ::testing::Benchmark {
     SetWarmUp(2);
 
     init_data();
-    auto p = Loader::params()
-        .setInput(VectorInput({_data}))
-        .setHeader(StringHeader("col1\nINTEGER\n0_R"));
-    _table = Loader::load(p);
+    auto p = io::Loader::params()
+        .setInput(io::VectorInput({_data}))
+        .setHeader(io::StringHeader("col1\nINTEGER\n0_R"));
+    _table = io::Loader::load(p);
     _value = _data[_data.size()-1];
   }
 
@@ -99,4 +99,5 @@ BENCHMARK_F(ScanBench, CMP_scanperformance_hyriseSpecial) {
   _tablescanSpecial->execute();
 }
 
-}
+} } // namespace hyrise::access
+

--- a/src/bin/perf_regression/tx_performance.cpp
+++ b/src/bin/perf_regression/tx_performance.cpp
@@ -43,7 +43,7 @@ class TXBase : public ::testing::Benchmark {
     one_row->setValue<hyrise_int_t>(0,0, 99);
     one_row->setValue<hyrise_int_t>(1,0, 999);
 
-    linxxxs = checked_pointer_cast<storage::Store>(Loader::shortcuts::load("test/lin_xxxs.tbl"));
+    linxxxs = checked_pointer_cast<storage::Store>(io::Loader::shortcuts::load("test/lin_xxxs.tbl"));
   }
 };
 

--- a/src/bin/units_access/CreateIndexTests.cpp
+++ b/src/bin/units_access/CreateIndexTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "access/CreateIndex.h"
 #include "io/shortcuts.h"
+#include "io/StorageManager.h"
 #include "storage/InvertedIndex.h"
 #include "testing/test.h"
 
@@ -10,9 +11,9 @@ namespace access {
 class CreateIndexTests : public AccessTest {};
 
 TEST_F(CreateIndexTests, basic_create_index_test) {
-  StorageManager *sm = StorageManager::getInstance();
+  auto sm = io::StorageManager::getInstance();
   std::string table = "test_table1";
-  std::shared_ptr<AbstractTable> t = Loader::shortcuts::load("test/index_test.tbl");
+  auto t = io::Loader::shortcuts::load("test/index_test.tbl");
 
   CreateIndex i;
   i.addInput(t);
@@ -20,9 +21,9 @@ TEST_F(CreateIndexTests, basic_create_index_test) {
   i.setIndexName(table);
   i.execute();
 
-  std::shared_ptr<InvertedIndex<hyrise_int_t>> index = std::dynamic_pointer_cast<InvertedIndex<hyrise_int_t>> (sm->getInvertedIndex(table));
+  auto index = std::dynamic_pointer_cast<storage::InvertedIndex<hyrise_int_t>> (sm->getInvertedIndex(table));
 
-  ASSERT_NE(index.get(), (InvertedIndex<storage::hyrise_int_t> *) nullptr);
+  ASSERT_NE(index.get(), (storage::InvertedIndex<storage::hyrise_int_t> *) nullptr);
 }
 
 }

--- a/src/bin/units_access/DistinctTests.cpp
+++ b/src/bin/units_access/DistinctTests.cpp
@@ -10,8 +10,8 @@ namespace access {
 class DistinctTests : public AccessTest {};
 
 TEST_F(DistinctTests, basic_distinct_test) {
-  auto t = Loader::shortcuts::load("test/tables/employees.tbl");
-  auto reference = Loader::shortcuts::load("test/tables/employees_distinct.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/employees.tbl");
+  auto reference = io::Loader::shortcuts::load("test/tables/employees_distinct.tbl");
 
   Distinct d;
   d.addInput(t);
@@ -24,7 +24,7 @@ TEST_F(DistinctTests, basic_distinct_test) {
 }
 
 TEST_F(DistinctTests, distinct_on_distinct_column_test) {
-  auto t = Loader::shortcuts::load("test/tables/employees.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/employees.tbl");
 
   Distinct d;
   d.addInput(t);

--- a/src/bin/units_access/ExpressionScanTests.cpp
+++ b/src/bin/units_access/ExpressionScanTests.cpp
@@ -9,8 +9,8 @@ namespace access {
 class ExpressionScanTests : public AccessTest {};
 
 TEST_F(ExpressionScanTests, basic_expression_scan_test) {
-  auto t = Loader::shortcuts::load("test/lin_xxxs.tbl");
-  auto reference = Loader::shortcuts::load("test/reference/simple_expression.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxxs.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/simple_expression.tbl");
 
   AddExp plus(t, 0, 1);
 

--- a/src/bin/units_access/ExpressionTests.cpp
+++ b/src/bin/units_access/ExpressionTests.cpp
@@ -13,7 +13,7 @@ class ExpressionTests : public AccessTest {
 protected:
   virtual void SetUp() {
     AccessTest::SetUp();    
-    students = Loader::shortcuts::load("test/students.tbl");
+    students = io::Loader::shortcuts::load("test/students.tbl");
     scan = new SimpleTableScan;
     scan->addInput(students);
   }

--- a/src/bin/units_access/GetTableTests.cpp
+++ b/src/bin/units_access/GetTableTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "access/storage/GetTable.h"
 #include "io/shortcuts.h"
+#include "io/StorageManager.h"
 #include "testing/test.h"
 
 namespace hyrise {
@@ -8,14 +9,14 @@ namespace access {
 
 class GetTableTests : public AccessTest {
 public:
-  GetTableTests() : _table(Loader::shortcuts::load("test/empty.tbl")) {
+  GetTableTests() : _table(io::Loader::shortcuts::load("test/empty.tbl")) {
   }
 
   storage::atable_ptr_t _table;
 };
 
 TEST_F(GetTableTests, basic_get_table_test) {
-  StorageManager::getInstance()->loadTable("new_table", _table);
+  io::StorageManager::getInstance()->loadTable("new_table", _table);
 
   GetTable gt("new_table");
   gt.execute();

--- a/src/bin/units_access/GroupByScanTests.cpp
+++ b/src/bin/units_access/GroupByScanTests.cpp
@@ -11,7 +11,7 @@ namespace access {
 class GroupByScanTests : public AccessTest {};
 
 TEST_F(GroupByScanTests, basic_group_by_test) {
-  auto t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   HashBuild hb;
   hb.addInput(t);
@@ -33,8 +33,8 @@ TEST_F(GroupByScanTests, basic_group_by_test) {
 }
 
 TEST_F(GroupByScanTests, group_by_with_multiple_fields) {
-  auto t = Loader::shortcuts::load("test/10_30_group.tbl");
-  auto reference = Loader::shortcuts::load("test/10_30_group_multi_result.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
+  auto reference = io::Loader::shortcuts::load("test/10_30_group_multi_result.tbl");
 
   HashBuild hb;
   hb.addInput(t);
@@ -58,8 +58,8 @@ TEST_F(GroupByScanTests, group_by_with_multiple_fields) {
 }
 
 TEST_F(GroupByScanTests, group_by_with_aggregate_function) {
-  auto t = Loader::shortcuts::load("test/10_30_group.tbl");
-  auto reference = Loader::shortcuts::load("test/10_30_group_count_result.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
+  auto reference = io::Loader::shortcuts::load("test/10_30_group_count_result.tbl");
 
   auto count = new CountAggregateFun(0);
 

--- a/src/bin/units_access/HashBuildTests.cpp
+++ b/src/bin/units_access/HashBuildTests.cpp
@@ -10,7 +10,7 @@ namespace access {
 class HashBuildTests : public AccessTest {};
 
 TEST_F(HashBuildTests, basic_hash_build_for_groupby_test) {
-  auto t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   HashBuild hb;
   hb.addInput(t);
@@ -18,13 +18,13 @@ TEST_F(HashBuildTests, basic_hash_build_for_groupby_test) {
   hb.setKey("groupby");
   hb.execute();
 
-  const auto &result = std::dynamic_pointer_cast<const SingleAggregateHashTable>(hb.getResultHashTable());
+  const auto &result = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable>(hb.getResultHashTable());
 
-  ASSERT_NE(result.get(), (SingleAggregateHashTable *) nullptr);
+  ASSERT_NE(result.get(), (storage::SingleAggregateHashTable *) nullptr);
 }
 
 TEST_F(HashBuildTests, basic_hash_build_for_join_test) {
-  auto t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   HashBuild hb;
   hb.addInput(t);
@@ -34,7 +34,7 @@ TEST_F(HashBuildTests, basic_hash_build_for_join_test) {
 
   const auto &result = hb.getResultHashTable();
 
-  ASSERT_NE(result.get(), (JoinHashTable *) nullptr);
+  ASSERT_NE(result.get(), (storage::JoinHashTable *) nullptr);
 }
 
 }

--- a/src/bin/units_access/HashJoinProbeTests.cpp
+++ b/src/bin/units_access/HashJoinProbeTests.cpp
@@ -16,9 +16,9 @@ TEST_F(HashJoinProbeTests, DISABLED_basic_hash_join_probe_test) {
   const std::string header_left("A|B|C\nINTEGER|STRING|FLOAT\n0_R|0_R|0_R");
   const std::string header_right("D|E|F\nINTEGER|STRING|FLOAT\n0_R|0_R|0_R");
   const std::string header_ref("A|B|C|D|E|F\nINTEGER|STRING|FLOAT|INTEGER|STRING|FLOAT\n0_R|0_R|0_R|0_R|0_R|0_R");
-  auto left      = Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_left);
-  auto right     = Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_right);
-  auto reference = Loader::shortcuts::loadWithStringHeader("test/reference/hash_table_test_int.tbl", header_ref);
+  auto left      = io::Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_left);
+  auto right     = io::Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_right);
+  auto reference = io::Loader::shortcuts::loadWithStringHeader("test/reference/hash_table_test_int.tbl", header_ref);
 
   HashBuild hb;
   hb.addInput(right);

--- a/src/bin/units_access/HashValueJoinTests.cpp
+++ b/src/bin/units_access/HashValueJoinTests.cpp
@@ -11,9 +11,9 @@ namespace access {
 class HashValueJoinTests : public AccessTest {};
 
 TEST_F(HashValueJoinTests, basic_hash_value_join_test) {
-  auto t1 = Loader::shortcuts::load("test/join_transactions.tbl");
-  auto t2 = Loader::shortcuts::load("test/join_exchange.tbl");
-  auto reference = Loader::shortcuts::load("test/reference/hash_value_join_result.tbl");
+  auto t1 = io::Loader::shortcuts::load("test/join_transactions.tbl");
+  auto t2 = io::Loader::shortcuts::load("test/join_exchange.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/hash_value_join_result.tbl");
 
   auto hvj = std::make_shared<HashValueJoin<storage::hyrise_int_t>>();
   hvj->setProducesPositions(true);

--- a/src/bin/units_access/HistogramTest.cpp
+++ b/src/bin/units_access/HistogramTest.cpp
@@ -11,13 +11,13 @@ namespace access {
 
 class HistogramTest : public AccessTest {
 public:
-  HistogramTest() : AccessTest(), _table(Loader::shortcuts::load("test/tables/hash_table_test.tbl")) {}
-  std::shared_ptr<AbstractTable> _table;
+  HistogramTest() : AccessTest(), _table(io::Loader::shortcuts::load("test/tables/hash_table_test.tbl")) {}
+  std::shared_ptr<storage::AbstractTable> _table;
 };
 
 TEST_F(HistogramTest, 2bit_test) {
 	
-  hyrise::access::Histogram hst;
+  Histogram hst;
   hst.setBits(2);
   hst.addField(0);
   hst.addInput(_table);
@@ -31,7 +31,7 @@ TEST_F(HistogramTest, 2bit_test) {
 
 TEST_F(HistogramTest, 2bit_test_string) {
 	
-  hyrise::access::Histogram hst;
+  Histogram hst;
   hst.setBits(2);
   hst.addField(1);
   hst.addInput(_table);
@@ -45,7 +45,7 @@ TEST_F(HistogramTest, 2bit_test_string) {
 
 TEST_F(HistogramTest, 1bit_test) {
 	
-  hyrise::access::Histogram hst;
+  Histogram hst;
   hst.setBits(1);
   hst.addField(0);
   hst.addInput(_table);

--- a/src/bin/units_access/IndexScanTests.cpp
+++ b/src/bin/units_access/IndexScanTests.cpp
@@ -14,7 +14,7 @@ public:
 
   virtual void SetUp() {
     AccessTest::SetUp();
-    t = Loader::shortcuts::load("test/index_test.tbl");
+    t = io::Loader::shortcuts::load("test/index_test.tbl");
     CreateIndex ci;
     ci.addInput(t);
     ci.addField(0);
@@ -26,7 +26,7 @@ public:
 };
 
 TEST_F(IndexScanTests, basic_index_scan_test) {
-  auto reference = Loader::shortcuts::load("test/reference/index_test_result.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/index_test_result.tbl");
 
   IndexScan is;
   is.addInput(t);

--- a/src/bin/units_access/InsertScanTests.cpp
+++ b/src/bin/units_access/InsertScanTests.cpp
@@ -11,8 +11,8 @@ namespace access {
 class InsertScanTests : public AccessTest {};
 
 TEST_F(InsertScanTests, basic_insert_scan_test) {
-  auto row = Loader::shortcuts::load("test/insert_one.tbl");
-  auto table = Loader::shortcuts::load("test/insert_one.tbl");
+  auto row = io::Loader::shortcuts::load("test/insert_one.tbl");
+  auto table = io::Loader::shortcuts::load("test/insert_one.tbl");
 
   auto ctx = tx::TransactionManager::getInstance().buildContext();
 

--- a/src/bin/units_access/JoinScanTests.cpp
+++ b/src/bin/units_access/JoinScanTests.cpp
@@ -10,9 +10,9 @@ namespace access {
 class JoinScanTests : public AccessTest {};
 
 TEST_F(JoinScanTests, basic_join_scan_test) {
-  auto t1 = Loader::shortcuts::load("test/join_transactions.tbl");
-  auto t2 = Loader::shortcuts::load("test/join_exchange.tbl");
-  auto reference = Loader::shortcuts::load("test/reference/join_result.tbl");
+  auto t1 = io::Loader::shortcuts::load("test/join_transactions.tbl");
+  auto t2 = io::Loader::shortcuts::load("test/join_exchange.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/join_result.tbl");
 
   JoinScan js(JoinType::EQUI);
   js.addInput(t1);

--- a/src/bin/units_access/LayoutTableTests.cpp
+++ b/src/bin/units_access/LayoutTableTests.cpp
@@ -11,7 +11,7 @@ namespace access {
 class LayoutTableTests : public AccessTest {};
 
 TEST_F(LayoutTableTests, basic_layout_table_test) {
-  auto t = Loader::shortcuts::load("test/tables/partitions.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/partitions.tbl");
   ASSERT_EQ(3u, t->partitionCount());
 
   LayoutTable lt("a|c|b|d\nINTEGER|INTEGER|INTEGER|INTEGER\n0_C|0_C|1_C|1_C");

--- a/src/bin/units_access/LoadFileTests.cpp
+++ b/src/bin/units_access/LoadFileTests.cpp
@@ -9,7 +9,7 @@ namespace access {
 class LoadFileTests : public AccessTest {};
 
 TEST_F(LoadFileTests, basic_load_file_test) {
-  auto t = Loader::shortcuts::load("test/tables/employees.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/employees.tbl");
 
   LoadFile lf("tables/employees.tbl");
   lf.execute();

--- a/src/bin/units_access/MaterializingScanTests.cpp
+++ b/src/bin/units_access/MaterializingScanTests.cpp
@@ -11,8 +11,8 @@ namespace access {
 class MaterializingScanTests : public AccessTest {};
 
 TEST_F(MaterializingScanTests, basic_materializing_scan_test) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
-  auto no_p = (PointerCalculator*) nullptr;
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto no_p = (storage::PointerCalculator*) nullptr;
 
   ProjectionScan ps;
   ps.addInput(t);
@@ -21,7 +21,7 @@ TEST_F(MaterializingScanTests, basic_materializing_scan_test) {
   ps.execute();
 
   const auto &t2 = ps.getResultTable();
-  ASSERT_NE(no_p, dynamic_cast<const PointerCalculator*>(t2.get()));
+  ASSERT_NE(no_p, dynamic_cast<const storage::PointerCalculator*>(t2.get()));
 
   MaterializingScan ms;
   ms.addInput(t2);
@@ -29,7 +29,7 @@ TEST_F(MaterializingScanTests, basic_materializing_scan_test) {
   ms.execute();
 
   const auto &result = ms.getResultTable();
-  ASSERT_EQ(no_p, dynamic_cast<const PointerCalculator*>(result.get()));
+  ASSERT_EQ(no_p, dynamic_cast<const storage::PointerCalculator*>(result.get()));
   ASSERT_EQ(100u, result->size());
   ASSERT_EQ(1u, result->columnCount());
 }

--- a/src/bin/units_access/MergeTableTests.cpp
+++ b/src/bin/units_access/MergeTableTests.cpp
@@ -10,8 +10,8 @@ namespace access {
 class MergeTableTests : public AccessTest {};
 
 TEST_F(MergeTableTests, basic_merge_table_test) {
-  auto s = Loader::shortcuts::loadMainDelta("test/merge1_main.tbl", "test/merge1_delta.tbl");
-  auto reference = Loader::shortcuts::load("test/merge1_result.tbl");
+  auto s = io::Loader::shortcuts::loadMainDelta("test/merge1_main.tbl", "test/merge1_delta.tbl");
+  auto reference = io::Loader::shortcuts::load("test/merge1_result.tbl");
 
   ASSERT_EQ(4u, s->getMainTable()->size());
   ASSERT_EQ(5u, s->getDeltaTable()->size());

--- a/src/bin/units_access/OperationDataTests.cpp
+++ b/src/bin/units_access/OperationDataTests.cpp
@@ -3,10 +3,11 @@
 #include "access/system/OperationData-Impl.h"
 #include "storage/AbstractResource.h"
 
-using namespace hyrise::access;
+namespace hyrise {
+namespace access {
 
-class CustomResource1 : public AbstractResource {};
-class CustomResource2 : public AbstractResource {};
+class CustomResource1 : public storage::AbstractResource {};
+class CustomResource2 : public storage::AbstractResource {};
 
 namespace {
 auto cr1a = std::make_shared<CustomResource1>();
@@ -68,3 +69,6 @@ TEST(OperationDataTests, merging) {
   EXPECT_EQ(2u, op.sizeOf<CustomResource1>());
   EXPECT_EQ(1u, op.sizeOf<CustomResource2>());
 }
+
+} } // namespace hyrise::access
+

--- a/src/bin/units_access/ProjectionScanTests.cpp
+++ b/src/bin/units_access/ProjectionScanTests.cpp
@@ -9,8 +9,8 @@ namespace access {
 class ProjectionScanTests : public AccessTest {};
 
 TEST_F(ProjectionScanTests, basic_projection_scan_test) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
-  auto reference = Loader::shortcuts::load("test/reference/simple_projection.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/simple_projection.tbl");
 
   ProjectionScan ps;
   ps.addInput(t);

--- a/src/bin/units_access/ReplaceTableTests.cpp
+++ b/src/bin/units_access/ReplaceTableTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "access/storage/ReplaceTable.h"
 #include "io/shortcuts.h"
+#include "io/StorageManager.h"
 #include "testing/test.h"
 
 namespace hyrise {
@@ -9,10 +10,10 @@ namespace access {
 class ReplaceTableTests : public AccessTest {};
 
 TEST_F(ReplaceTableTests, basic_replace_table_test) {
-  auto t1 = Loader::shortcuts::load("test/lin_xxs.tbl");
-  auto t2 = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t1 = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t2 = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
-  auto sm = StorageManager::getInstance();
+  auto sm = io::StorageManager::getInstance();
   sm->loadTable("replaceMe", t1);
 
   ASSERT_TABLE_EQUAL(t1, sm->getTable("replaceMe"));

--- a/src/bin/units_access/SetTableTests.cpp
+++ b/src/bin/units_access/SetTableTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "access/storage/SetTable.h"
 #include "io/shortcuts.h"
+#include "io/StorageManager.h"
 #include "testing/test.h"
 
 namespace hyrise {
@@ -9,8 +10,8 @@ namespace access {
 class SetTableTests : public AccessTest {};
 
 TEST_F(SetTableTests, basic_SetTable_test) {
-  auto sm = StorageManager::getInstance();
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto sm = io::StorageManager::getInstance();
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
 
   ASSERT_THROW(sm->getTable("myTable"), io::ResourceManagerException);
 

--- a/src/bin/units_access/SimpleRawTableScanTests.cpp
+++ b/src/bin/units_access/SimpleRawTableScanTests.cpp
@@ -11,10 +11,10 @@ namespace access {
 class SimpleRawTableScanTests : public AccessTest {
 public:
   storage::atable_ptr_t createRawTable() {
-    metadata_vec_t columns({ *ColumnMetadata::metadataFromString("INTEGER", "col1"),
-                             *ColumnMetadata::metadataFromString("STRING", "col2"),
-                             *ColumnMetadata::metadataFromString("FLOAT", "col3") });
-    auto main = std::make_shared<RawTable>(columns);
+    storage::metadata_vec_t columns({*storage::ColumnMetadata::metadataFromString("INTEGER", "col1"),
+                                     *storage::ColumnMetadata::metadataFromString("STRING", "col2"),
+                                     *storage::ColumnMetadata::metadataFromString("FLOAT", "col3") });
+    auto main = std::make_shared<storage::RawTable>(columns);
     storage::rawtable::RowHelper rh(columns);
     unsigned char *data = nullptr;
 
@@ -47,7 +47,7 @@ TEST_F(SimpleRawTableScanTests, basic_simple_raw_table_scan_test) {
 }
 
 TEST_F(SimpleRawTableScanTests, simple_raw_table_scan_fail_on_not_raw_test) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   auto expr = new EqualsExpressionRaw<storage::hyrise_int_t>(t, 0, 5);
 
   SimpleRawTableScan srts(expr);

--- a/src/bin/units_access/SimpleTableScanTests.cpp
+++ b/src/bin/units_access/SimpleTableScanTests.cpp
@@ -11,7 +11,7 @@ namespace access {
 class SimpleTableScanTests : public AccessTest {};
 
 TEST_F(SimpleTableScanTests, basic_simple_table_scan_test) {
-  storage::c_atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   auto expr = new EqualsExpression<storage::hyrise_int_t>(t, 0, 100);
 
   SimpleTableScan sts;
@@ -27,7 +27,7 @@ TEST_F(SimpleTableScanTests, basic_simple_table_scan_test) {
 
 // Same as above, but manually parallelized
 TEST_F(SimpleTableScanTests, parallelized_simple_table_scan) {
-  storage::c_atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
 
   SimpleTableScan sts1;
   sts1.addInput(t);

--- a/src/bin/units_access/SmallestTableScanTests.cpp
+++ b/src/bin/units_access/SmallestTableScanTests.cpp
@@ -9,9 +9,9 @@ namespace access {
 class SmallestTableScanTests : public AccessTest {};
 
 TEST_F(SmallestTableScanTests, basic_smallest_table_scan_test) {
-  auto t1 = Loader::shortcuts::load("test/10_30_group.tbl");
-  auto t2 = Loader::shortcuts::load("test/lin_xxs.tbl");
-  auto t3 = Loader::shortcuts::load("test/lin_xxxs.tbl");
+  auto t1 = io::Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t2 = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t3 = io::Loader::shortcuts::load("test/lin_xxxs.tbl");
 
   SmallestTableScan stc;
   stc.addInput(t1);

--- a/src/bin/units_access/SortScanTests.cpp
+++ b/src/bin/units_access/SortScanTests.cpp
@@ -9,8 +9,8 @@ namespace access {
 class SortScanTests : public AccessTest {};
 
 TEST_F(SortScanTests, basic_sort_scan_test) {
-  auto t = Loader::shortcuts::load("test/reference/group_by_scan_using_table_2.tbl");
-  auto reference = Loader::shortcuts::load("test/sort_test.tbl");
+  auto t = io::Loader::shortcuts::load("test/reference/group_by_scan_using_table_2.tbl");
+  auto reference = io::Loader::shortcuts::load("test/sort_test.tbl");
 
   SortScan ss;
   ss.addInput(t);

--- a/src/bin/units_access/SpawnConsecutiveSubtasks.cpp
+++ b/src/bin/units_access/SpawnConsecutiveSubtasks.cpp
@@ -15,7 +15,7 @@ namespace {
 void SpawnConsecutiveSubtasks::executePlanOperation() {
   std::vector<std::shared_ptr<PlanOperation>> children;
   std::vector<std::shared_ptr<Task>> successors;
-  auto scheduler = SharedScheduler::getInstance().getScheduler();
+  auto scheduler = taskscheduler::SharedScheduler::getInstance().getScheduler();
   
   {
     std::lock_guard<decltype(_observerMutex)> lk(_observerMutex);

--- a/src/bin/units_access/SpawnParallelSubtasks.cpp
+++ b/src/bin/units_access/SpawnParallelSubtasks.cpp
@@ -17,7 +17,7 @@ namespace {
 void SpawnParallelSubtasks::executePlanOperation() {
   std::vector<std::shared_ptr<PlanOperation>> children;
   std::vector<std::shared_ptr<Task>> successors;
-  auto scheduler = SharedScheduler::getInstance().getScheduler();
+  auto scheduler = taskscheduler::SharedScheduler::getInstance().getScheduler();
   
   {
     std::lock_guard<decltype(_observerMutex)> lk(_observerMutex);

--- a/src/bin/units_access/TableLoadTests.cpp
+++ b/src/bin/units_access/TableLoadTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "access/storage/TableLoad.h"
 #include "io/shortcuts.h"
+#include "io/StorageManager.h"
 #include "storage/RawTable.h"
 #include "testing/test.h"
 
@@ -10,7 +11,7 @@ namespace access {
 class TableLoadTests : public AccessTest {};
 
 TEST_F(TableLoadTests, basic_table_load_test) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
 
   TableLoad tl;
   tl.setFileName("lin_xxs.tbl");
@@ -23,8 +24,8 @@ TEST_F(TableLoadTests, basic_table_load_test) {
 }
 
 TEST_F(TableLoadTests, table_load_existing_test) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
-  auto sm = StorageManager::getInstance();
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto sm = io::StorageManager::getInstance();
   sm->loadTable("myTable2", t);
 
   TableLoad tl;
@@ -44,13 +45,13 @@ TEST_F(TableLoadTests, raw_table_load_test) {
   tl.execute();
 
   const auto &result = tl.getResultTable();
-  auto raw = std::dynamic_pointer_cast<const RawTable>(result);
+  auto raw = std::dynamic_pointer_cast<const storage::RawTable>(result);
 
   ASSERT_NE(raw, nullptr);
 }
 
 TEST_F(TableLoadTests, table_load_with_string_header_test) {
-  auto t = Loader::shortcuts::loadWithHeader("test/header/data.tbl", "test/header/header.data");
+  auto t = io::Loader::shortcuts::loadWithHeader("test/header/data.tbl", "test/header/header.data");
 
   std::string header = "col1_0|col1_1|col1_2|col1_3|col1_4|col1_5|col1_6|col1_7|col1_8|col1_9\n \
                         INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER|INTEGER\n \
@@ -68,7 +69,7 @@ TEST_F(TableLoadTests, table_load_with_string_header_test) {
 }
 
 TEST_F(TableLoadTests, table_load_with_header_file_test) {
-  auto t = Loader::shortcuts::loadWithHeader("test/header/data.tbl", "test/header/header.data");
+  auto t = io::Loader::shortcuts::loadWithHeader("test/header/data.tbl", "test/header/header.data");
 
   TableLoad tl;
   tl.setFileName("header/data.tbl");

--- a/src/bin/units_access/TableScan_test.cpp
+++ b/src/bin/units_access/TableScan_test.cpp
@@ -8,7 +8,7 @@
 namespace hyrise { namespace access {
 
 TEST(TableScan, test) {
-  auto tbl = Loader::shortcuts::load("test/tables/companies.tbl");
+  auto tbl = io::Loader::shortcuts::load("test/tables/companies.tbl");
   TableScan ts(std::unique_ptr<EqualsExpression<hyrise_int_t> >(new EqualsExpression<hyrise_int_t>(0, 0, 1)));
   ts.addInput(tbl);
   const auto& result = ts.execute()->getResultTable();
@@ -17,7 +17,7 @@ TEST(TableScan, test) {
 
 TEST(TableScan, test2) {
   auto eq = std::unique_ptr<EqualsExpression<hyrise_string_t> >(new EqualsExpression<hyrise_string_t>(0, 1, "Apple Inc"));
-  auto tbl = Loader::shortcuts::load("test/tables/companies.tbl");
+  auto tbl = io::Loader::shortcuts::load("test/tables/companies.tbl");
   TableScan ts(std::move(eq));
   ts.addInput(tbl);
   const auto& result = ts.execute()->getResultTable();

--- a/src/bin/units_access/TableUnloadTests.cpp
+++ b/src/bin/units_access/TableUnloadTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "access/storage/TableUnload.h"
 #include "io/shortcuts.h"
+#include "io/StorageManager.h"
 #include "testing/test.h"
 
 namespace hyrise {
@@ -9,8 +10,8 @@ namespace access {
 class TableUnloadTests : public AccessTest {};
 
 TEST_F(TableUnloadTests, basic_table_unload_test) {
-  auto sm = StorageManager::getInstance();
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto sm = io::StorageManager::getInstance();
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
 
   ASSERT_THROW(sm->getTable("myTable"), io::ResourceManagerException);
 

--- a/src/bin/units_access/UnionAllTests.cpp
+++ b/src/bin/units_access/UnionAllTests.cpp
@@ -13,7 +13,7 @@ class UnionAllTests : public Test{
  public:
   storage::atable_ptr_t t;
   void SetUp() {
-    t = Loader::shortcuts::load("test/lin_xxs.tbl");
+    t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   }
 };
   
@@ -30,8 +30,8 @@ TEST_F(UnionAllTests, basic_union_scan_test) {
 
 
 TEST_F(UnionAllTests, pointer_calc_input) {
-  auto pc1 = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
-  auto pc2 = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
+  auto pc1 = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
+  auto pc2 = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
 
   UnionAll us;
   us.addInput(pc1);
@@ -40,14 +40,14 @@ TEST_F(UnionAllTests, pointer_calc_input) {
 
   const auto &result = us.getResultTable();
 
-  ASSERT_TRUE(std::dynamic_pointer_cast<const PointerCalculator>(result) != nullptr);
+  ASSERT_TRUE(std::dynamic_pointer_cast<const storage::PointerCalculator>(result) != nullptr);
 }
 
 
 TEST_F(UnionAllTests, many_pointer_calc_input) {
-  auto pc1 = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
-  auto pc2 = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
-  auto pc3 = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
+  auto pc1 = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
+  auto pc2 = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
+  auto pc3 = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
 
   UnionAll us;
   us.addInput(pc1);
@@ -57,17 +57,17 @@ TEST_F(UnionAllTests, many_pointer_calc_input) {
 
   const auto &result = us.getResultTable();
   ASSERT_EQ(3 * t->size(), result->size()) << "Needs to be three times as large as original table";
-  ASSERT_TRUE(std::dynamic_pointer_cast<const PointerCalculator>(result) != nullptr);
+  ASSERT_TRUE(std::dynamic_pointer_cast<const storage::PointerCalculator>(result) != nullptr);
 }
 
 TEST_F(UnionAllTests, vertical_nested_pointer_calculators) {
-  auto pc1_l = std::make_shared<PointerCalculator>(t, new std::vector<size_t> {1}, new std::vector<size_t> {0, 1});
-  auto pc1_r = std::make_shared<PointerCalculator>(t, new std::vector<size_t> {5}, new std::vector<size_t> {2, 3, 4});
+  auto pc1_l = std::make_shared<storage::PointerCalculator>(t, new std::vector<size_t> {1}, new std::vector<size_t> {0, 1});
+  auto pc1_r = std::make_shared<storage::PointerCalculator>(t, new std::vector<size_t> {5}, new std::vector<size_t> {2, 3, 4});
   std::vector<storage::atable_ptr_t> pc1 {pc1_l , pc1_r};
   auto mtv1  = std::make_shared<storage::MutableVerticalTable>(pc1);
   
-  auto pc2_l = std::make_shared<PointerCalculator>(t, new std::vector<size_t> {2, 3}, new std::vector<size_t> {0, 1});
-  auto pc2_r = std::make_shared<PointerCalculator>(t, new std::vector<size_t> {2, 6}, new std::vector<size_t> {2, 3, 4});
+  auto pc2_l = std::make_shared<storage::PointerCalculator>(t, new std::vector<size_t> {2, 3}, new std::vector<size_t> {0, 1});
+  auto pc2_r = std::make_shared<storage::PointerCalculator>(t, new std::vector<size_t> {2, 6}, new std::vector<size_t> {2, 3, 4});
   std::vector<storage::atable_ptr_t> pc2 {pc2_l , pc2_r};
   auto mtv2  = std::make_shared<storage::MutableVerticalTable>(pc2);
 
@@ -82,8 +82,8 @@ TEST_F(UnionAllTests, vertical_nested_pointer_calculators) {
 }
 
 TEST_F(UnionAllTests, mixed_input) {
-  auto pc1 = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
-  auto pc2 = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
+  auto pc1 = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
+  auto pc2 = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
 
   UnionAll us;
   us.addInput(pc1);

--- a/src/bin/units_access/UnionScanTests.cpp
+++ b/src/bin/units_access/UnionScanTests.cpp
@@ -7,8 +7,8 @@
 namespace hyrise { namespace access {
 
 TEST(UnionScanTests, basic_union_scan_test) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
-  auto pc = std::make_shared<PointerCalculator>(t, nullptr, nullptr);
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto pc = std::make_shared<storage::PointerCalculator>(t, nullptr, nullptr);
 
   UnionScan us;
   us.addInput(pc);

--- a/src/bin/units_access/UnloadAllTests.cpp
+++ b/src/bin/units_access/UnloadAllTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "access/storage/UnloadAll.h"
 #include "io/shortcuts.h"
+#include "io/StorageManager.h"
 #include "testing/test.h"
 
 namespace hyrise {
@@ -9,10 +10,10 @@ namespace access {
 class UnloadAllTests : public AccessTest {};
 
 TEST_F(UnloadAllTests, basic_unload_all_test) {
-  auto sm = StorageManager::getInstance();
-  auto t1 = Loader::shortcuts::load("test/lin_xxs.tbl");
-  auto t2 = Loader::shortcuts::load("test/lin_xxxs.tbl");
-  auto t3 = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto sm = io::StorageManager::getInstance();
+  auto t1 = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t2 = io::Loader::shortcuts::load("test/lin_xxxs.tbl");
+  auto t3 = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   ASSERT_THROW(sm->getTable("table1"), io::ResourceManagerException);
   ASSERT_THROW(sm->getTable("table2"), io::ResourceManagerException);

--- a/src/bin/units_access/autojson.cpp
+++ b/src/bin/units_access/autojson.cpp
@@ -10,9 +10,11 @@
 
 #include "access/system/PlanOperation.h"
 #include "io/TransactionManager.h"
+#include "io/StorageManager.h"
 #include "testing/TableEqualityTest.h"
 
 namespace hyrise {
+namespace access {
 
 using namespace boost::filesystem;
 
@@ -24,7 +26,7 @@ using ::testing::ValuesIn;
 class AutoJsonTest : public TestWithParam<std::string> {
  public:
   AutoJsonTest() {
-    sm = StorageManager::getInstance();
+    sm = io::StorageManager::getInstance();
   }
   virtual ~AutoJsonTest() { }
 
@@ -40,7 +42,7 @@ class AutoJsonTest : public TestWithParam<std::string> {
 
  protected:
   std::string json_name;
-  StorageManager *sm;
+  io::StorageManager *sm;
 };
 
 TEST_P(AutoJsonTest, Query) {
@@ -61,7 +63,7 @@ TEST_P(AutoJsonTest, Query) {
   
   if (sm->exists("reference")) {
     ASSERT_TRUE((bool)out);
-    auto ref = StorageManager::getInstance()->getTable("reference");
+    auto ref = io::StorageManager::getInstance()->getTable("reference");
     EXPECT_NE(ref.get(), out.get()) << "May not use 'reference' table to compare with itself";
     EXPECT_RELATION_EQ(ref, out);
   }
@@ -101,4 +103,5 @@ INSTANTIATE_TEST_CASE_P(
 TEST(DummyTest, ValueParameterizedTestsAreNotSupportedOnThisPlatform) {}
 #endif
 
-}
+} } // namespace hyrise::access
+

--- a/src/bin/units_access/create_index.cpp
+++ b/src/bin/units_access/create_index.cpp
@@ -15,7 +15,7 @@ class IndexTests : public AccessTest {};
 TEST_F(IndexTests, basic_index_test) {
   std::string table = "test_table1";
 
-  std::shared_ptr<AbstractTable> t = Loader::shortcuts::load("test/index_test.tbl");
+  auto t = io::Loader::shortcuts::load("test/index_test.tbl");
 
   hyrise::access::CreateIndex i;
   i.addInput(t);
@@ -23,8 +23,8 @@ TEST_F(IndexTests, basic_index_test) {
   i.setIndexName(table);
   i.execute();
 
-  StorageManager *sm = StorageManager::getInstance();
-  std::shared_ptr<InvertedIndex<hyrise_int_t>> index = std::dynamic_pointer_cast<InvertedIndex<hyrise_int_t>> (sm->getInvertedIndex(table));
+  auto sm = io::StorageManager::getInstance();
+  auto index = std::dynamic_pointer_cast<storage::InvertedIndex<hyrise_int_t>> (sm->getInvertedIndex(table));
   int key = 30;
   pos_list_t positions = index->getPositionsForKey(key);
   pos_t first_pos = positions[0];
@@ -35,15 +35,15 @@ TEST_F(IndexTests, basic_index_test) {
 
 TEST_F(IndexTests, multiple_positions_index_test) {
   std::string table = "test_table2";
-  std::shared_ptr<AbstractTable> t = Loader::shortcuts::load("test/index_test2.tbl");
-  hyrise::access::CreateIndex i;
+  auto t = io::Loader::shortcuts::load("test/index_test2.tbl");
+  CreateIndex i;
   i.addInput(t);
   i.addField(1);
   i.setIndexName(table);
   i.execute();
 
-  StorageManager *sm = StorageManager::getInstance();
-  std::shared_ptr<InvertedIndex<hyrise_string_t>> index = std::dynamic_pointer_cast<InvertedIndex<hyrise_string_t>> (sm->getInvertedIndex(table));
+  auto sm = io::StorageManager::getInstance();
+  auto index = std::dynamic_pointer_cast<storage::InvertedIndex<hyrise_string_t>> (sm->getInvertedIndex(table));
   std::string key1 = "Bayer";
   std::string key2 = "RWE";
   pos_list_t positions1 = index->getPositionsForKey(key1);
@@ -64,7 +64,7 @@ TEST_F(IndexTests, multiple_positions_index_test) {
 TEST_F(IndexTests, basic_index_test_float) {
   std::string table = "test_table3";
 
-  std::shared_ptr<AbstractTable> t = Loader::shortcuts::load("test/index_test.tbl");
+  auto t = io::Loader::shortcuts::load("test/index_test.tbl");
 
   hyrise::access::CreateIndex i;
   i.addInput(t);
@@ -72,8 +72,8 @@ TEST_F(IndexTests, basic_index_test_float) {
   i.setIndexName(table);
   i.execute();
 
-  StorageManager *sm = StorageManager::getInstance();
-  std::shared_ptr<InvertedIndex<hyrise_float_t>> index = std::dynamic_pointer_cast<InvertedIndex<hyrise_float_t>> (sm->getInvertedIndex(table));
+  auto sm = io::StorageManager::getInstance();
+  auto index = std::dynamic_pointer_cast<storage::InvertedIndex<hyrise_float_t>> (sm->getInvertedIndex(table));
   float key = 71.1;
   pos_list_t positions = index->getPositionsForKey(key);
   pos_t first_pos = positions[0];

--- a/src/bin/units_access/hash_build.cpp
+++ b/src/bin/units_access/hash_build.cpp
@@ -36,14 +36,14 @@ bool check_equality(const storage::c_ahashtable_ptr_t & ht1, const storage::c_ah
 }
 
 TEST_F(HashBuildTest, check_equality) {
-  std::shared_ptr<AbstractTable> t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   HashBuild hb;
   hb.addInput(t);
   hb.addField(1);
   hb.setKey("groupby");
   hb.execute();
-  auto hash = std::dynamic_pointer_cast<const SingleAggregateHashTable >(hb.getResultHashTable());
+  auto hash = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(hb.getResultHashTable());
 
   auto t1 = storage::TableRangeView::create(t, 0, 4);
   auto t2 = storage::TableRangeView::create(t, 5, 9);
@@ -53,34 +53,34 @@ TEST_F(HashBuildTest, check_equality) {
   hb1.addField(1);
   hb1.setKey("groupby");
   hb1.execute();
-  auto hash1 = std::dynamic_pointer_cast<const SingleAggregateHashTable >(hb1.getResultHashTable());
+  auto hash1 = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(hb1.getResultHashTable());
 
   HashBuild hb2;
   hb2.addInput(t2);
   hb2.addField(1);
   hb2.setKey("groupby");
   hb2.execute();
-  auto hash2 = std::dynamic_pointer_cast<const SingleAggregateHashTable >(hb2.getResultHashTable());
+  auto hash2 = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(hb2.getResultHashTable());
 
   ASSERT_TRUE(check_equality(hash, hash));
   ASSERT_FALSE(check_equality(hash1, hash2));
 }
 
 TEST_F(HashBuildTest, merge_one_table_test) {
-  std::shared_ptr<AbstractTable> t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   HashBuild hb;
   hb.addInput(t);
   hb.addField(1);
   hb.setKey("groupby");
   hb.execute();
-  auto hash1 = std::dynamic_pointer_cast<const SingleAggregateHashTable >(hb.getResultHashTable());
+  auto hash1 = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(hb.getResultHashTable());
 
   MergeHashTables mht;
   mht.addInput(hash1);
   mht.setKey("groupby");
   mht.execute();
-  auto hash2 = std::dynamic_pointer_cast<const SingleAggregateHashTable >(mht.getResultHashTable());
+  auto hash2 = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(mht.getResultHashTable());
 
 
   ASSERT_TRUE(check_equality(hash1, hash2));
@@ -88,13 +88,13 @@ TEST_F(HashBuildTest, merge_one_table_test) {
 
 TEST_F(HashBuildTest, merge_two_tables_test) {
   // reference hash Table
-  std::shared_ptr<AbstractTable> t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
   HashBuild hb;
   hb.addInput(t);
   hb.addField(1);
   hb.setKey("groupby");
   hb.execute();
-  auto hash = std::dynamic_pointer_cast<const SingleAggregateHashTable >(hb.getResultHashTable());
+  auto hash = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(hb.getResultHashTable());
 
   //test to merge two tables
   auto t1 = storage::TableRangeView::create(t, 0, 5);
@@ -105,21 +105,21 @@ TEST_F(HashBuildTest, merge_two_tables_test) {
   hb1.addField(1);
   hb1.setKey("groupby");
   hb1.execute();
-  auto hash1 = std::dynamic_pointer_cast<const SingleAggregateHashTable >(hb1.getResultHashTable());
+  auto hash1 = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(hb1.getResultHashTable());
 
   HashBuild hb2;
   hb2.addInput(t2);
   hb2.addField(1);
   hb2.setKey("groupby");
   hb2.execute();
-  auto hash2 = std::dynamic_pointer_cast<const SingleAggregateHashTable >(hb2.getResultHashTable());
+  auto hash2 = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(hb2.getResultHashTable());
 
   MergeHashTables mht;
   mht.addInput(hash1);
   mht.addInput(hash2);
   mht.setKey("groupby");
   mht.execute();
-  auto hash3 = std::dynamic_pointer_cast<const SingleAggregateHashTable >(mht.getResultHashTable());
+  auto hash3 = std::dynamic_pointer_cast<const storage::SingleAggregateHashTable >(mht.getResultHashTable());
 
   ASSERT_EQ(hash->size(), hash3->size());
   ASSERT_EQ(hash->numKeys(), hash3->numKeys());

--- a/src/bin/units_access/hash_join.cpp
+++ b/src/bin/units_access/hash_join.cpp
@@ -13,13 +13,16 @@
 
 #include "testing/TableEqualityTest.h"
 
-typedef std::shared_ptr<AbstractTable> tbl_ptr;
+namespace hyrise {
+namespace access {
 
-hyrise::storage::c_atable_ptr_t join(const tbl_ptr &left,
-                                    const tbl_ptr &right,
-                                    const std::vector<size_t> &fields_left,
-                                    const std::vector<size_t> &fields_right) {
-  hyrise::access::HashBuild hashBuild;
+typedef std::shared_ptr<storage::AbstractTable> tbl_ptr;
+
+storage::c_atable_ptr_t join(const tbl_ptr &left,
+                             const tbl_ptr &right,
+                             const std::vector<size_t> &fields_left,
+                             const std::vector<size_t> &fields_right) {
+  HashBuild hashBuild;
   hashBuild.addInput(left);
   hashBuild.setKey("join");
   for (auto & field_left: fields_left) hashBuild.addField(field_left);
@@ -51,11 +54,11 @@ class HashTestJoinIdentical : public ::testing::TestWithParam<identicalJoinParam
 
 TEST_P(HashTestJoinIdentical, join_identical) {
   auto params = GetParam();
-  auto left = Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_a);
-  auto right = Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_b);
+  auto left = io::Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_a);
+  auto right = io::Loader::shortcuts::loadWithStringHeader("test/tables/hash_table_test.tbl", header_b);
 
   auto result = join(left, right, params.fields, params.fields);
-  auto reference = Loader::shortcuts::load(params.result);
+  auto reference = io::Loader::shortcuts::load(params.result);
 
   EXPECT_RELATION_EQ(result, reference);
 }
@@ -92,4 +95,6 @@ INSTANTIATE_TEST_CASE_P(HashTestWithoutDelta,
 INSTANTIATE_TEST_CASE_P(HashTestWithDelta,
                         HashTestJoinIdenticalWithDelta,
                         ::testing::ValuesIn(cases));
+
+} } // namespace hyrise::access
 

--- a/src/bin/units_access/helper.h
+++ b/src/bin/units_access/helper.h
@@ -1,16 +1,16 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_BIN_UNITS_ACCESS_HELPER_H_
-#define SRC_BIN_UNITS_ACCESS_HELPER_H_
+#pragma once
 
 #include <json.h>
 #include <gtest/gtest.h>
 #include "helper/HwlocHelper.h"
 #include <storage/AbstractTable.h>
 
+namespace hyrise {
+namespace access {
+
 //  Joins specified columns of a single table using hash join.
-hyrise::storage::c_atable_ptr_t hashJoinSameTable(
-    hyrise::storage::atable_ptr_t table,
-    field_list_t &columns);
+storage::c_atable_ptr_t hashJoinSameTable(storage::atable_ptr_t table, field_list_t &columns);
 
 //  Used for message chaining to improve code readability when building edges maps
 class EdgesBuilder {
@@ -27,7 +27,7 @@ class EdgesBuilder {
   Json::Value getEdges() const;
 };
 
-hyrise::storage::c_atable_ptr_t sortTable(hyrise::storage::c_atable_ptr_t table);
+storage::c_atable_ptr_t sortTable(storage::c_atable_ptr_t table);
 
 bool isEdgeEqual(
     const Json::Value &edges,
@@ -37,9 +37,9 @@ bool isEdgeEqual(
 
 std::string loadFromFile(std::string path);
 
-hyrise::storage::c_atable_ptr_t executeAndWait(
+storage::c_atable_ptr_t executeAndWait(
     std::string httpQuery,
     size_t poolSize = getNumberOfCoresOnSystem(),
     std::string *evt = nullptr);
 
-#endif  // SRC_BIN_UNITS_ACCESS_HELPER_H_
+} } // namespace hyrise::access

--- a/src/bin/units_access/jsontests.cpp
+++ b/src/bin/units_access/jsontests.cpp
@@ -8,7 +8,8 @@
 #include <storage.h>
 
 #include <io/shortcuts.h>
-#include "taskscheduler/SharedScheduler.h"
+#include <io/StorageManager.h>
+#include <taskscheduler/SharedScheduler.h>
 
 namespace hyrise {
 namespace access {
@@ -174,8 +175,8 @@ TEST_F(JSONTests, simple_parse) {
 }
 
 TEST_F(JSONTests, parse_projection) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
-  hyrise::storage::atable_ptr_t reference = Loader::shortcuts::load("test/reference/simple_projection.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/simple_projection.tbl");
   std::string query = "{\"type\": \"ProjectionScan\", \"fields\": [0], \"inputs\": [\"table1\"] }";
 
   Json::Value root;
@@ -192,12 +193,11 @@ TEST_F(JSONTests, parse_projection) {
   ASSERT_EQ(OpSuccess, ps->getState());
   auto result = ps->getResultTable();
   ASSERT_TRUE(result->contentEquals(reference));
-
 }
 
 TEST_F(JSONTests, parse_papi_event_set) {
-  StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
-  StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
 
   std::string q = loadFromFile("test/json/simple_query_with_papi.json");
 
@@ -205,15 +205,14 @@ TEST_F(JSONTests, parse_papi_event_set) {
   const auto& out = executeAndWait(q, 1, &papi);
 
   ASSERT_FALSE(!out);
-  ASSERT_TABLE_EQUAL(out, StorageManager::getInstance()->getTable("lin_xxs_comp"));
+  ASSERT_TABLE_EQUAL(out, io::StorageManager::getInstance()->getTable("lin_xxs_comp"));
   ASSERT_EQ("PAPI_L2_DCM", papi);
-  StorageManager::getInstance()->removeAll();
 }
 
 #ifdef USE_PAPI_TRACE
 TEST_F(JSONTests, parse_papi_badevent_set) {
-  StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
-  StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
 
   std::string q = loadFromFile("test/json/simple_query_with_papi_bad.json");
 
@@ -221,14 +220,12 @@ TEST_F(JSONTests, parse_papi_badevent_set) {
   ASSERT_THROW( {
       executeAndWait(q, 1, &papi);
     }, std::runtime_error);
-
-  StorageManager::getInstance()->removeAll();
 }
 #endif
 
 TEST_F(JSONTests, parse_papi_event_not_set) {
-  StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
-  StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
 
   std::string q = loadFromFile("test/json/simple_query.json");
 
@@ -236,10 +233,8 @@ TEST_F(JSONTests, parse_papi_event_not_set) {
   const auto& out = executeAndWait(q, 1, &papi);
 
   ASSERT_FALSE(!out);
-  ASSERT_TABLE_EQUAL(out, StorageManager::getInstance()->getTable("lin_xxs_comp"));
+  ASSERT_TABLE_EQUAL(out, io::StorageManager::getInstance()->getTable("lin_xxs_comp"));
   ASSERT_EQ("PAPI_TOT_INS", papi);
-  StorageManager::getInstance()->removeAll();
-
 }
 
 TEST_F(JSONTests, parse_predicate) {
@@ -264,8 +259,8 @@ TEST_F(JSONTests, parse_predicate_string) {
 
 
 TEST_F(JSONTests, parse_selection) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
-  hyrise::storage::atable_ptr_t reference = Loader::shortcuts::load("test/reference/simple_select_1.tbl");
+  auto t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/simple_select_1.tbl");
 
   std::string query = "{\"type\": \"SimpleTableScan\", \"predicates\":[{\"type\": 8},{\"type\": 7},{\"type\": 0, \"in\":0, \"f\":0, \"vtype\":0, \"value\":2009},{\"type\": 0, \"in\":0, \"f\":1, \"vtype\":0, \"value\":1}]}";
 
@@ -285,8 +280,8 @@ TEST_F(JSONTests, parse_selection) {
 }
 
 TEST_F(JSONTests, simple_query_parser) {
-  StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
-  StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
 
   std::string q = loadFromFile("test/json/simple_query.json");
 
@@ -294,13 +289,12 @@ TEST_F(JSONTests, simple_query_parser) {
 
   ASSERT_FALSE(!out);
 
-  ASSERT_TABLE_EQUAL(out, StorageManager::getInstance()->getTable("lin_xxs_comp"));
-  StorageManager::getInstance()->removeAll();
+  ASSERT_TABLE_EQUAL(out, io::StorageManager::getInstance()->getTable("lin_xxs_comp"));
 }
 
 TEST_F(JSONTests, simple_query_with_names_parser) {
-  StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
-  StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs", "lin_xxs.tbl");
+  io::StorageManager::getInstance()->loadTableFile("lin_xxs_comp", "reference/simple_projection.tbl");
 
   std::string q = loadFromFile("test/json/simple_query_with_names.json");
 
@@ -308,13 +302,13 @@ TEST_F(JSONTests, simple_query_with_names_parser) {
 
   ASSERT_FALSE(!out);
 
-  ASSERT_TABLE_EQUAL(out, StorageManager::getInstance()->getTable("lin_xxs_comp"));
-  StorageManager::getInstance()->removeAll();
+  ASSERT_TABLE_EQUAL(out, io::StorageManager::getInstance()->getTable("lin_xxs_comp"));
+  io::StorageManager::getInstance()->removeAll();
 }
 
 TEST_F(JSONTests, DISABLED_group_by_parser) {
-  StorageManager::getInstance()->loadTableFile("groupby", "10_30_group.tbl");
-  StorageManager::getInstance()->loadTableFile("reference", "reference/group_by_scan_with_sum.tbl");
+  io::StorageManager::getInstance()->loadTableFile("groupby", "10_30_group.tbl");
+  io::StorageManager::getInstance()->loadTableFile("reference", "reference/group_by_scan_with_sum.tbl");
 
   std::string q = loadFromFile("test/json/group_by_query.json");
 
@@ -322,14 +316,13 @@ TEST_F(JSONTests, DISABLED_group_by_parser) {
 
   ASSERT_FALSE(!out);
 
-  ASSERT_TABLE_EQUAL(out, StorageManager::getInstance()->getTable("reference"));
-  StorageManager::getInstance()->removeAll();
+  ASSERT_TABLE_EQUAL(out, io::StorageManager::getInstance()->getTable("reference"));
 }
 
 TEST_F(JSONTests, complex_query_parser) {
 
-  StorageManager::getInstance()->loadTableFile("groupby_xs", "groupby_xs.tbl");
-  StorageManager::getInstance()->loadTableFile("reference", "reference/simple_select_1.tbl");
+  io::StorageManager::getInstance()->loadTableFile("groupby_xs", "groupby_xs.tbl");
+  io::StorageManager::getInstance()->loadTableFile("reference", "reference/simple_select_1.tbl");
 
   std::string q = loadFromFile("test/json/complex_query.json");
 
@@ -337,23 +330,21 @@ TEST_F(JSONTests, complex_query_parser) {
 
   ASSERT_FALSE(!out);
 
-  ASSERT_TABLE_EQUAL(out, StorageManager::getInstance()->getTable("reference"));
-  StorageManager::getInstance()->removeAll();
+  ASSERT_TABLE_EQUAL(out, io::StorageManager::getInstance()->getTable("reference"));
 }
 
 TEST_F(JSONTests, edges_query_parser) {
-  StorageManager::getInstance()->loadTableFile("reference", "edges_ref.tbl");
+  io::StorageManager::getInstance()->loadTableFile("reference", "edges_ref.tbl");
 
 
   std::string query = loadFromFile("test/json/edges_query.json");
   const auto& result = executeAndWait(query);
   ASSERT_FALSE(!result);
-  ASSERT_TABLE_EQUAL(result, StorageManager::getInstance()->getTable("reference"));
-  StorageManager::getInstance()->removeAll();
+  ASSERT_TABLE_EQUAL(result, io::StorageManager::getInstance()->getTable("reference"));
 }
 
 TEST_F(JSONTests, parallel_query_positions_parser) {
-  StorageManager::getInstance()->loadTableFile("reference", "edges_ref.tbl");
+  io::StorageManager::getInstance()->loadTableFile("reference", "edges_ref.tbl");
   //std::string query = loadFromFile("test/json/parallel_query_positions.json");
   std::string query = loadFromFile("test/json/parallel_stc_with_join.json");
 
@@ -361,18 +352,16 @@ TEST_F(JSONTests, parallel_query_positions_parser) {
   ASSERT_FALSE(!result);
 
   //ASSERT_TABLE_EQUAL(result, StorageManager::getInstance()->getTable("reference"));
-  StorageManager::getInstance()->removeAll();
 }
 
 TEST_F(JSONTests, parallel_query_materializing_parser) {
-  StorageManager::getInstance()->loadTableFile("reference", "edges_ref.tbl");
+  io::StorageManager::getInstance()->loadTableFile("reference", "edges_ref.tbl");
   std::string query = loadFromFile("test/json/parallel_query_materializing.json");
 
   const auto& result = executeAndWait(query, 4);
   ASSERT_FALSE(!result);
 
-  ASSERT_TABLE_EQUAL(result, StorageManager::getInstance()->getTable("reference"));
-  StorageManager::getInstance()->removeAll();
+  ASSERT_TABLE_EQUAL(result, io::StorageManager::getInstance()->getTable("reference"));
 }
 
 }

--- a/src/bin/units_access/ops_getset.cpp
+++ b/src/bin/units_access/ops_getset.cpp
@@ -3,7 +3,7 @@
 
 #include "access/storage/GetTable.h"
 #include "access/storage/SetTable.h"
-
+#include "io/StorageManager.h"
 #include "io/shortcuts.h"
 
 namespace hyrise {
@@ -11,9 +11,9 @@ namespace access {
 
 class GetSetTests : public AccessTest {
  protected:
-  std::shared_ptr<AbstractTable> _table;
+  std::shared_ptr<storage::AbstractTable> _table;
   GetSetTests() : AccessTest(),
-                  _table(Loader::shortcuts::load("test/empty.tbl")) {}
+                  _table(io::Loader::shortcuts::load("test/empty.tbl")) {}
 };
 
 TEST_F(GetSetTests, basic_set) {
@@ -21,13 +21,13 @@ TEST_F(GetSetTests, basic_set) {
   st.addInput(_table);
   ASSERT_EQ(_table, st.execute()->getResultTable())
       << "Operation result should be the input table";
-  ASSERT_EQ(StorageManager::getInstance()->getTable("new_table"), _table)
+  ASSERT_EQ(io::StorageManager::getInstance()->getTable("new_table"), _table)
       << "Make sure table is now managed by storage manager";
 
 }
 
 TEST_F(GetSetTests, basic_get) {
-  StorageManager::getInstance()->loadTable("new_table", _table);
+  io::StorageManager::getInstance()->loadTable("new_table", _table);
   GetTable gt("new_table");
   ASSERT_EQ(_table, gt.execute()->getResultTable())
       << "Result table should be equal to the one loaded prior to operation";

--- a/src/bin/units_access/ops_groupby.cpp
+++ b/src/bin/units_access/ops_groupby.cpp
@@ -15,7 +15,7 @@
 namespace hyrise {
 namespace access {
 
-hyrise::storage::c_atable_ptr_t sort(hyrise::storage::c_atable_ptr_t table, field_t field=0) {
+storage::c_atable_ptr_t sort(storage::c_atable_ptr_t table, field_t field=0) {
   SortScan ss;
   ss.addInput(table);
   ss.setSortField(field);
@@ -198,13 +198,13 @@ TEST_F(GroupByTests, aggregated_group_by_scan_using_table_2) {
 
 
 TEST_F(GroupByTests, DISABLED_group_by_performance) {
-  hyrise::storage::atable_ptr_t  t = Loader::shortcuts::load("test/test10k_12.tbl");
+  auto  t = io::Loader::shortcuts::load("test/test10k_12.tbl");
 
-  hyrise::access::GroupByScan gs;
+  GroupByScan gs;
   gs.addInput(t);
   gs.addField(0);
 
-  hyrise::access::HashBuild hs;
+  HashBuild hs;
   hs.addInput(t);
   hs.addField(0);
 
@@ -220,14 +220,14 @@ TEST_F(GroupByTests, DISABLED_group_by_performance) {
 }
 
 TEST_F(GroupByTests, group_by_scan_using_table_2) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   {
-    auto gs = std::make_shared<hyrise::access::GroupByScan>();
+    auto gs = std::make_shared<GroupByScan>();
     gs->addInput(t);
     gs->addField(0);
 
-    auto hs = std::make_shared<hyrise::access::HashBuild>();
+    auto hs = std::make_shared<HashBuild>();
     hs->addInput(t);
     hs->addField(0);
     hs->setKey("groupby");
@@ -263,7 +263,7 @@ TEST_F(GroupByTests, group_by_scan_using_table_2) {
     s.setSortField(0);
     const auto& r2 = s.execute()->getResultTable();
 
-    hyrise::storage::atable_ptr_t reference = Loader::shortcuts::load("test/reference/group_by_scan_using_table_2.tbl");
+    auto reference = io::Loader::shortcuts::load("test/reference/group_by_scan_using_table_2.tbl");
 
     SortScan s2;
     s2.addInput(reference);
@@ -276,7 +276,7 @@ TEST_F(GroupByTests, group_by_scan_using_table_2) {
 }
 
 TEST_F(GroupByTests, group_by_scan_using_table_multiple_fields) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   hyrise::access::GroupByScan gs;
   gs.addInput(t);
@@ -299,7 +299,7 @@ TEST_F(GroupByTests, group_by_scan_using_table_multiple_fields) {
   const auto& r2 = so.execute()->getResultTable();
 
 
-  const auto& reference = Loader::shortcuts::load("test/reference/group_by_scan_using_table_multiple_fields.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/group_by_scan_using_table_multiple_fields.tbl");
 
   SortScan so2;
   so2.addInput(reference);
@@ -310,7 +310,7 @@ TEST_F(GroupByTests, group_by_scan_using_table_multiple_fields) {
 }
 
 TEST_F(GroupByTests, group_by_scan_with_count) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   auto count = new CountAggregateFun(0);
 
@@ -328,7 +328,7 @@ TEST_F(GroupByTests, group_by_scan_with_count) {
   gs.addInput(group_map);
 
   const auto& result = gs.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/group_by_scan_with_count.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/group_by_scan_with_count.tbl");
 
   SortScan so;
   so.addInput(result);
@@ -345,7 +345,7 @@ TEST_F(GroupByTests, group_by_scan_with_count) {
 }
 
 TEST_F(GroupByTests, group_by_scan_with_sum) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   hyrise::access::GroupByScan gs;
   auto count = new SumAggregateFun(0);
@@ -353,13 +353,13 @@ TEST_F(GroupByTests, group_by_scan_with_sum) {
   gs.addFunction(count);
   const auto& result = gs.execute()->getResultTable();
 
-  const auto& reference = Loader::shortcuts::load("test/reference/group_by_scan_with_sum.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/group_by_scan_with_sum.tbl");
   ASSERT_TABLE_EQUAL(result, reference);
 }
 
 
 TEST_F(GroupByTests, group_by_scan_with_avg_on_integer) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/tables/revenue.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/revenue.tbl");
 
   hyrise::access::GroupByScan gs;
   auto average = new AverageAggregateFun("amount");
@@ -377,12 +377,12 @@ TEST_F(GroupByTests, group_by_scan_with_avg_on_integer) {
 
   const auto& result = sort(gs.execute()->getResultTable());
 
-  const auto& reference = Loader::shortcuts::load("test/tables/revenue_average_per_year.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/tables/revenue_average_per_year.tbl");
   ASSERT_TABLE_EQUAL(result, reference);
 }
 
 TEST_F(GroupByTests, group_by_scan_with_avg_on_float) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/tables/revenue_float.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/revenue_float.tbl");
 
   hyrise::access::GroupByScan gs;
   auto average = new AverageAggregateFun("amount");
@@ -400,12 +400,12 @@ TEST_F(GroupByTests, group_by_scan_with_avg_on_float) {
 
   const auto& result = sort(gs.execute()->getResultTable());
 
-  const auto& reference = Loader::shortcuts::load("test/tables/revenue_average_per_year.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/tables/revenue_average_per_year.tbl");
   ASSERT_TABLE_EQUAL(result, reference);
 }
 
 TEST_F(GroupByTests, group_by_scan_with_avg_on_string) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/tables/companies.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/companies.tbl");
 
   hyrise::access::GroupByScan gs;
   auto average = new AverageAggregateFun(1);
@@ -427,7 +427,7 @@ TEST_F(GroupByTests, group_by_scan_with_avg_on_string) {
 }
 
 TEST_F(GroupByTests, group_by_scan_with_sum_and_two_args) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   hyrise::access::GroupByScan gs;
   auto count = new SumAggregateFun(0);
@@ -435,7 +435,7 @@ TEST_F(GroupByTests, group_by_scan_with_sum_and_two_args) {
   gs.addFunction(count);
   const auto& result = gs.execute()->getResultTable();
 
-  const auto& reference = Loader::shortcuts::load("test/reference/group_by_scan_with_sum.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/group_by_scan_with_sum.tbl");
 
   SortScan so;
   so.addInput(result);
@@ -452,7 +452,7 @@ TEST_F(GroupByTests, group_by_scan_with_sum_and_two_args) {
 }
 
 TEST_F(GroupByTests, group_by_scan_with_count_and_two_args) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   hyrise::access::GroupByScan gs;
   auto count = new CountAggregateFun(0);
@@ -472,7 +472,7 @@ TEST_F(GroupByTests, group_by_scan_with_count_and_two_args) {
   gs.addInput(group_map);
 
   const auto& result = gs.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/group_by_scan_with_count_and_two_args.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/group_by_scan_with_count_and_two_args.tbl");
 
   SortScan so;
   so.addInput(result);
@@ -489,7 +489,7 @@ TEST_F(GroupByTests, group_by_scan_with_count_and_two_args) {
 
 
 TEST_F(GroupByTests, group_by_scan_with_sum_and_without_grouping_field) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   auto sum = new SumAggregateFun(0);
 
@@ -498,13 +498,13 @@ TEST_F(GroupByTests, group_by_scan_with_sum_and_without_grouping_field) {
   gs.addFunction(sum);
 
   const auto& result = gs.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/group_by_scan_without_grouping_field.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/group_by_scan_without_grouping_field.tbl");
 
   ASSERT_TABLE_EQUAL(result, reference);
 }
 
 TEST_F(GroupByTests, group_by_scan_with_sum_and_one_arg) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/10_30_group.tbl");
+  auto t = io::Loader::shortcuts::load("test/10_30_group.tbl");
 
   auto sum = new SumAggregateFun(0);
 
@@ -523,7 +523,7 @@ TEST_F(GroupByTests, group_by_scan_with_sum_and_one_arg) {
 
   const auto& result = gs.execute()->getResultTable();
 
-  const auto& reference = Loader::shortcuts::load("test/reference/group_by_scan_with_sum_and_one_arg.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/group_by_scan_with_sum_and_one_arg.tbl");
 
   SortScan so;
   so.addInput(result);
@@ -542,8 +542,8 @@ TEST_F(GroupByTests, group_by_scan_with_sum_and_one_arg) {
 TEST_F(GroupByTests,  group_multi_table) {
 
   // Load raw data
-  hyrise::storage::atable_ptr_t s = Loader::shortcuts::load("test/10_30_group.tbl");
-  hyrise::storage::atable_ptr_t reference = Loader::shortcuts::load("test/reference/group_by_scan_with_sum_and_one_arg.tbl");
+  auto s = io::Loader::shortcuts::load("test/10_30_group.tbl");
+  auto reference = io::Loader::shortcuts::load("test/reference/group_by_scan_with_sum_and_one_arg.tbl");
 
   auto sum = new SumAggregateFun(0);
 
@@ -684,12 +684,12 @@ TEST_F(GroupByTests, group_multi_table_with_delta_not_unique) {
 */
 
 TEST_F(GroupByTests, groupby_on_empty_table) {
-  metadata_list metaList = {new ColumnMetadata("field1", IntegerType),
-                            new ColumnMetadata("field2", StringType),
-                            new ColumnMetadata("field2", FloatType) };
-  hyrise::storage::atable_ptr_t t = std::make_shared<Table>(&metaList);
+  storage::metadata_list metaList = {new storage::ColumnMetadata("field1", IntegerType),
+                                     new storage::ColumnMetadata("field2", StringType),
+                                     new storage::ColumnMetadata("field2", FloatType) };
+  auto t = std::make_shared<storage::Table>(&metaList);
 
-  hyrise::access::GroupByScan gs;
+  GroupByScan gs;
   gs.addInput(t);
   gs.addField(0);
   
@@ -700,7 +700,7 @@ TEST_F(GroupByTests, groupby_on_empty_table) {
   gs.addFunction(new MinAggregateFun("field1"));
   gs.addFunction(new MaxAggregateFun("field1"));
 
-  hyrise::access::HashBuild hs;
+  HashBuild hs;
   hs.addInput(t);
   hs.addField(0);
   hs.setKey("groupby");

--- a/src/bin/units_access/ops_join.cpp
+++ b/src/bin/units_access/ops_join.cpp
@@ -14,10 +14,10 @@ namespace access {
 class JoinTests : public AccessTest {};
 
 TEST_F(JoinTests, DISABLED_join_column_renaming) {
-  const auto& table1 = Loader::shortcuts::load("test/join_transactions.tbl");
-  const auto& table2 = Loader::shortcuts::load("test/join_transactions_2.tbl");
+  const auto& table1 = io::Loader::shortcuts::load("test/join_transactions.tbl");
+  const auto& table2 = io::Loader::shortcuts::load("test/join_transactions_2.tbl");
 
-  auto join = std::make_shared<hyrise::access::JoinScan>(hyrise::access::JoinType::EQUI);
+  auto join = std::make_shared<JoinScan>(JoinType::EQUI);
   join->addInput(table1);
   join->addInput(table2);
   join->addCombiningClause(AND);
@@ -38,10 +38,10 @@ TEST_F(JoinTests, DISABLED_join_column_renaming) {
 }
 
 TEST_F(JoinTests, join_exchange_rates) {
-  hyrise::storage::c_atable_ptr_t table1 = Loader::shortcuts::load("test/join_transactions.tbl");
-  hyrise::storage::c_atable_ptr_t table2 = Loader::shortcuts::load("test/join_exchange.tbl");
+  storage::c_atable_ptr_t table1 = io::Loader::shortcuts::load("test/join_transactions.tbl");
+  storage::c_atable_ptr_t table2 = io::Loader::shortcuts::load("test/join_exchange.tbl");
 
-  EqualsExpression<std::string> *expr4 = new EqualsExpression<std::string>(table2, 2, "USD");
+  auto expr4 = new EqualsExpression<std::string>(table2, 2, "USD");
 
   auto scan = std::make_shared<SimpleTableScan>();
   scan->addInput(table2);
@@ -60,15 +60,15 @@ TEST_F(JoinTests, join_exchange_rates) {
 
   const auto& out = join->execute()->getResultTable();
 
-  const auto& reference = Loader::shortcuts::load("test/reference/join_exchange_rates.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/join_exchange_rates.tbl");
   ASSERT_TRUE(out->contentEquals(reference));
 }
 
 TEST_F(JoinTests, hash_join_exchange_rates_multiple_columns) {
-  hyrise::storage::c_atable_ptr_t table1 = Loader::shortcuts::load("test/join_transactions.tbl");
-  hyrise::storage::c_atable_ptr_t table2 = Loader::shortcuts::load("test/join_exchange.tbl");
+  storage::c_atable_ptr_t table1 = io::Loader::shortcuts::load("test/join_transactions.tbl");
+  storage::c_atable_ptr_t table2 = io::Loader::shortcuts::load("test/join_exchange.tbl");
 
-  EqualsExpression<std::string> *expr4 = new EqualsExpression<std::string>(table2, 2, "USD");
+  auto expr4 = new EqualsExpression<std::string>(table2, 2, "USD");
 
   auto scan = std::make_shared<SimpleTableScan>();
   scan->addInput(table2);
@@ -93,7 +93,7 @@ TEST_F(JoinTests, hash_join_exchange_rates_multiple_columns) {
   auto result = hashJoinProbe->execute()->getResultTable();
 
 
-  const auto& reference = Loader::shortcuts::load("test/reference/join_exchange_rates.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/join_exchange_rates.tbl");
   ASSERT_TRUE(result->contentEquals(reference));
 
 }

--- a/src/bin/units_access/ops_json_table.cpp
+++ b/src/bin/units_access/ops_json_table.cpp
@@ -32,7 +32,7 @@ TEST_F(JsonTableTest, simple_test) {
   op.setTypes({"INTEGER", "STRING", "FLOAT"});
   op.setGroups({3});
 
-  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
 
   op.execute();
   auto result = op.getResultTable();
@@ -49,7 +49,7 @@ TEST_F(JsonTableTest, simple_test_with_data) {
   op.setGroups({1,1});
   op.setData({ {"1", "Apple Inc"}, {"2", "Microsoft"}, {"3", "SAP AG"}, {"4", "Oracle"}  });
 
-  auto t = Loader::shortcuts::load("test/tables/companies.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/companies.tbl");
 
   op.execute();
   auto result = op.getResultTable();
@@ -67,7 +67,7 @@ TEST_F(JsonTableTest, builder_should_raise_in_case_of_errors_wrong_groups) {
   op.setTypes({"INTEGER", "STRING", "FLOAT"});
   op.setGroups({3,3,3,3,3,3});
 
-  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
   ASSERT_ANY_THROW(op.execute());
 }
 
@@ -79,7 +79,7 @@ TEST_F(JsonTableTest, builder_should_raise_in_case_of_errors_wrong_type) {
   op.setTypes({"ISNTEGER", "STRING", "FLOAT"});
   op.setGroups({3,3,3});
 
-  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
   ASSERT_ANY_THROW(op.execute());
 }
 
@@ -87,7 +87,7 @@ TEST_F(JsonTableTest, load_and_create_from_json) {
   auto data = loadFromFile(_good_file);
   auto result = executeAndWait(data);
 
-  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
   EXPECT_RELATION_SCHEMA_EQ(t, result);
 
   EXPECT_TRUE(std::dynamic_pointer_cast<const storage::Store>(result) == nullptr);
@@ -97,7 +97,7 @@ TEST_F(JsonTableTest, load_and_create_from_json_store) {
   auto data = loadFromFile(_good_file_store);
   auto result = executeAndWait(data);
 
-  auto t = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  auto t = io::Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
   EXPECT_RELATION_SCHEMA_EQ(t, result);
   EXPECT_TRUE(std::dynamic_pointer_cast<const storage::Store>(result) != nullptr);
 }

--- a/src/bin/units_access/ops_layouter.cpp
+++ b/src/bin/units_access/ops_layouter.cpp
@@ -95,7 +95,7 @@ TEST_F(LayouterOpsTest, parse_full_scenario_candidate) {
 
 
 TEST_F(LayouterOpsTest, layouting_table_op_basic) {
-  auto table = Loader::shortcuts::load("test/tables/partitions.tbl");
+  auto table = io::Loader::shortcuts::load("test/tables/partitions.tbl");
   ASSERT_EQ(table->partitionCount(), 3u);
 
   LayoutTable op("a|b|c|d\nINTEGER|INTEGER|INTEGER|INTEGER\n0_C|0_C|1_C|1_C");
@@ -106,7 +106,7 @@ TEST_F(LayouterOpsTest, layouting_table_op_basic) {
 }
 
 TEST_F(LayouterOpsTest, layouting_table_op_reordering) {
-  auto table = Loader::shortcuts::load("test/tables/partitions.tbl");
+  auto table = io::Loader::shortcuts::load("test/tables/partitions.tbl");
   ASSERT_EQ(table->partitionCount(), 3u);
 
   LayoutTable op("a|c|b|d\nINTEGER|INTEGER|INTEGER|INTEGER\n0_C|0_C|1_C|1_C");
@@ -122,7 +122,7 @@ TEST_F(LayouterOpsTest, load_layout_replace) {
   std::string data = loadFromFile("test/json/load_layout_replace.json");
   const auto& e = executeAndWait(data);
   ASSERT_EQ(e->partitionCount(), 3u);
-  ASSERT_EQ(3u, StorageManager::getInstance()->getTable("revenue")->partitionCount());
+  ASSERT_EQ(3u, io::StorageManager::getInstance()->getTable("revenue")->partitionCount());
 }
 
 }

--- a/src/bin/units_access/ops_load.cpp
+++ b/src/bin/units_access/ops_load.cpp
@@ -21,7 +21,6 @@ TEST_F(LoadTests, simple_load_op) {
 
   // Workaround. Else, "groupme" will be released to often at block end.
   t.output.getTables().clear();
-  StorageManager::getInstance()->removeAll();
 }
 
 
@@ -32,7 +31,7 @@ TEST_F(LoadTests, simple_unloadall_op) {
   const auto& r = t.execute()->getResultTable();
   ASSERT_TRUE((bool)r) << "A table should be returned";
 
-  StorageManager *sm = StorageManager::getInstance();
+  auto sm = io::StorageManager::getInstance();
 
   ASSERT_TRUE(sm->size() > 0) << "A table should be loaded";
 
@@ -49,7 +48,6 @@ TEST_F(LoadTests, simple_query_with_loadops) {
   std::string q = loadFromFile("test/json/simple_query_with_loadop.json");
   const auto& out = executeAndWait(q);
   ASSERT_TRUE((bool)out);
-  StorageManager::getInstance()->removeAll();
 }
 
 TEST_F(LoadTests, simple_query_with_two_loadops) {
@@ -59,7 +57,6 @@ TEST_F(LoadTests, simple_query_with_two_loadops) {
     q = loadFromFile("test/json/unload_io.json");
     const auto& out = executeAndWait(q);
     ASSERT_TRUE(!out);
-    StorageManager::getInstance()->removeAll();
   }
 }
 
@@ -67,7 +64,6 @@ TEST_F(LoadTests, simple_query_with_load_with_header) {
   std::string q = loadFromFile("test/json/simple_query_load_with_header.json");
   const auto& out = executeAndWait(q);
   ASSERT_TRUE((bool)out);
-  StorageManager::getInstance()->removeAll();
 }
 
 TEST_F(LoadTests, load_exception) {
@@ -97,7 +93,6 @@ TEST_F(LoadTests, sql_table_load_op) {
   std::string q = loadFromFile("test/json/mysql_table_load.json");
   const auto& out = executeAndWait(q);
   ASSERT_TRUE((bool)out);
-  StorageManager::getInstance()->removeAll();
 }
 
 #endif

--- a/src/bin/units_access/ops_mergeop.cpp
+++ b/src/bin/units_access/ops_mergeop.cpp
@@ -23,7 +23,7 @@ TEST_F(MergeTableOpTests, simple) {
   mop.addInput(load_delta);
   auto result = mop.execute()->getResultTable();
 
-  ASSERT_TABLE_EQUAL(Loader::shortcuts::load("test/tables/employees_revised.tbl"), result);
+  ASSERT_TABLE_EQUAL(io::Loader::shortcuts::load("test/tables/employees_revised.tbl"), result);
 }
 
 }

--- a/src/bin/units_access/ops_select.cpp
+++ b/src/bin/units_access/ops_select.cpp
@@ -21,12 +21,12 @@ class SelectTests : public AccessTest {
 
  public:
 
-  std::shared_ptr<AbstractTable> createRawTable() {
-    metadata_vec_t cols({ *ColumnMetadata::metadataFromString("INTEGER", "col1"),
-            *ColumnMetadata::metadataFromString("STRING", "col2"),
-            *ColumnMetadata::metadataFromString("FLOAT", "col3") });
+  std::shared_ptr<storage::AbstractTable> createRawTable() {
+    storage::metadata_vec_t cols({*storage::ColumnMetadata::metadataFromString("INTEGER", "col1"),
+                                  *storage::ColumnMetadata::metadataFromString("STRING", "col2"),
+                                  *storage::ColumnMetadata::metadataFromString("FLOAT", "col3") });
 
-    auto main = std::make_shared<RawTable>(cols);
+    auto main = std::make_shared<storage::RawTable>(cols);
     for (size_t i=0; i < 100; ++i) {
       hyrise::storage::rawtable::RowHelper rh(cols);
       rh.set<hyrise_int_t>(0, i);
@@ -43,19 +43,19 @@ class SelectTests : public AccessTest {
 };
 
 TEST_F(SelectTests, simple_projection_with_position) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   ProjectionScan gs;
   gs.setProducesPositions(true);
   gs.addInput(t);
   gs.addField(0);
 
   const auto& result = gs.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_projection.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_projection.tbl");
   ASSERT_TRUE(result->contentEquals(reference));
 }
 
 TEST_F(SelectTests, simple_projection_with_position_mat) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   ProjectionScan gs;
   gs.setProducesPositions(true);
   gs.addInput(t);
@@ -65,12 +65,12 @@ TEST_F(SelectTests, simple_projection_with_position_mat) {
   MaterializingScan ms(false);
   ms.addInput(result);
   const auto& result2 = ms.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_projection.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_projection.tbl");
   ASSERT_TRUE(result2->contentEquals(reference));
 }
 
 TEST_F(SelectTests, simple_projection_with_position_all_mat) {
-  auto t = Loader::shortcuts::load("test/lin_xxxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxxs.tbl");
   ProjectionScan gs;
   gs.setProducesPositions(true);
   gs.addInput(t);
@@ -81,14 +81,14 @@ TEST_F(SelectTests, simple_projection_with_position_all_mat) {
   MaterializingScan ms(false);
   ms.addInput(result);
   const auto& result2 = ms.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/lin_xxxs.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/lin_xxxs.tbl");
   ASSERT_TRUE(result2->contentEquals(reference));
 }
 
 
 
 TEST_F(SelectTests, simple_projection_with_position_mat_memcpy) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   ProjectionScan gs;
   gs.setProducesPositions(true);
   gs.addInput(t);
@@ -102,14 +102,14 @@ TEST_F(SelectTests, simple_projection_with_position_mat_memcpy) {
   const auto& result2 = ms.execute()->getResultTable();
 
   ASSERT_EQ((unsigned) 100, result2->size());
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_projection.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_projection.tbl");
 
   ASSERT_TABLE_EQUAL(reference, result2);
 }
 
 
 TEST_F(SelectTests, simple_projection_with_position_mat_and_sample) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   ProjectionScan gs;
   gs.setProducesPositions(true);
   gs.addInput(t);
@@ -127,7 +127,7 @@ TEST_F(SelectTests, simple_projection_with_position_mat_and_sample) {
 
 
 TEST_F(SelectTests, simple_projection_with_materialization) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
 
   ProjectionScan gs;
   gs.addInput(t);
@@ -136,12 +136,12 @@ TEST_F(SelectTests, simple_projection_with_materialization) {
 
   const auto& result = gs.execute()->getResultTable();
 
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_projection.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_projection.tbl");
   ASSERT_TRUE(result->contentEquals(reference));
 }
 
 TEST_F(SelectTests, simple_expression) {
-  auto t = Loader::shortcuts::load("test/lin_xxxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxxs.tbl");
 
   hyrise::access::ExpressionScan *es = new hyrise::access::ExpressionScan();
   es->addInput(t);
@@ -150,7 +150,7 @@ TEST_F(SelectTests, simple_expression) {
 
   const auto& result = es->execute()->getResultTable();
 
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_expression.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_expression.tbl");
   ASSERT_TRUE(result->contentEquals(reference));
 }
 
@@ -162,7 +162,7 @@ TEST_F(SelectTests, should_throw_without_predicates) {
 
 
 TEST_F(SelectTests, simple_select) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
+  hyrise::storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
 
   EqualsExpression<hyrise_int_t> *expr1 = new EqualsExpression<hyrise_int_t>(t, 0, 2009);
   EqualsExpression<hyrise_int_t> *expr2 = new EqualsExpression<hyrise_int_t>(t, 1, 1);
@@ -175,13 +175,13 @@ TEST_F(SelectTests, simple_select) {
   scan->setPredicate(expr4);
   scan->setProducesPositions(true);
   const auto& out = scan->execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_select_1.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_select_1.tbl");
 
   ASSERT_TRUE(out->contentEquals(reference));
 }
 
 TEST_F(SelectTests, simple_select_2) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
+  hyrise::storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
 
   auto *expr5 = new LessThanExpression<hyrise_int_t>(t, 0, 2010);
   auto scan = std::make_shared<SimpleTableScan>();
@@ -190,14 +190,14 @@ TEST_F(SelectTests, simple_select_2) {
   scan->setProducesPositions(true);
 
   const auto& out = scan->execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_select_2.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_select_2.tbl");
 
   ASSERT_TRUE(out->contentEquals(reference));
 }
 
 
 TEST_F(SelectTests, simple_select_3) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
+  hyrise::storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
 
   GreaterThanExpression<hyrise_int_t> *expr6 = new GreaterThanExpression<hyrise_int_t>(t, 0, 2009);
   GreaterThanExpression<hyrise_int_t> *expr8 = new GreaterThanExpression<hyrise_int_t>(t, 0, 2008);
@@ -211,14 +211,14 @@ TEST_F(SelectTests, simple_select_3) {
   scan->setProducesPositions(true);
 
   const auto& out = scan->execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_select_3.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_select_3.tbl");
 
   ASSERT_TRUE(out->contentEquals(reference));
 
 }
 
 TEST_F(SelectTests, select_between) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
+  hyrise::storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
 
   auto stc = std::make_shared<SimpleTableScan>();
   BetweenExpression<hyrise_int_t> *between = new BetweenExpression<hyrise_int_t>(t, t->numberOfColumn("month"), 2, 4);
@@ -226,13 +226,13 @@ TEST_F(SelectTests, select_between) {
   stc->setPredicate(between);
 
   const auto& result = stc->execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/select_between.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/select_between.tbl");
 
   ASSERT_TRUE(result->contentEquals(reference));
 }
 
 TEST_F(SelectTests, simple_projection_on_empty_table) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/empty.tbl");
+  hyrise::storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/empty.tbl");
 
   ProjectionScan gs;
   gs.setProducesPositions(true);
@@ -244,13 +244,13 @@ TEST_F(SelectTests, simple_projection_on_empty_table) {
   gs.addField(6);
 
   const auto& result = gs.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/empty_after_projection.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/empty_after_projection.tbl");
   ASSERT_TRUE(result->contentEquals(reference));
 }
 
 TEST_F(SelectTests, select_after_insert_simple) {
   auto ctx = tx::TransactionManager::getInstance().buildContext();
-  hyrise::storage::atable_ptr_t s = Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t s = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   auto initial_size = s->size();
   hyrise::storage::atable_ptr_t data = s->copy_structure_modifiable(nullptr, s->size());
   data->resize(1);
@@ -270,7 +270,7 @@ TEST_F(SelectTests, select_after_insert_simple) {
 
 
 TEST_F(SelectTests, simple_select_with_raw_table_fails_because_input_is_not_raw) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
+  hyrise::storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
 
   EqualsExpression<hyrise_int_t> *expr1 = new EqualsExpression<hyrise_int_t>(t, 0, 2009);
   auto scan = std::make_shared<SimpleRawTableScan>(expr1);
@@ -280,7 +280,7 @@ TEST_F(SelectTests, simple_select_with_raw_table_fails_because_input_is_not_raw)
 }
 
 TEST_F(SelectTests, simple_select_with_raw_table_fails_because_predicate_is_wrong) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
+  hyrise::storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
 
   EqualsExpression<hyrise_int_t> *expr1 = new EqualsExpression<hyrise_int_t>(t, 0, 2009);
   auto scan = std::make_shared<SimpleRawTableScan>(expr1);
@@ -309,7 +309,7 @@ TEST_F(SelectTests, simple_select_with_raw_table_equals_predicate) {
 
   ASSERT_EQ(1u, scan->getResultTable(0)->size());
   const auto& out = scan->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_raw_select_integer.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_raw_select_integer.tbl");
   ASSERT_TABLE_EQUAL(reference, out);
 }
 
@@ -322,7 +322,7 @@ TEST_F(SelectTests, simple_select_with_raw_table_less_than_predicate) {
 
   scan->execute();
   const auto& out = scan->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_raw_select_integer_less_than.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_raw_select_integer_less_than.tbl");
   ASSERT_TABLE_EQUAL(reference, out);
 }
 
@@ -335,7 +335,7 @@ TEST_F(SelectTests, simple_select_with_raw_table_greater_than_predicate) {
 
   scan->execute();
   const auto& out = scan->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_raw_select_integer_greater_than.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_raw_select_integer_greater_than.tbl");
   ASSERT_TABLE_EQUAL(reference, out);
 }
 
@@ -351,7 +351,7 @@ TEST_F(SelectTests, simple_select_with_raw_table_equals_predicate_string) {
 
   ASSERT_EQ(1u, scan->getResultTable(0)->size());
   const auto& out = scan->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_raw_select_integer.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_raw_select_integer.tbl");
   ASSERT_TABLE_EQUAL(reference, out);
 }
 
@@ -366,7 +366,7 @@ TEST_F(SelectTests, simple_select_with_raw_table_equals_predicate_float) {
 
   ASSERT_EQ(1u, scan->getResultTable(0)->size());
   const auto& out = scan->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_raw_select_integer.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_raw_select_integer.tbl");
   ASSERT_TABLE_EQUAL(reference, out);
 }
 

--- a/src/bin/units_access/ops_sort.cpp
+++ b/src/bin/units_access/ops_sort.cpp
@@ -16,8 +16,8 @@ namespace access {
 class SortTest : public AccessTest {};
 
 TEST_F(SortTest, simple_sort_test) {
-  auto data = Loader::shortcuts::load("test/reference/group_by_scan_using_table_2.tbl");
-  const auto& reference = Loader::shortcuts::load("test/sort_test.tbl");
+  auto data = io::Loader::shortcuts::load("test/reference/group_by_scan_using_table_2.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/sort_test.tbl");
 
   SortScan s2;
   s2.addInput(data);
@@ -30,13 +30,13 @@ TEST_F(SortTest, simple_sort_test) {
 
 // TODO: Loader should be able to differentiate modifiable/nonmodifiable
 TEST_F(SortTest, DISABLED_simple_sort_test_modifiable) {
-  Loader::params p;
-  p.setHeader(CSVHeader("test/reference/group_by_scan_using_table_2.tbl"));
-  p.setInput(CSVInput("test/reference/group_by_scan_using_table_2.tbl"));
+  io::Loader::params p;
+  p.setHeader(io::CSVHeader("test/reference/group_by_scan_using_table_2.tbl"));
+  p.setInput(io::CSVInput("test/reference/group_by_scan_using_table_2.tbl"));
   p.setModifiableMutableVerticalTable(true);
 
-  auto data = Loader::load(p);
-  const auto& reference = Loader::shortcuts::load("test/sort_test.tbl");
+  auto data = io::Loader::load(p);
+  const auto& reference = io::Loader::shortcuts::load("test/sort_test.tbl");
 
   SortScan s2;
   s2.addInput(data);
@@ -48,7 +48,7 @@ TEST_F(SortTest, DISABLED_simple_sort_test_modifiable) {
 }
 
 TEST_F(SortTest, simple_sort_test_modifiable_unsorted) {
-  const auto& reference = Loader::shortcuts::load("test/reference/unsorted_sort.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/unsorted_sort.tbl");
   auto data = reference->copy_structure_modifiable();
 
   data->resize(3);

--- a/src/bin/units_access/ops_write.cpp
+++ b/src/bin/units_access/ops_write.cpp
@@ -17,9 +17,9 @@ namespace access {
 class WriteTests : public AccessTest {};
 
 TEST_F(WriteTests, insert_test) {
-  auto writeCtx =hyrise::tx::TransactionManager::getInstance().buildContext(); 
-  hyrise::storage::atable_ptr_t s = Loader::shortcuts::load("test/lin_xxxs.tbl");
-  hyrise::storage::atable_ptr_t i = Loader::shortcuts::load("test/insert_one.tbl");
+  auto writeCtx = tx::TransactionManager::getInstance().buildContext(); 
+  hyrise::storage::atable_ptr_t s = io::Loader::shortcuts::load("test/lin_xxxs.tbl");
+  hyrise::storage::atable_ptr_t i = io::Loader::shortcuts::load("test/insert_one.tbl");
 
   InsertScan gs;
   gs.setTXContext(writeCtx);
@@ -27,7 +27,7 @@ TEST_F(WriteTests, insert_test) {
   gs.setInputData(i);
 
   const auto& result = gs.execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/lin_xxxs_insert.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/lin_xxxs_insert.tbl");
 
   ASSERT_TRUE(result->contentEquals(reference));
 }

--- a/src/bin/units_access/performance_data.cpp
+++ b/src/bin/units_access/performance_data.cpp
@@ -9,7 +9,7 @@ namespace access {
 class PerformanceDataTests : public AccessTest {};
 
 TEST_F(PerformanceDataTests, single_op_data) {
-  hyrise::storage::atable_ptr_t w = Loader::shortcuts::loadWithHeader("test/regression/projection_fail.data", "test/regression/projection_fail.tbl");
+  storage::atable_ptr_t w = io::Loader::shortcuts::loadWithHeader("test/regression/projection_fail.data", "test/regression/projection_fail.tbl");
 
   ProjectionScan ps;
   ps.addInput(w);

--- a/src/bin/units_access/predicate_builder.cpp
+++ b/src/bin/units_access/predicate_builder.cpp
@@ -16,7 +16,7 @@ namespace access {
 class PredicateBldr : public AccessTest {};
 
 TEST_F(PredicateBldr, one_field) {
-  EqualsExpression<hyrise_int_t> *e = new EqualsExpression<hyrise_int_t>((size_t)0, 0, 2009);
+  auto e = new EqualsExpression<hyrise_int_t>((size_t)0, 0, 2009);
 
   PredicateBuilder b;
   b.add(e);
@@ -29,8 +29,8 @@ TEST_F(PredicateBldr, one_field) {
 }
 
 TEST_F(PredicateBldr, one_leg_expression) {
-  CompoundExpression *c = new CompoundExpression(NOT);
-  EqualsExpression<hyrise_int_t> *e = new EqualsExpression<hyrise_int_t>((size_t)0, 0, 2009);
+  auto c = new CompoundExpression(NOT);
+  auto e = new EqualsExpression<hyrise_int_t>((size_t)0, 0, 2009);
 
   PredicateBuilder b;
   b.add(c);
@@ -44,12 +44,12 @@ TEST_F(PredicateBldr, one_leg_expression) {
 }
 
 TEST_F(PredicateBldr, complex_expression) {
-  hyrise::storage::c_atable_ptr_t t = Loader::shortcuts::load("test/groupby_xs.tbl");
+  storage::c_atable_ptr_t t = io::Loader::shortcuts::load("test/groupby_xs.tbl");
 
-  EqualsExpression<hyrise_int_t> *expr1 = new EqualsExpression<hyrise_int_t>(t, 0, 2009);
-  EqualsExpression<hyrise_int_t> *expr2 = new EqualsExpression<hyrise_int_t>(t, 1, 1);
-  CompoundExpression *expr3 = new CompoundExpression(OR);
-  CompoundExpression *expr4 = new CompoundExpression(NOT);
+  auto expr1 = new EqualsExpression<hyrise_int_t>(t, 0, 2009);
+  auto expr2 = new EqualsExpression<hyrise_int_t>(t, 1, 1);
+  auto expr3 = new CompoundExpression(OR);
+  auto expr4 = new CompoundExpression(NOT);
 
   PredicateBuilder b;
   b.add(expr4);
@@ -66,7 +66,7 @@ TEST_F(PredicateBldr, complex_expression) {
   scan->setProducesPositions(true);
 
   auto out = scan->execute()->getResultTable();
-  const auto& reference = Loader::shortcuts::load("test/reference/simple_select_1.tbl");
+  const auto& reference = io::Loader::shortcuts::load("test/reference/simple_select_1.tbl");
 
   ASSERT_TRUE(out->contentEquals(reference));
 }

--- a/src/bin/units_access/priority_tasks.cpp
+++ b/src/bin/units_access/priority_tasks.cpp
@@ -23,7 +23,7 @@ TEST_F(PriorityTaskTest, compare_test){
   t2->setPriority(2);
   t3->setPriority(3);
 
-  std::priority_queue<std::shared_ptr<Task>, std::vector<std::shared_ptr<Task>>, CompareTaskPtr> _runQueue;
+  std::priority_queue<std::shared_ptr<taskscheduler::Task>, std::vector<std::shared_ptr<taskscheduler::Task>>, taskscheduler::CompareTaskPtr> _runQueue;
 
   _runQueue.push(t1);
   _runQueue.push(t3);

--- a/src/bin/units_access/radix_join.cpp
+++ b/src/bin/units_access/radix_join.cpp
@@ -13,13 +13,14 @@
 
 namespace hyrise {
 namespace access {
+
 using storage::TableBuilder;
 
 class RadixJoinTest : public AccessTest {};
 
 TEST_F(RadixJoinTest, histogram_parallel_4x) {
 
-  auto table = Loader::shortcuts::load("test/tables/hash_table_test.tbl");
+  auto table = io::Loader::shortcuts::load("test/tables/hash_table_test.tbl");
 
   Histogram h1;
   h1.addInput(table);
@@ -140,8 +141,8 @@ TEST_F(RadixJoinTest, histogram_parallel_4x) {
 
 TEST_F(RadixJoinTest, check_prefixsum) {
   // create input Table
-  std::shared_ptr<AbstractTable> t1 = Loader::shortcuts::load("test/prefix_sum.tbl");
-  std::shared_ptr<AbstractTable> reference = Loader::shortcuts::load("test/prefix_sum_result.tbl");
+  auto t1 = io::Loader::shortcuts::load("test/prefix_sum.tbl");
+  auto reference = io::Loader::shortcuts::load("test/prefix_sum_result.tbl");
 
   PrefixSum ps;
   ps.addInput(t1);
@@ -156,9 +157,9 @@ TEST_F(RadixJoinTest, check_prefixsum) {
 TEST_F(RadixJoinTest, check_prefixsum_parallel_p3) {
   TableBuilder::param_list list;
   list.append().set_type("INTEGER").set_name("count");
-  hyrise::storage::atable_ptr_t  t1 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t2 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t3 = TableBuilder::build(list, false);
+  auto t1 = TableBuilder::build(list, false);
+  auto t2 = TableBuilder::build(list, false);
+  auto t3 = TableBuilder::build(list, false);
 
   t1->resize(2); t2->resize(2); t3->resize(2);
   t1->setValueId(0,0, {10,0});
@@ -187,9 +188,9 @@ TEST_F(RadixJoinTest, check_prefixsum_parallel_p3) {
 TEST_F(RadixJoinTest, check_prefixsum_parallel_p2) {
   TableBuilder::param_list list;
   list.append().set_type("INTEGER").set_name("count");
-  hyrise::storage::atable_ptr_t  t1 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t2 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t3 = TableBuilder::build(list, false);
+  auto t1 = TableBuilder::build(list, false);
+  auto t2 = TableBuilder::build(list, false);
+  auto t3 = TableBuilder::build(list, false);
 
   t1->resize(2); t2->resize(2); t3->resize(2);
   t1->setValueId(0,0, {10,0});
@@ -217,9 +218,9 @@ TEST_F(RadixJoinTest, check_prefixsum_parallel_p2) {
 TEST_F(RadixJoinTest, check_prefixsum_parallel_p1) {
   TableBuilder::param_list list;
   list.append().set_type("INTEGER").set_name("count");
-  hyrise::storage::atable_ptr_t  t1 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t2 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t3 = TableBuilder::build(list, false);
+  auto t1 = TableBuilder::build(list, false);
+  auto t2 = TableBuilder::build(list, false);
+  auto t3 = TableBuilder::build(list, false);
 
   t1->resize(2); t2->resize(2); t3->resize(2);
   t1->setValueId(0,0, {10,0});
@@ -248,9 +249,9 @@ TEST_F(RadixJoinTest, check_prefixsum_parallel_p1) {
 TEST_F(RadixJoinTest, check_prefixsum_parallel_merge) {
   TableBuilder::param_list list;
   list.append().set_type("INTEGER").set_name("count");
-  hyrise::storage::atable_ptr_t  t1 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t2 = TableBuilder::build(list, false);
-  hyrise::storage::atable_ptr_t  t3 = TableBuilder::build(list, false);
+  auto t1 = TableBuilder::build(list, false);
+  auto t2 = TableBuilder::build(list, false);
+  auto t3 = TableBuilder::build(list, false);
 
   t1->resize(2); t2->resize(2); t3->resize(2);
   t1->setValueId(0,0, {0,0});
@@ -277,7 +278,7 @@ TEST_F(RadixJoinTest, check_prefixsum_parallel_merge) {
 
 TEST_F(RadixJoinTest, hist_prefix_radix_cluster) {
 
-  auto table = Loader::shortcuts::load("test/tables/hash_table_test.tbl");
+  auto table = io::Loader::shortcuts::load("test/tables/hash_table_test.tbl");
   hyrise::access::Histogram hst;
   hst.setBits(2);
   hst.addField(0);
@@ -329,7 +330,7 @@ TEST_F(RadixJoinTest, hist_prefix_radix_cluster) {
 
 TEST_F(RadixJoinTest, hist_prefix_radix_cluster_string) {
 
-  auto table = Loader::shortcuts::load("test/tables/hash_table_test.tbl");
+  auto table = io::Loader::shortcuts::load("test/tables/hash_table_test.tbl");
   hyrise::access::Histogram hst;
   hst.setBits(2);
   hst.addField(1);
@@ -380,7 +381,7 @@ TEST_F(RadixJoinTest, hist_prefix_radix_cluster_string) {
 }
 
 TEST_F(RadixJoinTest, multi_pass_radix_cluster) {
-  auto table = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  auto table = io::Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
 
   // Create a histogram
   Histogram hst;
@@ -502,7 +503,7 @@ TEST_F(RadixJoinTest, multi_pass_radix_cluster) {
 }
 
 TEST_F(RadixJoinTest, multi_pass_radix_cluster_parallel) {
-  auto table = Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
+  auto table = io::Loader::shortcuts::load("test/tables/radix_cluster_mpass.tbl");
 
   // Create a histogram
   Histogram hst;

--- a/src/bin/units_access/regression.cpp
+++ b/src/bin/units_access/regression.cpp
@@ -11,7 +11,7 @@ namespace access {
 class RegressionTests : public AccessTest {};
 
 TEST_F(RegressionTests, projection_fail) {
-  auto w = Loader::shortcuts::loadWithHeader("test/regression/projection_fail.data", "test/regression/projection_fail.tbl");
+  auto w = io::Loader::shortcuts::loadWithHeader("test/regression/projection_fail.data", "test/regression/projection_fail.tbl");
 
   ProjectionScan ps;
   ps.addInput(w);

--- a/src/bin/units_access/table_equality.cpp
+++ b/src/bin/units_access/table_equality.cpp
@@ -5,18 +5,22 @@
 #include "storage/AbstractTable.h"
 #include "testing/TableEqualityTest.h"
 
+namespace hyrise {
+namespace access {
+
 class TableEqualityTests : public ::testing::Test {};
 
 TEST_F(TableEqualityTests, test_equal) {
-  auto
-      t1 = Loader::shortcuts::load("test/tables/employees.tbl"),
-      t2 = Loader::shortcuts::load("test/tables/employees.tbl");
+  auto t1 = io::Loader::shortcuts::load("test/tables/employees.tbl"),
+       t2 = io::Loader::shortcuts::load("test/tables/employees.tbl");
   EXPECT_RELATION_EQ(t1, t2);
 }
 
 TEST_F(TableEqualityTests, test_not_equal) {
-  auto
-      t1 = Loader::shortcuts::load("test/tables/employees.tbl"),
-      t2 = Loader::shortcuts::load("test/tables/employees_revised.tbl");
+  auto t1 = io::Loader::shortcuts::load("test/tables/employees.tbl"),
+       t2 = io::Loader::shortcuts::load("test/tables/employees_revised.tbl");
   EXPECT_RELATION_NEQ(t1, t2);
 }
+
+} } // namespace hyrise::access
+

--- a/src/bin/units_io/csv_tests.cpp
+++ b/src/bin/units_io/csv_tests.cpp
@@ -2,6 +2,9 @@
 #include "testing/test.h"
 #include <io/loaders.h>
 
+namespace hyrise {
+namespace io {
+
 class CSVTests : public ::hyrise::Test {};
 
 TEST_F(CSVTests, load_test) {
@@ -20,4 +23,6 @@ TEST_F(CSVTests, DISABLED_load_test_mpass) {
       .setInput(MPassCSVInput("test/loader/demo"))
                                                   );
 }
+
+} } // namespace hyrise::io
 

--- a/src/bin/units_io/dump_tests.cpp
+++ b/src/bin/units_io/dump_tests.cpp
@@ -21,6 +21,9 @@
 #include <storage/SequentialHeapMerger.h>
 #include <storage/storage_types.h>
 
+namespace hyrise {
+namespace io {
+
 class DumpTests : public ::hyrise::Test {
 
 protected:
@@ -48,7 +51,7 @@ TEST_F(DumpTests, should_not_dump_other_tables_than_stores) {
 
 TEST_F(DumpTests, should_not_dump_store_with_muliple_generations) {
 
-  TableMerger *merger = new TableMerger(new DefaultMergeStrategy(), new SequentialHeapMerger(), false);
+  auto *merger = new storage::TableMerger(new storage::DefaultMergeStrategy(), new storage::SequentialHeapMerger(), false);
   auto s = std::dynamic_pointer_cast<hyrise::storage::Store>(simpleTable);
   s->setMerger(merger);
   s->merge();
@@ -113,9 +116,9 @@ TEST_F(DumpTests, simple_dump_load_all) {
   ASSERT_TRUE(result);
 
 
-  hyrise::storage::TableDumpLoader input("./test/dump", "simple");
+  TableDumpLoader input("./test/dump", "simple");
   CSVHeader header("test/dump/simple/header.dat", CSVHeader::params().setCSVParams(csv::HYRISE_FORMAT));
-  hyrise::storage::atable_ptr_t  t = Loader::load(Loader::params().setInput(input).setHeader(header));
+  auto t = Loader::load(Loader::params().setInput(input).setHeader(header));
   ASSERT_EQ(t->size(), 100u);
   ASSERT_EQ(t->columnCount(), simpleTable->columnCount());
   ASSERT_TABLE_EQUAL(t, simpleTable);
@@ -147,10 +150,13 @@ TEST_F(DumpTests, simple_dump_should_not_dump_delta) {
   // Reload table
   simpleTable = Loader::shortcuts::load("test/lin_xxs.tbl");
 
-  hyrise::storage::TableDumpLoader input("./test/dump", "simple");
+  TableDumpLoader input("./test/dump", "simple");
   CSVHeader header("test/dump/simple/header.dat", CSVHeader::params().setCSVParams(csv::HYRISE_FORMAT));
-  hyrise::storage::atable_ptr_t  t = Loader::load(Loader::params().setInput(input).setHeader(header));
+  auto t = Loader::load(Loader::params().setInput(input).setHeader(header));
   ASSERT_EQ(t->size(), 100u);
   ASSERT_EQ(t->columnCount(), simpleTable->columnCount());
   ASSERT_TABLE_EQUAL(t, simpleTable);
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/io_tests.cpp
+++ b/src/bin/units_io/io_tests.cpp
@@ -5,6 +5,9 @@
 #include "io/shortcuts.h"
 #include "storage/AbstractTable.h"
 
+namespace hyrise {
+namespace io {
+
 class IoTest : public ::hyrise::Test {
 
  protected:
@@ -68,4 +71,6 @@ TEST_F(IoTest, wrong_file) {
   //         OldLoader::load_with_string_header(fail_file_4, "themen | epic\nINTEGER|INTEGER\n0_R|0_R");
   //     }, OldLoaderError);
 }
+
+} } // namespace hyrise::io
 

--- a/src/bin/units_io/loader_factory_tests.cpp
+++ b/src/bin/units_io/loader_factory_tests.cpp
@@ -4,29 +4,33 @@
 #include <io/loaders.h>
 #include <storage/TableFactory.h>
 
+namespace hyrise {
+namespace io {
+
 class LoaderFactoryTests : public ::hyrise::Test {};
 
-class MockTableFactory : public AbstractTableFactory {
+class MockTableFactory : public storage::AbstractTableFactory {
 public:
   int generate_call_cnt;
   MockTableFactory() : generate_call_cnt(0)  {}
   ~MockTableFactory() {}
-  hyrise::storage::atable_ptr_t  generate(std::vector<const ColumnMetadata *> *m,
-                                          std::vector<AbstractTable::SharedDictionaryPtr> *d = nullptr,
-                                          size_t initial_size = 0,
-                                          bool sorted = true,
-                                          bool compressed = false) {
+  storage::atable_ptr_t  generate(std::vector<const storage::ColumnMetadata *> *m,
+                                  std::vector<storage::AbstractTable::SharedDictionaryPtr> *d = nullptr,
+                                  size_t initial_size = 0,
+                                  bool sorted = true,
+                                  bool compressed = false) {
     ++generate_call_cnt;
-    return std::make_shared<Table>(m, d, initial_size, sorted, compressed);
+    return std::make_shared<storage::Table>(m, d, initial_size, sorted, compressed);
   }
 };
 
 TEST_F(LoaderFactoryTests, load_test) {
   MockTableFactory mf;
-  hyrise::storage::atable_ptr_t  t = Loader::load(
-                                       Loader::params().setHeader(CSVHeader("test/structured/1col_4rows.tbl"))
-                                       .setFactory((AbstractTableFactory *) &mf)
-                                     );
+  auto t = Loader::load(Loader::params().setHeader(CSVHeader("test/structured/1col_4rows.tbl"))
+                        .setFactory((storage::AbstractTableFactory *) &mf));
   ASSERT_EQ(mf.generate_call_cnt, 1) << "Generate should be called once";
 
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/loader_tests.cpp
+++ b/src/bin/units_io/loader_tests.cpp
@@ -4,11 +4,13 @@
 #include <io/CSVLoader.h>
 #include <io/EmptyLoader.h>
 #include <io/Loader.h>
+#include <io/StringLoader.h>
 
 #include <storage/MutableVerticalTable.h>
 #include <storage/Store.h>
 
-using namespace hyrise;
+namespace hyrise {
+namespace io {
 
 class LoaderTests : public ::hyrise::Test {};
 
@@ -53,8 +55,6 @@ TEST_F(LoaderTests, load_table_simple_empty) {
   ASSERT_EQ(t->columnCount(), 5u);
 }
 
-#include <io/StringLoader.h>
-
 TEST_F(LoaderTests, load_string_header) {
   StringHeader header("a|b|c|d|e\nINTEGER|INTEGER|INTEGER|INTEGER|INTEGER\n0_R|0_R|1_R|2_R|3_R");
   hyrise::storage::atable_ptr_t  t =  Loader::load(Loader::params().setHeader(header));
@@ -78,3 +78,6 @@ TEST_F(LoaderTests, load_table_hyrise_format) {
   hyrise::storage::atable_ptr_t  t = loadTable();
   ASSERT_EQ(t->size(), 100u);
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/loading_example.cpp
+++ b/src/bin/units_io/loading_example.cpp
@@ -4,6 +4,9 @@
 #include <io/CSVLoader.h>
 #include <io/Loader.h>
 
+namespace hyrise {
+namespace io {
+
 class LoaderExample : public ::hyrise::Test {};
 
 TEST_F(LoaderExample, load_with_basepath) {
@@ -14,3 +17,6 @@ TEST_F(LoaderExample, load_with_basepath) {
       .setBasePath("test/tables/")
                                                   );
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/mysql_tests.cpp
+++ b/src/bin/units_io/mysql_tests.cpp
@@ -8,6 +8,9 @@
 
 #include <unistd.h>
 
+namespace hyrise {
+namespace io {
+
 class MySQLTests : public ::hyrise::Test {
  protected:
   std::string _pid_suffix;
@@ -70,6 +73,6 @@ TEST_F(MySQLTests, convert_date_to_int) {
   ASSERT_EQ(IntegerType, t->typeOfColumn(5));
 }
 
-
+} } // namespace hyrise::io
 
 #endif

--- a/src/bin/units_io/old_loader_tests.cpp
+++ b/src/bin/units_io/old_loader_tests.cpp
@@ -4,6 +4,9 @@
 #include "io/loaders.h"
 #include "storage/AbstractTable.h"
 
+namespace hyrise {
+namespace io {
+
 class OldLoaderTests : public ::hyrise::Test {};
 
 /*TEST_F(OldLoaderTests, generate_validity_table_from_tab) {
@@ -53,3 +56,6 @@ TEST_F(OldLoaderTests, unsafe_table_unsafe_load_set_true) {
   hyrise::storage::atable_ptr_t reference = Loader::shortcuts::load("test/tables/revenue_small.tbl");
   ASSERT_TRUE(loadedTable->contentEquals(reference));
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/resourcemgr_tests.cpp
+++ b/src/bin/units_io/resourcemgr_tests.cpp
@@ -13,15 +13,15 @@ namespace hyrise { namespace io {
 
 namespace {
   storage::aresource_ptr_t emptyResource() {
-    return std::make_shared<AbstractResource>();
+    return std::make_shared<storage::AbstractResource>();
   }
 
   storage::atable_ptr_t emptyTable() {
-    std::shared_ptr<metadata_list> metadata = std::make_shared<metadata_list>();
-    return std::make_shared<Table>(metadata.get());
+    auto metadata = std::make_shared<storage::metadata_list>();
+    return std::make_shared<storage::Table>(metadata.get());
   }
 
-  class FakeIndex : public AbstractIndex {
+  class FakeIndex : public storage::AbstractIndex {
    public:
     void shrink() {}
   };
@@ -217,13 +217,13 @@ TEST_F(ResourceManagerTests, get_typed_resource) {
   rm->add("Table", table);
   rm->add("Index", index);
 
-  const storage::aresource_ptr_t resource_g = rm->get<AbstractResource>("Resource");
+  const storage::aresource_ptr_t resource_g = rm->get<storage::AbstractResource>("Resource");
   EXPECT_EQ(resource, resource_g);
 
-  const auto table_g = rm->get<AbstractTable>("Table");
+  const auto table_g = rm->get<storage::AbstractTable>("Table");
   EXPECT_EQ(table, table_g);
 
-  const storage::aindex_ptr_t index_g = rm->get<AbstractIndex>("Index");
+  const storage::aindex_ptr_t index_g = rm->get<storage::AbstractIndex>("Index");
   EXPECT_EQ(index, index_g);
 }
 
@@ -232,18 +232,18 @@ TEST_F(ResourceManagerTests, get_typed_resource_throws_exception) {
   rm->add("Table", emptyTable());
   rm->add("Index", emptyIndex());
 
-  EXPECT_NO_THROW(rm->get<AbstractResource>("Resource"));
-  EXPECT_NO_THROW(rm->get<AbstractTable>("Table"));
-  EXPECT_NO_THROW(rm->get<AbstractIndex>("Index"));
+  EXPECT_NO_THROW(rm->get<storage::AbstractResource>("Resource"));
+  EXPECT_NO_THROW(rm->get<storage::AbstractTable>("Table"));
+  EXPECT_NO_THROW(rm->get<storage::AbstractIndex>("Index"));
   
-  EXPECT_THROW(   rm->get<AbstractTable>("Resource"), std::runtime_error);
-  EXPECT_THROW(   rm->get<AbstractIndex>("Resource"), std::runtime_error);
+  EXPECT_THROW(   rm->get<storage::AbstractTable>("Resource"), std::runtime_error);
+  EXPECT_THROW(   rm->get<storage::AbstractIndex>("Resource"), std::runtime_error);
 
-  EXPECT_NO_THROW(rm->get<AbstractResource>("Table"));
-  EXPECT_THROW(   rm->get<AbstractIndex>("Table"), std::runtime_error);
+  EXPECT_NO_THROW(rm->get<storage::AbstractResource>("Table"));
+  EXPECT_THROW(   rm->get<storage::AbstractIndex>("Table"), std::runtime_error);
 
-  EXPECT_NO_THROW(rm->get<AbstractResource>("Index"));
-  EXPECT_THROW(   rm->get<AbstractTable>("Index"), std::runtime_error);
+  EXPECT_NO_THROW(rm->get<storage::AbstractResource>("Index"));
+  EXPECT_THROW(   rm->get<storage::AbstractTable>("Index"), std::runtime_error);
 }
 
 } } // namespace hyrise::io

--- a/src/bin/units_io/shortcut_tests.cpp
+++ b/src/bin/units_io/shortcut_tests.cpp
@@ -5,7 +5,8 @@
 #include <storage/Store.h>
 #include <storage/RawTable.h>
 
-using namespace hyrise;
+namespace hyrise {
+namespace io {
 
 class LoaderShortcutTests : public ::hyrise::Test {};
 
@@ -24,7 +25,10 @@ TEST_F(LoaderShortcutTests, loadShouldReturnStore) {
 }
 
 TEST_F(LoaderShortcutTests, loadRawShouldReturnRawTable) {
-  hyrise::storage::atable_ptr_t  t = Loader::shortcuts::loadRaw("test/lin_xxs.tbl");
-  ASSERT_TRUE((bool)std::dynamic_pointer_cast<RawTable>(t));
+  auto t = Loader::shortcuts::loadRaw("test/lin_xxs.tbl");
+  ASSERT_TRUE((bool)std::dynamic_pointer_cast<storage::RawTable>(t));
   ASSERT_LT(0u, t->size());
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/storagemgr_tests.cpp
+++ b/src/bin/units_io/storagemgr_tests.cpp
@@ -5,6 +5,9 @@
 #include <io/StorageManager.h>
 #include <storage/MutableVerticalTable.h>
 
+namespace hyrise {
+namespace io {
+
 class StorageManagerTests : public ::hyrise::Test {
 
 public:
@@ -71,3 +74,6 @@ TEST_F(StorageManagerTests, load_table_header_data) {
 
   ASSERT_EQ(0u, sm->getTableNames().size());
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/string_tests.cpp
+++ b/src/bin/units_io/string_tests.cpp
@@ -4,6 +4,9 @@
 #include "io/loaders.h"
 #include "storage/AbstractTable.h"
 
+namespace hyrise {
+namespace io {
+
 class StringLoaderTests : public ::hyrise::Test {};
 
 TEST_F(StringLoaderTests, load_test) {
@@ -39,3 +42,6 @@ TEST_F(StringLoaderTests, load_test_typesafe) {
 
   ASSERT_EQ(t->typeOfColumn(2), res->typeOfColumn(2));
 }
+
+} } // namespace hyrise::io
+

--- a/src/bin/units_io/tx_tests.cpp
+++ b/src/bin/units_io/tx_tests.cpp
@@ -4,7 +4,10 @@
 
 #include "io/TransactionManager.h"
 
-using namespace hyrise::tx;
+namespace hyrise {
+namespace tx {
+
+
 using TM = TransactionManager;
 
 TEST(TX, begin_commit) {
@@ -45,3 +48,6 @@ TEST(TX, rollback_transaction) {
   auto after = TM::getInstance().getLastCommitId();
   EXPECT_EQ(before, after) << "No commits are made when doing a rollback";
 }
+
+} } // namespace hyrise::tx
+

--- a/src/bin/units_layouter/helper.h
+++ b/src/bin/units_layouter/helper.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_BIN_UNITS_LAYOUTER_HELPER_H_
-#define SRC_BIN_UNITS_LAYOUTER_HELPER_H_
+#pragma once
 
 #include "testing/test.h"
 
@@ -8,4 +7,3 @@
 
 std::string loadFromFile(std::string path);
 
-#endif  // SRC_BIN_UNITS_LAYOUTER_HELPER_H_

--- a/src/bin/units_layouter/layouter.cpp
+++ b/src/bin/units_layouter/layouter.cpp
@@ -18,16 +18,16 @@
 
 #include "gtest/gtest.h"
 
-
-using namespace layouter;
-
 using namespace boost::assign;
+
+namespace hyrise {
+namespace layouter {
 
 class LayouterTests : public ::testing::Test {
 
  public:
 
-  layouter::Schema simpleSchema() {
+  Schema simpleSchema() {
     std::vector< std::string > names;
     names.push_back("A");
     names.push_back("B");
@@ -38,11 +38,11 @@ class LayouterTests : public ::testing::Test {
     atts.push_back(4);
     atts.push_back(4);
 
-    layouter::Schema s(atts, 1000000, names);
+    Schema s(atts, 1000000, names);
     return s;
   }
 
-  layouter::Schema wideSchema() {
+  Schema wideSchema() {
     std::vector< std::string > names;
     names.push_back("A");
     names.push_back("B");
@@ -64,22 +64,22 @@ class LayouterTests : public ::testing::Test {
     atts.push_back(4);
 
 
-    layouter::Schema s(atts, 100000, names);
+    Schema s(atts, 100000, names);
     return s;
   }
 
-  layouter::Result executeSimpleQuery() {
+  Result executeSimpleQuery() {
 
-    layouter::Schema s = simpleSchema();
+    Schema s = simpleSchema();
 
     std::vector<unsigned> aq1;
     aq1.push_back(0);
 
     // type, attributes, selection, weight
-    layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+    Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
     s.add(&q1);
 
-    layouter::BaseLayouter bl;
+    BaseLayouter bl;
     bl.layout(s, HYRISE_COST);
 
     // for (const auto& r: bl.getNBestResults(9999)) {
@@ -127,17 +127,17 @@ TEST_F(LayouterTests, selection_experiment_for_thesis) {
       sq += i;
     }
 
-    layouter::Schema s(atts, 10000000, names);
+    Schema s(atts, 10000000, names);
 
 
     // Add projection
     pq += 0;
-    layouter::Query *q1 = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, pq, -1.0, 1);
+    Query *q1 = new Query(LayouterConfiguration::access_type_fullprojection, pq, -1.0, 1);
     s.add(q1);
 
 
     // Add selection
-    layouter::Query *q2 = new layouter::Query(layouter::LayouterConfiguration::access_type_outoforder, sq, 0.1, 1);
+    Query *q2 = new Query(LayouterConfiguration::access_type_outoforder, sq, 0.1, 1);
     s.add(q2);
 
     // Check the cost
@@ -163,12 +163,12 @@ TEST_F(LayouterTests, cost_calculation_with_att_order) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   std::vector<unsigned> aq2;
   aq2.push_back(1);
   aq2.push_back(2);
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.02, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.02, 1);
   s.add(&q2);
 
 
@@ -199,20 +199,20 @@ TEST_F(LayouterTests, DISABLED_correct_cost_calculation) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   // Add first query
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
   s.add(&q1);
 
   //Add second query
   std::vector<unsigned> aq2;
   aq2.push_back(1);
   aq2.push_back(2);
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.02, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.02, 1);
   s.add(&q2);
 
 
@@ -220,18 +220,18 @@ TEST_F(LayouterTests, DISABLED_correct_cost_calculation) {
   std::vector<unsigned> aq3;
   aq3.push_back(1);
   aq3.push_back(3);
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.02, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.02, 1);
   s.add(&q3);
 
 
   // Check the cost
-  layouter::subset_t first;
+  subset_t first;
   first.push_back(4);
 
   ASSERT_EQ(0, s.costForSubset(first, HYRISE_COST));
 
   // Check cost for different partitions
-  layouter::subset_t second;
+  subset_t second;
   second.push_back(1);
   second.push_back(2);
   second.push_back(3);
@@ -252,73 +252,73 @@ TEST_F(LayouterTests, divide_and_conquer_affinity) {
     names.push_back(a.str());
   }
 
-  layouter::Schema *s = new layouter::Schema(atts, 1000000, names);
+  Schema *s = new Schema(atts, 1000000, names);
 
   std::vector<unsigned> aq;
   aq += 0, 1, 2;
 
-  layouter::Query *q;
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  Query *q;
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 0, 1;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 0, 1;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 2, 3;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 3, 4;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 5, 6, 7, 8;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 5, 7, 8, 9;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
 
   aq = std::vector<unsigned>();
   aq += 5, 7, 9;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 3, 9;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
   aq = std::vector<unsigned>();
   aq += 0, 1, 9;
 
-  q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
+  q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 2);
   s->add(q);
 
 
 
-  layouter::BaseLayouter *l = new DivideAndConquerLayouter();
+  BaseLayouter *l = new DivideAndConquerLayouter();
   l->layout(*s, HYRISE_COST);
 
   //l->getBestResult().print();
@@ -335,7 +335,7 @@ TEST_F(LayouterTests, divide_and_conquer_with_larger_group) {
     names.push_back(a.str());
   }
 
-  layouter::Schema *s = new layouter::Schema(atts, 1000000, names);
+  Schema *s = new Schema(atts, 1000000, names);
 
   // Add the queries
   for (int i = 0; i < 10; ++i) {
@@ -343,11 +343,11 @@ TEST_F(LayouterTests, divide_and_conquer_with_larger_group) {
     for (int j = 0; j < i; ++j)
       aq.push_back(j);
 
-    layouter::Query *q = new layouter::Query(layouter::LayouterConfiguration::access_type_fullprojection, aq, -1.0, 1);
+    Query *q = new Query(LayouterConfiguration::access_type_fullprojection, aq, -1.0, 1);
     s->add(q);
   }
 
-  layouter::BaseLayouter *l = new DivideAndConquerLayouter();
+  BaseLayouter *l = new DivideAndConquerLayouter();
   l->layout(*s, HYRISE_COST);
 }
 
@@ -368,7 +368,7 @@ TEST_F(LayouterTests, candidate_layouter_only_one_primary_partition) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   std::vector<unsigned> aq1;
   aq1.push_back(0);
@@ -378,18 +378,18 @@ TEST_F(LayouterTests, candidate_layouter_only_one_primary_partition) {
   aq1.push_back(4);
   aq1.push_back(5);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
 
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
-  std::vector<layouter::Result> results = cl.getNBestResults(9999);
+  std::vector<Result> results = cl.getNBestResults(9999);
   ASSERT_LT(0u, results.size()) << "Even with one primary partition there should be a result";
 
 }
@@ -411,41 +411,41 @@ TEST_F(LayouterTests, DISABLED_candidate_test_from_presentation) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   std::vector<unsigned> aq1;
   aq1.push_back(5);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
   std::vector<unsigned> aq2;
   aq2.push_back(0);
   aq2.push_back(1);
 
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.1, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.1, 1);
   s.add(&q2);
 
   std::vector<unsigned> aq3;
   aq3.push_back(0);
   aq3.push_back(3);
 
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.1, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.1, 1);
   s.add(&q3);
 
   std::vector<unsigned> aq4;
   aq4.push_back(5);
 
-  layouter::Query q4(LayouterConfiguration::access_type_fullprojection, aq4, -1.0, 1);
+  Query q4(LayouterConfiguration::access_type_fullprojection, aq4, -1.0, 1);
   s.add(&q4);
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  layouter::BaseLayouter bl;
+  BaseLayouter bl;
   bl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
@@ -482,43 +482,43 @@ TEST_F(LayouterTests, matrix_metis_test) {
 
 
 TEST_F(LayouterTests, simple_divide_and_conquer) {
-  layouter::Schema s = wideSchema();
+  Schema s = wideSchema();
 
   // type, attributes, selection, weight
   std::vector<unsigned> aq1;
   aq1.push_back(0);
   aq1.push_back(1);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
   std::vector<unsigned> aq2;
   aq2.push_back(1);
   aq2.push_back(2);
 
-  layouter::Query q2(LayouterConfiguration::access_type_fullprojection, aq2, -1.0, 1);
+  Query q2(LayouterConfiguration::access_type_fullprojection, aq2, -1.0, 1);
   s.add(&q2);
 
   std::vector<unsigned> aq3;
   aq3.push_back(7);
   aq3.push_back(6);
 
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.1, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.1, 1);
   s.add(&q3);
 
 
-  layouter::DivideAndConquerLayouter bl;
+  DivideAndConquerLayouter bl;
   bl.layout(s, HYRISE_COST);
   //std::cout << bl.getColumnCost() << " " << bl.getRowCost() << std::endl;
 
 
-  layouter::Result r = bl.getBestResult();
+  Result r = bl.getBestResult();
   double tmp =  r.totalCost;
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
@@ -540,8 +540,8 @@ TEST_F(LayouterTests, layout_load_table_from_output) {
   Result r = executeSimpleQuery();
   std::string tmp = r.output();
 
-  hyrise::storage::atable_ptr_t  t = Loader::shortcuts::loadWithStringHeader("test/tables/only_data.tbl", tmp);
-  hyrise::storage::atable_ptr_t  res = Loader::shortcuts::loadWithHeader("test/tables/only_data.tbl", "test/header/layouter_simple.tbl");
+  auto t = io::Loader::shortcuts::loadWithStringHeader("test/tables/only_data.tbl", tmp);
+  auto res = io::Loader::shortcuts::loadWithHeader("test/tables/only_data.tbl", "test/header/layouter_simple.tbl");
 
   ASSERT_TABLE_EQUAL(t, res);
 }
@@ -557,20 +557,20 @@ TEST_F(LayouterTests, initial_layouter_test) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000, names);
+  Schema s(atts, 1000, names);
 
 
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
   // type, attributes, selection, weight
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
-  layouter::BaseLayouter bl;
+  BaseLayouter bl;
   bl.layout(s, HYRISE_COST);
 
-  layouter::Result r = bl.getBestResult();
+  Result r = bl.getBestResult();
   ASSERT_EQ(r.layout.containerCount(), 2u);
 }
 
@@ -585,7 +585,7 @@ TEST_F(LayouterTests, more_complex_layouter_test) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 100000, names);
+  Schema s(atts, 100000, names);
 
 
   std::vector<unsigned> aq1;
@@ -593,13 +593,13 @@ TEST_F(LayouterTests, more_complex_layouter_test) {
   //aq1.push_back(1);
 
   // type, attributes, selection, weight
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
-  layouter::BaseLayouter bl;
+  BaseLayouter bl;
   bl.layout(s, HYRISE_COST);
 
-  layouter::Result r = bl.getBestResult();
+  Result r = bl.getBestResult();
   ASSERT_EQ(r.layout.containerCount(), 2u);
 }
 
@@ -614,14 +614,14 @@ TEST_F(LayouterTests, layouter_two_queries) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000, names);
+  Schema s(atts, 1000, names);
 
 
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
   // type, attributes, selection, weight
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
 
@@ -629,13 +629,13 @@ TEST_F(LayouterTests, layouter_two_queries) {
   aq2.push_back(0);
   aq2.push_back(1);
 
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.9, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.9, 1);
   s.add(&q2);
 
-  layouter::BaseLayouter bl;
+  BaseLayouter bl;
   bl.layout(s, HYRISE_COST);
 
-  layouter::Result r = bl.getBestResult();
+  Result r = bl.getBestResult();
   ASSERT_EQ(r.layout.containerCount(), 3u);
 }
 
@@ -651,7 +651,7 @@ TEST_F(LayouterTests, initial_layouter_test_candidate) {
   atts.push_back(4);
   //atts.push_back(4);
 
-  layouter::Schema s(atts, 1000, names);
+  Schema s(atts, 1000, names);
 
 
   std::vector<unsigned> aq1;
@@ -659,18 +659,18 @@ TEST_F(LayouterTests, initial_layouter_test_candidate) {
   //aq1.push_back(1);
 
   // type, attributes, selection, weight
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
-  layouter::CandidateLayouter bl;
+  CandidateLayouter bl;
   bl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(bl.getBestResult() == fcl.getBestResult());
 
 
-  layouter::Result r = bl.getBestResult();
+  Result r = bl.getBestResult();
   //r.print();
   ASSERT_EQ(r.layout.containerCount(), 2u);
 
@@ -688,14 +688,14 @@ TEST_F(LayouterTests, layouter_two_queries_candidate) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000, names);
+  Schema s(atts, 1000, names);
 
 
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
   // type, attributes, selection, weight
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
 
@@ -703,18 +703,18 @@ TEST_F(LayouterTests, layouter_two_queries_candidate) {
   aq2.push_back(0);
   aq2.push_back(1);
 
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.9, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.9, 1);
   s.add(&q2);
 
-  layouter::CandidateLayouter bl;
+  CandidateLayouter bl;
   bl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(bl.getBestResult() == fcl.getBestResult());
 
 
-  layouter::Result r = bl.getBestResult();
+  Result r = bl.getBestResult();
   //r.print();
   ASSERT_EQ(r.layout.containerCount(), 3u);
 
@@ -737,26 +737,26 @@ TEST_F(LayouterTests, incremental_layouter_initial) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   // Add first query
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
 
-  layouter::IncrementalCandidateLayouter cl;
+  IncrementalCandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
 
   //Add second query
   std::vector<unsigned> aq2;
   aq2.push_back(0);
   aq2.push_back(1);
   aq2.push_back(2);
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.1, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.1, 1);
 
 
   // Incremental layout
@@ -785,13 +785,13 @@ TEST_F(LayouterTests, candidate_layoute_merged) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   // Add first query
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
   s.add(&q1);
 
   //Add second query
@@ -799,14 +799,14 @@ TEST_F(LayouterTests, candidate_layoute_merged) {
   aq2.push_back(0);
   aq2.push_back(1);
   aq2.push_back(2);
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.01, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.01, 1);
   s.add(&q2);
 
   std::vector<unsigned> aq3;
   aq3.push_back(0);
   aq3.push_back(1);
   aq3.push_back(3);
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.01, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.01, 1);
   s.add(&q3);
 
 
@@ -815,19 +815,19 @@ TEST_F(LayouterTests, candidate_layoute_merged) {
   aq4.push_back(1);
   aq4.push_back(4);
   aq4.push_back(5);
-  layouter::Query q4(LayouterConfiguration::access_type_outoforder, aq4, 0.01, 1);
+  Query q4(LayouterConfiguration::access_type_outoforder, aq4, 0.01, 1);
   s.add(&q4);
 
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
 
 
 
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
   // r.print();
 
   //ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
@@ -850,14 +850,14 @@ TEST_F(LayouterTests, incrementalLayout_layoute_merged) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
-  layouter::Schema sinc(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
+  Schema sinc(atts, 1000000, names);
 
   // Add first query
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
   s.add(&q1);
   sinc.add(&q1);
 
@@ -866,7 +866,7 @@ TEST_F(LayouterTests, incrementalLayout_layoute_merged) {
   //aq2.push_back(0);
   aq2.push_back(1);
   aq2.push_back(2);
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.02, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.02, 1);
   s.add(&q2);
   sinc.add(&q2);
 
@@ -874,25 +874,25 @@ TEST_F(LayouterTests, incrementalLayout_layoute_merged) {
   //aq3.push_back(0);
   aq3.push_back(1);
   aq3.push_back(3);
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.02, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.02, 1);
   s.add(&q3);
 
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
 
-  layouter::IncrementalCandidateLayouter il;
+  IncrementalCandidateLayouter il;
   il.layout(sinc, HYRISE_COST);
 
   // // Incrementally add
   il.incrementalLayout(&q3);
-  layouter::Result r2 = il.getBestResult();
+  Result r2 = il.getBestResult();
 
   // r.print();
   // r2.print();
@@ -918,14 +918,14 @@ TEST_F(LayouterTests, incrementalLayout_layoute_merged_merge_groups) {
   atts.push_back(4);
   atts.push_back(4);
 
-  layouter::Schema s(atts, 1000000, names);
-  layouter::Schema sinc(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
+  Schema sinc(atts, 1000000, names);
 
   // Add first query
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
   s.add(&q1);
   sinc.add(&q1);
 
@@ -934,7 +934,7 @@ TEST_F(LayouterTests, incrementalLayout_layoute_merged_merge_groups) {
   //aq2.push_back(0);
   aq2.push_back(1);
   aq2.push_back(2);
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.1, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.1, 1);
   s.add(&q2);
   sinc.add(&q2);
 
@@ -942,7 +942,7 @@ TEST_F(LayouterTests, incrementalLayout_layoute_merged_merge_groups) {
   //aq3.push_back(0);
   aq3.push_back(1);
   aq3.push_back(3);
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.1, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.1, 1);
   s.add(&q3);
 
   std::vector<unsigned> aq4;
@@ -950,35 +950,35 @@ TEST_F(LayouterTests, incrementalLayout_layoute_merged_merge_groups) {
   aq4.push_back(2);
   aq4.push_back(3);
   aq4.push_back(4);
-  layouter::Query q4(LayouterConfiguration::access_type_outoforder, aq4, 0.3, 1);
+  Query q4(LayouterConfiguration::access_type_outoforder, aq4, 0.3, 1);
   s.add(&q4);
 
 
   std::vector<unsigned> aq5;
   aq5.push_back(4);
-  layouter::Query q5(LayouterConfiguration::access_type_fullprojection, aq5, -1, 1);
+  Query q5(LayouterConfiguration::access_type_fullprojection, aq5, -1, 1);
   //s.add(&q5);
 
 
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
   // r.print();
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
 
-  layouter::IncrementalCandidateLayouter il;
+  IncrementalCandidateLayouter il;
   il.layout(sinc, HYRISE_COST);
 
   // Incrementally add
   il.incrementalLayout(&q3);
   il.incrementalLayout(&q4);
   //il.incrementalLayout(&q5);
-  layouter::Result r2 = il.getBestResult();
+  Result r2 = il.getBestResult();
   // r2.print();
 
   ASSERT_TRUE(r == r2);
@@ -991,14 +991,14 @@ TEST_F(LayouterTests, paper_layouter_performance) {
   std::vector<unsigned> atts;
   atts += 4, repeat(8, 4);
 
-  layouter::Schema s(atts, 1000000, names);
-  layouter::Schema sinc(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
+  Schema sinc(atts, 1000000, names);
 
   // Add first query
   std::vector<unsigned> aq1;
   aq1 += 0, 1;
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 1);
   s.add(&q1);
   sinc.add(&q1);
 
@@ -1006,7 +1006,7 @@ TEST_F(LayouterTests, paper_layouter_performance) {
   std::vector<unsigned> aq2;
   aq2 += 2, 3, 4;
 
-  layouter::Query q2(LayouterConfiguration::access_type_fullprojection, aq2, -1.0, 1);
+  Query q2(LayouterConfiguration::access_type_fullprojection, aq2, -1.0, 1);
   s.add(&q2);
   sinc.add(&q2);
 
@@ -1014,7 +1014,7 @@ TEST_F(LayouterTests, paper_layouter_performance) {
   std::vector<unsigned> aq3;
   aq3 += 5;
 
-  layouter::Query q3(LayouterConfiguration::access_type_fullprojection, aq3, -1.0, 1);
+  Query q3(LayouterConfiguration::access_type_fullprojection, aq3, -1.0, 1);
   s.add(&q3);
   sinc.add(&q3);
 
@@ -1022,7 +1022,7 @@ TEST_F(LayouterTests, paper_layouter_performance) {
   std::vector<unsigned> aq4;
   aq4 += 6, 7, 8;
 
-  layouter::Query q4(LayouterConfiguration::access_type_fullprojection, aq4, -1.0, 1);
+  Query q4(LayouterConfiguration::access_type_fullprojection, aq4, -1.0, 1);
   s.add(&q4);
   sinc.add(&q4);
 
@@ -1031,23 +1031,23 @@ TEST_F(LayouterTests, paper_layouter_performance) {
   std::vector<unsigned> aq5;
   aq5 += 3, 5;
 
-  layouter::Query q5(LayouterConfiguration::access_type_outoforder, aq5, 0.1, 1);
+  Query q5(LayouterConfiguration::access_type_outoforder, aq5, 0.1, 1);
   s.add(&q5);
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
-  layouter::IncrementalCandidateLayouter il;
+  IncrementalCandidateLayouter il;
   il.layout(sinc, HYRISE_COST);
   il.incrementalLayout(&q5);
 
-  layouter::Result r2 = il.getBestResult();
+  Result r2 = il.getBestResult();
 
   // r.print();
   // r2.print();
@@ -1065,13 +1065,13 @@ TEST_F(LayouterTests, group_merge_performance) {
   std::vector<unsigned> atts;
   atts += 4, repeat(5, 4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   // Add first query
   std::vector<unsigned> aq1;
   aq1.push_back(0);
 
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
+  Query q1(LayouterConfiguration::access_type_fullprojection, aq1, -1.0, 2);
   s.add(&q1);
 
   //Add second query
@@ -1079,14 +1079,14 @@ TEST_F(LayouterTests, group_merge_performance) {
   aq2.push_back(0);
   aq2.push_back(1);
   aq2.push_back(2);
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.01, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, aq2, 0.01, 1);
   s.add(&q2);
 
   std::vector<unsigned> aq3;
   aq3.push_back(0);
   aq3.push_back(1);
   aq3.push_back(3);
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.01, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, aq3, 0.01, 1);
   s.add(&q3);
 
 
@@ -1095,52 +1095,52 @@ TEST_F(LayouterTests, group_merge_performance) {
   aq4.push_back(1);
   aq4.push_back(4);
   aq4.push_back(5);
-  layouter::Query q4(LayouterConfiguration::access_type_outoforder, aq4, 0.01, 1);
+  Query q4(LayouterConfiguration::access_type_outoforder, aq4, 0.01, 1);
   s.add(&q4);
 
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
 
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
   //r.print();
 
   // Primary Partitions
-  layouter::subset_t p1;
+  subset_t p1;
   p1 += 0;
 
-  layouter::subset_t p13;
+  subset_t p13;
   p13 += 0, 2;
 
 
-  layouter::subset_t p2;
+  subset_t p2;
   p2 += 1;
 
-  layouter::subset_t p3;
+  subset_t p3;
   p3 += 2;
 
-  layouter::subset_t p23;
+  subset_t p23;
   p23 += 1, 2;
 
 
-  layouter::subset_t p4;
+  subset_t p4;
   p4 += 3;
 
-  layouter::subset_t p234;
+  subset_t p234;
   p234 += 1, 2, 3;
 
-  layouter::subset_t p5;
+  subset_t p5;
   p5 += 4, 5;
 
-  layouter::subset_t p2345;
+  subset_t p2345;
   p2345 += 1, 2, 3, 4, 5;
 
-  layouter::subset_t merged;
+  subset_t merged;
   merged += 4, 5, 1, 3, 2;
 
 
@@ -1169,39 +1169,39 @@ TEST_F(LayouterTests , cost_distribution_test) {
   std::vector<unsigned> atts;
   atts += 4, repeat(6, 4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   subset_t a1;
   a1 += 2;
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, a1, -1.0, 1);
+  Query q1(LayouterConfiguration::access_type_fullprojection, a1, -1.0, 1);
   s.add(&q1);
 
 
   subset_t a2;
   a2 += 0, 1, 2;
-  layouter::Query q2(LayouterConfiguration::access_type_outoforder, a2, 0.3, 1);
+  Query q2(LayouterConfiguration::access_type_outoforder, a2, 0.3, 1);
   s.add(&q2);
 
   subset_t a3;
   a3 += 3, 4;
-  layouter::Query q3(LayouterConfiguration::access_type_outoforder, a3, 0.3, 1);
+  Query q3(LayouterConfiguration::access_type_outoforder, a3, 0.3, 1);
   s.add(&q3);
 
   subset_t a4;
   a4 += 0, 1, 3, 4, 5, 6;
-  layouter::Query q4(LayouterConfiguration::access_type_outoforder, a4, 0.3, 1);
+  Query q4(LayouterConfiguration::access_type_outoforder, a4, 0.3, 1);
   s.add(&q4);
 
 
   subset_t a5;
   a5 += 2, 3, 4;
-  layouter::Query q5(LayouterConfiguration::access_type_outoforder, a5, 0.3, 65);
+  Query q5(LayouterConfiguration::access_type_outoforder, a5, 0.3, 65);
   s.add(&q5);
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
   // r.print();
 
 }
@@ -1214,53 +1214,53 @@ TEST_F(LayouterTests, candidate_generation_performance) {
   std::vector<unsigned> atts;
   atts += 4, repeat(8, 4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   subset_t a1 = subset_t(1, 0);
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, a1, -1.0, 2);
+  Query q1(LayouterConfiguration::access_type_fullprojection, a1, -1.0, 2);
   s.add(&q1);
 
   subset_t a2 = subset_t(1, 1);
-  layouter::Query q2(LayouterConfiguration::access_type_fullprojection, a2, -1.0, 2);
+  Query q2(LayouterConfiguration::access_type_fullprojection, a2, -1.0, 2);
   s.add(&q2);
 
   subset_t a3 = subset_t(1, 2);
-  layouter::Query q3(LayouterConfiguration::access_type_fullprojection, a3, -1.0, 2);
+  Query q3(LayouterConfiguration::access_type_fullprojection, a3, -1.0, 2);
   s.add(&q3);
 
   subset_t a4 = subset_t(1, 3);
-  layouter::Query q4(LayouterConfiguration::access_type_fullprojection, a4, -1.0, 2);
+  Query q4(LayouterConfiguration::access_type_fullprojection, a4, -1.0, 2);
   s.add(&q4);
 
   subset_t a5 = subset_t(1, 4);
-  layouter::Query q5(LayouterConfiguration::access_type_fullprojection, a5, -1.0, 2);
+  Query q5(LayouterConfiguration::access_type_fullprojection, a5, -1.0, 2);
   s.add(&q5);
 
   subset_t a6 = subset_t(1, 5);
-  layouter::Query q6(LayouterConfiguration::access_type_fullprojection, a6, -1.0, 2);
+  Query q6(LayouterConfiguration::access_type_fullprojection, a6, -1.0, 2);
   s.add(&q6);
 
   subset_t a7 = subset_t(1, 6);
-  layouter::Query q7(LayouterConfiguration::access_type_fullprojection, a7, -1.0, 2);
+  Query q7(LayouterConfiguration::access_type_fullprojection, a7, -1.0, 2);
   s.add(&q7);
 
   subset_t a8 = subset_t(1, 7);
-  layouter::Query q8(LayouterConfiguration::access_type_fullprojection, a8, -1.0, 2);
+  Query q8(LayouterConfiguration::access_type_fullprojection, a8, -1.0, 2);
   //s.add(&q8);
 
   subset_t a9 = subset_t(1, 8);
-  layouter::Query q9(LayouterConfiguration::access_type_fullprojection, a9, -1.0, 2);
+  Query q9(LayouterConfiguration::access_type_fullprojection, a9, -1.0, 2);
   //s.add(&q9);
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 
-  // layouter::FastCandidateLayouter fcl;
+  // FastCandidateLayouter fcl;
   // fcl.layout(s, HYRISE_COST);
   // ASSERT_TRUE(cl.getBestResult() == fcl.getBestResult());
 
 
-  layouter::Result r = cl.getBestResult();
+  Result r = cl.getBestResult();
   // r.print();
 
 
@@ -1274,93 +1274,93 @@ TEST_F(LayouterTests, candidate_iteration_performance) {
   std::vector<unsigned> atts;
   atts += 4, repeat(22, 4);
 
-  layouter::Schema s(atts, 1000000, names);
+  Schema s(atts, 1000000, names);
 
   subset_t a1 = subset_t(1, 0);
-  layouter::Query q1(LayouterConfiguration::access_type_fullprojection, a1, -1.0, 2);
+  Query q1(LayouterConfiguration::access_type_fullprojection, a1, -1.0, 2);
   s.add(&q1);
 
   subset_t a2 = subset_t(1, 1);
-  layouter::Query q2(LayouterConfiguration::access_type_fullprojection, a2, -1.0, 2);
+  Query q2(LayouterConfiguration::access_type_fullprojection, a2, -1.0, 2);
   s.add(&q2);
 
   subset_t a3 = subset_t(1, 2);
-  layouter::Query q3(LayouterConfiguration::access_type_fullprojection, a3, -1.0, 2);
+  Query q3(LayouterConfiguration::access_type_fullprojection, a3, -1.0, 2);
   s.add(&q3);
 
   subset_t a4 = subset_t(1, 3);
-  layouter::Query q4(LayouterConfiguration::access_type_fullprojection, a4, -1.0, 2);
+  Query q4(LayouterConfiguration::access_type_fullprojection, a4, -1.0, 2);
   s.add(&q4);
 
   subset_t a5 = subset_t(1, 4);
-  layouter::Query q5(LayouterConfiguration::access_type_fullprojection, a5, -1.0, 2);
+  Query q5(LayouterConfiguration::access_type_fullprojection, a5, -1.0, 2);
   s.add(&q5);
 
   subset_t a6 = subset_t(1, 5);
-  layouter::Query q6(LayouterConfiguration::access_type_fullprojection, a6, -1.0, 2);
+  Query q6(LayouterConfiguration::access_type_fullprojection, a6, -1.0, 2);
   s.add(&q6);
 
   subset_t a7 = subset_t(1, 6);
-  layouter::Query q7(LayouterConfiguration::access_type_fullprojection, a7, -1.0, 2);
+  Query q7(LayouterConfiguration::access_type_fullprojection, a7, -1.0, 2);
   s.add(&q7);
 
   subset_t a8 = subset_t(1, 7);
-  layouter::Query q8(LayouterConfiguration::access_type_fullprojection, a8, -1.0, 2);
+  Query q8(LayouterConfiguration::access_type_fullprojection, a8, -1.0, 2);
   s.add(&q8);
 
   subset_t a9 = subset_t(1, 8);
-  layouter::Query q9(LayouterConfiguration::access_type_fullprojection, a9, -1.0, 2);
+  Query q9(LayouterConfiguration::access_type_fullprojection, a9, -1.0, 2);
   s.add(&q9);
 
   subset_t a10 = subset_t(1, 9);
-  layouter::Query q10(LayouterConfiguration::access_type_fullprojection, a10, -1.0, 2);
+  Query q10(LayouterConfiguration::access_type_fullprojection, a10, -1.0, 2);
   s.add(&q10);
 
   subset_t a11 = subset_t(1, 10);
-  layouter::Query q11(LayouterConfiguration::access_type_fullprojection, a11, -1.0, 2);
+  Query q11(LayouterConfiguration::access_type_fullprojection, a11, -1.0, 2);
   s.add(&q11);
 
   subset_t a12 = subset_t(1, 11);
-  layouter::Query q12(LayouterConfiguration::access_type_fullprojection, a12, -1.0, 2);
+  Query q12(LayouterConfiguration::access_type_fullprojection, a12, -1.0, 2);
   s.add(&q12);
 
   subset_t a13 = subset_t(1, 12);
-  layouter::Query q13(LayouterConfiguration::access_type_fullprojection, a13, -1.0, 2);
+  Query q13(LayouterConfiguration::access_type_fullprojection, a13, -1.0, 2);
   s.add(&q13);
 
   subset_t a14 = subset_t(1, 13);
-  layouter::Query q14(LayouterConfiguration::access_type_fullprojection, a14, -1.0, 2);
+  Query q14(LayouterConfiguration::access_type_fullprojection, a14, -1.0, 2);
   s.add(&q14);
 
   subset_t a15 = subset_t(1, 14);
-  layouter::Query q15(LayouterConfiguration::access_type_fullprojection, a15, -1.0, 2);
+  Query q15(LayouterConfiguration::access_type_fullprojection, a15, -1.0, 2);
   s.add(&q15);
 
   subset_t a16 = subset_t(1, 15);
-  layouter::Query q16(LayouterConfiguration::access_type_fullprojection, a16, -1.0, 2);
+  Query q16(LayouterConfiguration::access_type_fullprojection, a16, -1.0, 2);
   s.add(&q16);
 
   subset_t a17 = subset_t(1, 16);
-  layouter::Query q17(LayouterConfiguration::access_type_fullprojection, a17, -1.0, 2);
+  Query q17(LayouterConfiguration::access_type_fullprojection, a17, -1.0, 2);
   s.add(&q17);
 
   subset_t a18 = subset_t(1, 17);
-  layouter::Query q18(LayouterConfiguration::access_type_fullprojection, a18, -1.0, 2);
+  Query q18(LayouterConfiguration::access_type_fullprojection, a18, -1.0, 2);
   //s.add(&q18);
 
   subset_t a19 = subset_t(1, 18);
-  layouter::Query q19(LayouterConfiguration::access_type_fullprojection, a19, -1.0, 2);
+  Query q19(LayouterConfiguration::access_type_fullprojection, a19, -1.0, 2);
   //s.add(&q19);
 
   subset_t a20 = subset_t(1, 19);
-  layouter::Query q20(LayouterConfiguration::access_type_fullprojection, a20, -1.0, 2);
+  Query q20(LayouterConfiguration::access_type_fullprojection, a20, -1.0, 2);
   //s.add(&q20);
 
   subset_t a21 = subset_t(1, 20);
-  layouter::Query q21(LayouterConfiguration::access_type_fullprojection, a21, -1.0, 2);
+  Query q21(LayouterConfiguration::access_type_fullprojection, a21, -1.0, 2);
   //s.add(&q21);
 
-  layouter::CandidateLayouter cl;
+  CandidateLayouter cl;
   cl.layout(s, HYRISE_COST);
 #endif
 }
@@ -1379,8 +1379,8 @@ TEST_F(LayouterTests, candidate_iteration_performance_fast_version)
 
   #include "builder.h"
 
-  layouter::Schema s(atts, 1000000, names);
-  layouter::CandidateLayouter cl;
+  Schema s(atts, 1000000, names);
+  CandidateLayouter cl;
 
   for(size_t i=1; i <= names.size(); ++i)
   {
@@ -1395,4 +1395,5 @@ TEST_F(LayouterTests, candidate_iteration_performance_fast_version)
 #endif
 }
 
+} } // namespace hyrise::layouter
 

--- a/src/bin/units_storage/AbstractTable_getAttributeVectors.cpp
+++ b/src/bin/units_storage/AbstractTable_getAttributeVectors.cpp
@@ -3,8 +3,14 @@
 #include "io/shortcuts.h"
 #include "storage/AbstractTable.h"
 
+namespace hyrise {
+namespace storage {
+
 TEST(AbstractTable_getAttributeVectors, test) {
-  const auto& table = Loader::shortcuts::load("test/tables/employees.tbl");
+  const auto& table = io::Loader::shortcuts::load("test/tables/employees.tbl");
   const auto& vectors = table->getAttributeVectors(1);
   EXPECT_EQ(2u, vectors.size());
 }
+
+} } // namespace hyrise::storage
+

--- a/src/bin/units_storage/attribute_vector_allocator_behaviour.cpp
+++ b/src/bin/units_storage/attribute_vector_allocator_behaviour.cpp
@@ -4,6 +4,9 @@
 #include <storage.h>
 #include <storage/BitCompressedVector.h>
 
+namespace hyrise {
+namespace storage {
+
 class MockStrategyTest : public ::hyrise::Test {};
 
 
@@ -40,3 +43,6 @@ TEST_F(MockStrategyTest, base_test) {
   delete a;
   ASSERT_EQ(MockMallocStrategy::allocates + MockMallocStrategy::reallocates, MockMallocStrategy::deallocates);
 }
+
+} } // namespace hyrise::storage
+

--- a/src/bin/units_storage/attribute_vector_tests.cpp
+++ b/src/bin/units_storage/attribute_vector_tests.cpp
@@ -7,6 +7,9 @@
 #include "storage/BitCompressedVector.h"
 #include "storage/FixedLengthVector.h"
 
+namespace hyrise {
+namespace storage {
+
 TEST(BitCompressedTests, set_retrieve_bits) {
   std::vector<uint64_t> bits {1, 2, 4, 8, 13};
   BitCompressedVector<value_id_t> tuples(5, 2, bits);
@@ -46,3 +49,5 @@ TEST(FixedLengthVectorTest, increment_test) {
   EXPECT_EQ(1u, tuples.atomic_inc(0,0));
   EXPECT_EQ(2u, tuples.get(0,0));
 }
+
+} } // namespace hyrise::storage

--- a/src/bin/units_storage/dictionary_tests.cpp
+++ b/src/bin/units_storage/dictionary_tests.cpp
@@ -4,7 +4,10 @@
 #include "storage/OrderIndifferentDictionary.h"
 #include "storage/OrderPreservingDictionary.h"
 
-class DictionaryTest : public ::hyrise::Test {};
+namespace hyrise {
+namespace storage {
+
+class DictionaryTest : public Test {};
 
 TEST_F(DictionaryTest, create_dictionary) {
   OrderPreservingDictionary<int> d;
@@ -123,4 +126,6 @@ TEST_F(DictionaryTest, order_preserving_string_exists) {
   ASSERT_FALSE(dict.valueExists("321"));
 
 }
+
+} } // namepsace hyrise::storage
 

--- a/src/bin/units_storage/generic_attribute_vector_tests.cpp
+++ b/src/bin/units_storage/generic_attribute_vector_tests.cpp
@@ -8,6 +8,9 @@
 #include "storage/ConcurrentFixedLengthVector.h"
 #include "storage/AttributeVectorFactory.h"
 
+namespace hyrise {
+namespace storage {
+
 template <typename T>
 class AttributeVectorTests : public ::hyrise::Test {};
 
@@ -60,3 +63,6 @@ TYPED_TEST(AttributeVectorTests, copy) {
   auto cp = tuples.copy();
   ASSERT_EQ(tuples.size(), cp->size());
 }
+
+} } // namespace hyrise::storage
+

--- a/src/bin/units_storage/generic_dictionary_tests.cpp
+++ b/src/bin/units_storage/generic_dictionary_tests.cpp
@@ -7,10 +7,13 @@
 #include "storage/OrderIndifferentDictionary.h"
 #include "storage/OrderPreservingDictionary.h"
 
-class DictionaryTest : public ::hyrise::Test {};
+namespace hyrise {
+namespace storage {
+
+class DictionaryTest : public Test {};
 
 template <typename T>
-class DictTests : public ::hyrise::Test {};
+class DictTests : public Test {};
 
 typedef testing::Types <
   OrderIndifferentDictionary<hyrise_int_t>, OrderIndifferentDictionary<hyrise_float_t>, OrderIndifferentDictionary<hyrise_string_t>, 
@@ -113,4 +116,7 @@ TYPED_TEST(DictTests, iterator_test) {
   }
   EXPECT_TRUE(std::is_sorted(p.begin(), p.end())) << "Resulting iterator should be sorted";
 }
+
+} } // namespace hyrise::storage
+
 

--- a/src/bin/units_storage/hash_table_tests.cpp
+++ b/src/bin/units_storage/hash_table_tests.cpp
@@ -8,8 +8,11 @@
 #include "storage/HashTable.h"
 #include "storage/Store.h"
 
+namespace hyrise {
+namespace storage {
+
 template <typename HT>
-::testing::AssertionResult TestCoverage(const hyrise::storage::atable_ptr_t &table,
+::testing::AssertionResult TestCoverage(const atable_ptr_t &table,
                                         const field_list_t &columns) {
   HT ht(table, columns);
   if (testHashTableFullCoverage(ht, table, columns)) {
@@ -22,7 +25,7 @@ template <typename HT>
 
 template <typename HT>
 bool testHashTableFullCoverage(const HT &hashTable,
-                               const hyrise::storage::atable_ptr_t &table,
+                               const atable_ptr_t &table,
                                const field_list_t &columns) {
   bool result = true;
   for (pos_t row = 0; row < table->size(); ++row) {
@@ -41,7 +44,7 @@ public:
   std::shared_ptr<AbstractTable> table;
 
   virtual void SetUp() {
-    table = Loader::shortcuts::load("test/join_exchange.tbl");
+    table = io::Loader::shortcuts::load("test/join_exchange.tbl");
   }
 };
 
@@ -67,7 +70,7 @@ public:
   std::shared_ptr<AbstractTable> table;
 
   virtual void SetUp() {
-    table = Loader::shortcuts::load("test/join_exchange.tbl");
+    table = io::Loader::shortcuts::load("test/join_exchange.tbl");
   }
 };
 
@@ -112,7 +115,7 @@ TYPED_TEST(HashTableTest, load_key_test) {
 const std::vector<field_list_t> combinations {{0}, {1}, {2}, {0, 1}, {1, 2},  {0, 1, 2}};
 
 TYPED_TEST(HashTableTest, test_column_combinations) {
-  hyrise::storage::atable_ptr_t table = Loader::shortcuts::load("test/tables/hash_table_test.tbl");
+  hyrise::storage::atable_ptr_t table = io::Loader::shortcuts::load("test/tables/hash_table_test.tbl");
 for (auto & cols: combinations) {
     SCOPED_TRACE(joinString(cols, ","));
     EXPECT_TRUE(TestCoverage<TypeParam>(table, cols));
@@ -120,7 +123,7 @@ for (auto & cols: combinations) {
 }
 
 TYPED_TEST(HashTableTest, test_column_combinations_store) {
-  hyrise::storage::atable_ptr_t store = Loader::shortcuts::loadMainDelta("test/tables/hash_table_test_main.tbl",
+  hyrise::storage::atable_ptr_t store = io::Loader::shortcuts::loadMainDelta("test/tables/hash_table_test_main.tbl",
                                         "test/tables/hash_table_test_delta.tbl");
 for (auto & cols: combinations) {
     SCOPED_TRACE(joinString(cols, ","));
@@ -133,7 +136,7 @@ class HashTableViewTest : public ::hyrise::Test {
 protected:
   hyrise::storage::atable_ptr_t table;
   virtual void SetUp() {
-    table = Loader::shortcuts::load("test/tables/hash_table_test.tbl");
+    table = io::Loader::shortcuts::load("test/tables/hash_table_test.tbl");
   }
 };
 
@@ -197,4 +200,5 @@ TYPED_TEST(HashTableViewTest, partial_range) {
   }
 }
 
+} } // namespace hyrise::storage
 

--- a/src/bin/units_storage/merge_tests.cpp
+++ b/src/bin/units_storage/merge_tests.cpp
@@ -20,11 +20,11 @@ class MergeTests : public ::hyrise::Test {};
 
 
 TEST_F(MergeTests, simple_merge_test_with_rows) {
-  hyrise::storage::atable_ptr_t main = Loader::shortcuts::load("test/merge1_main_row.tbl");
-  hyrise::storage::atable_ptr_t delta = Loader::shortcuts::load("test/merge1_delta.tbl"); 
-  hyrise::storage::atable_ptr_t correct_result = Loader::shortcuts::load("test/merge1_result.tbl");
+  auto main = io::Loader::shortcuts::load("test/merge1_main_row.tbl");
+  auto delta = io::Loader::shortcuts::load("test/merge1_delta.tbl"); 
+  auto correct_result = io::Loader::shortcuts::load("test/merge1_result.tbl");
 
-  std::vector<hyrise::storage::c_atable_ptr_t > tables;
+  std::vector<storage::c_atable_ptr_t > tables;
   tables.push_back(main);
   tables.push_back(delta);
 
@@ -41,9 +41,9 @@ TEST_F(MergeTests, simple_merge_test_with_rows) {
 
 
 TEST_F(MergeTests, simple_merge_test) {
-  hyrise::storage::atable_ptr_t main = Loader::shortcuts::load("test/merge1_main.tbl");
-  hyrise::storage::atable_ptr_t delta = Loader::shortcuts::load("test/merge1_delta.tbl");
-  hyrise::storage::atable_ptr_t correct_result = Loader::shortcuts::load("test/merge1_result.tbl");
+  auto main = io::Loader::shortcuts::load("test/merge1_main.tbl");
+  auto delta = io::Loader::shortcuts::load("test/merge1_delta.tbl");
+  auto correct_result = io::Loader::shortcuts::load("test/merge1_result.tbl");
 
   std::vector<hyrise::storage::c_atable_ptr_t > tables;
   tables.push_back(main);
@@ -61,9 +61,9 @@ TEST_F(MergeTests, simple_merge_test) {
 }
 
 TEST_F(MergeTests, simple_merge_test_valid_rows) {
-  hyrise::storage::atable_ptr_t main = Loader::shortcuts::load("test/merge1_main.tbl");
-  hyrise::storage::atable_ptr_t delta = Loader::shortcuts::load("test/merge1_delta.tbl");
-  hyrise::storage::atable_ptr_t correct_result = Loader::shortcuts::load("test/merge1_result.tbl");
+  auto main = io::Loader::shortcuts::load("test/merge1_main.tbl");
+  auto delta = io::Loader::shortcuts::load("test/merge1_delta.tbl");
+  auto correct_result = io::Loader::shortcuts::load("test/merge1_result.tbl");
 
   std::vector<hyrise::storage::c_atable_ptr_t > tables;
   tables.push_back(main);
@@ -232,14 +232,14 @@ TEST_F(MergeTests, DISABLED_parallel_heap_merger_delta_test) {
 }
 
 TEST_F(MergeTests, simple_logarithmic_merger_test) {
-  auto m = Loader::shortcuts::loadMainDelta("test/merge1_main.tbl", "test/merge1_delta.tbl");
+  auto m = io::Loader::shortcuts::loadMainDelta("test/merge1_main.tbl", "test/merge1_delta.tbl");
   std::vector<hyrise::storage::c_atable_ptr_t > tables;
   tables.push_back(m->getMainTable());
   tables.push_back(m->getDeltaTable());
   TableMerger merger(new DefaultMergeStrategy(), new SequentialHeapMerger());
   const auto& result = merger.merge(tables);
 
-  const auto& correct_result = Loader::shortcuts::load("test/merge1_result.tbl");
+  const auto& correct_result = io::Loader::shortcuts::load("test/merge1_result.tbl");
   ASSERT_TRUE(result[0]->contentEquals(correct_result));
   ASSERT_TRUE(result[0]->dictionaryAt(0)->size() == 7);
   ASSERT_TRUE(result[0]->dictionaryAt(1)->size() == 7);
@@ -248,7 +248,7 @@ TEST_F(MergeTests, simple_logarithmic_merger_test) {
 }
 
 TEST_F(MergeTests, DISABLED_parallel_value_merger_test) {
-  auto m = Loader::shortcuts::loadMainDelta("test/merge1_main.tbl", "test/merge1_delta.tbl", Loader::params().setCompressed(false));
+  auto m = io::Loader::shortcuts::loadMainDelta("test/merge1_main.tbl", "test/merge1_delta.tbl", io::Loader::params().setCompressed(false));
   std::vector<hyrise::storage::c_atable_ptr_t > tables;
   tables.push_back(m->getMainTable());
   tables.push_back(m->getDeltaTable());
@@ -257,7 +257,7 @@ TEST_F(MergeTests, DISABLED_parallel_value_merger_test) {
 
   const auto& result = merger.merge(tables);
 
-  const auto& correct_result = Loader::shortcuts::load("test/merge1_result.tbl");
+  const auto& correct_result = io::Loader::shortcuts::load("test/merge1_result.tbl");
   ASSERT_TRUE(result[0]->contentEquals(correct_result));
   ASSERT_TRUE(result[0]->dictionaryAt(0)->size() == 7);
   ASSERT_TRUE(result[0]->dictionaryAt(1)->size() == 7);
@@ -266,11 +266,11 @@ TEST_F(MergeTests, DISABLED_parallel_value_merger_test) {
 }
 
 TEST_F(MergeTests, merge_with_different_layout) {
-  hyrise::storage::atable_ptr_t main = Loader::shortcuts::load("test/merge1_main.tbl");
-  hyrise::storage::atable_ptr_t delta = Loader::shortcuts::load("test/merge1_delta.tbl"); //, Loader::params().set_modifiable(true));
-  hyrise::storage::atable_ptr_t correct_result = Loader::shortcuts::load("test/merge1_result.tbl");
+  auto main = io::Loader::shortcuts::load("test/merge1_main.tbl");
+  auto delta = io::Loader::shortcuts::load("test/merge1_delta.tbl"); //, io::Loader::params().set_modifiable(true));
+  auto correct_result = io::Loader::shortcuts::load("test/merge1_result.tbl");
 
-  hyrise::storage::atable_ptr_t dest = Loader::shortcuts::load("test/merge1_newlayout.tbl", Loader::params().setModifiableMutableVerticalTable(true));
+ auto dest = io::Loader::shortcuts::load("test/merge1_newlayout.tbl", io::Loader::params().setModifiableMutableVerticalTable(true));
 
   ASSERT_EQ(3u, main->partitionCount());
   ASSERT_EQ(1u, dest->partitionCount());
@@ -294,11 +294,11 @@ TEST_F(MergeTests, merge_with_different_layout) {
 }
 
 TEST_F(MergeTests, merge_with_different_layout_2) {
-  hyrise::storage::atable_ptr_t main = Loader::shortcuts::load("test/merge1_main.tbl");
-  hyrise::storage::atable_ptr_t delta = Loader::shortcuts::load("test/merge1_delta.tbl"); //, Loader::params().set_modifiable(true));
-  hyrise::storage::atable_ptr_t correct_result = Loader::shortcuts::load("test/merge1_result.tbl");
+  auto main = io::Loader::shortcuts::load("test/merge1_main.tbl");
+  auto delta = io::Loader::shortcuts::load("test/merge1_delta.tbl"); //, io::Loader::params().set_modifiable(true));
+  auto correct_result = io::Loader::shortcuts::load("test/merge1_result.tbl");
 
-  hyrise::storage::atable_ptr_t dest = Loader::shortcuts::load("test/merge1_newlayout_2.tbl", Loader::params().setModifiableMutableVerticalTable(true));
+  hyrise::storage::atable_ptr_t dest = io::Loader::shortcuts::load("test/merge1_newlayout_2.tbl", io::Loader::params().setModifiableMutableVerticalTable(true));
 
   ASSERT_EQ(3u, main->partitionCount());
   ASSERT_EQ(2u, dest->partitionCount());
@@ -323,8 +323,8 @@ TEST_F(MergeTests, merge_with_different_layout_2) {
 
 
 TEST_F(MergeTests, store_merge_compex) {
-  auto linxxxs = std::dynamic_pointer_cast<storage::Store>(Loader::shortcuts::load("test/lin_xxxs.tbl"));
-  auto ref = std::dynamic_pointer_cast<storage::Store>(Loader::shortcuts::load("test/reference/lin_xxxs_update.tbl"));
+  auto linxxxs = std::dynamic_pointer_cast<storage::Store>(io::Loader::shortcuts::load("test/lin_xxxs.tbl"));
+  auto ref = std::dynamic_pointer_cast<storage::Store>(io::Loader::shortcuts::load("test/reference/lin_xxxs_update.tbl"));
   linxxxs->resizeDelta(2);
   linxxxs->copyRowToDelta(linxxxs, 0, 0, 1);
   linxxxs->copyRowToDelta(linxxxs, 4, 1, 1);
@@ -346,5 +346,5 @@ TEST_F(MergeTests, store_merge_compex) {
   EXPECT_RELATION_EQ(ref, result[0]);
 }
 
-
 }}
+

--- a/src/bin/units_storage/pointercalc_tests.cpp
+++ b/src/bin/units_storage/pointercalc_tests.cpp
@@ -6,22 +6,24 @@
 
 #include <storage/PointerCalculator.h>
 #include <io/StorageManager.h>
+#include <io/StringLoader.h>
 #include <io/shortcuts.h>
 #include <io/loaders.h>
 
-class PointerCalcTests : public ::hyrise::StorageManagerTest {
+namespace hyrise {
+namespace storage {
+
+class PointerCalcTests : public StorageManagerTest {
  protected:
   std::string table_7 = "Mobile | ID | Name | Mail | Company | Phone | Org\nINTEGER | INTEGER | INTEGER | INTEGER | INTEGER | INTEGER | INTEGER\n0_R | 1_R | 2_R | 3_R | 4_R | 5_R | 6_R";
   std::string table_5 = "Mobile | ID | Name | Mail | Company | Phone | Org\nINTEGER | INTEGER | INTEGER | INTEGER | INTEGER | INTEGER | INTEGER\n0_R | 1_R | 1_R | 1_R | 2_R | 3_R | 4_R";
 };
 
-using namespace hyrise::storage;
-
 atable_ptr_t createTable(std::string description) {
-  Loader::params params;
-  params.setHeader(StringHeader(description));
-  params.setInput(CSVInput("test/tables/10_col_only_data.tbl", CSVInput::params().setUnsafe(true).setCSVParams(csv::HYRISE_FORMAT)));
-  return Loader::load(params);
+  io::Loader::params params;
+  params.setHeader(io::StringHeader(description));
+  params.setInput(io::CSVInput("test/tables/10_col_only_data.tbl", io::CSVInput::params().setUnsafe(true).setCSVParams(io::csv::HYRISE_FORMAT)));
+  return io::Loader::load(params);
 }
 
 TEST_F(PointerCalcTests, pc_from_vertical_table_slice_count) {
@@ -63,7 +65,7 @@ TEST_F(PointerCalcTests, pc_from_vertical_table_slice_count_1_group_projection) 
 
 
 TEST_F(PointerCalcTests, pc_using_factory) {
-  auto t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   auto pc = PointerCalculator::create(t);
 
   ASSERT_TRUE(pc->columnCount() == 10);
@@ -76,7 +78,7 @@ TEST_F(PointerCalcTests, pc_using_factory) {
 
 
 TEST_F(PointerCalcTests, pc_on_selected_columns) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
 
   field_list_t field_definition {1, 3, 5, 7};
 
@@ -89,4 +91,6 @@ TEST_F(PointerCalcTests, pc_on_selected_columns) {
   ASSERT_TRUE(pc->metadataAt(2)->matches(t->metadataAt(5)));
   ASSERT_TRUE(pc->metadataAt(3)->matches(t->metadataAt(7)));
 }
+
+} } // namespace hyrise::storage
 

--- a/src/bin/units_storage/rawtable_tests.cpp
+++ b/src/bin/units_storage/rawtable_tests.cpp
@@ -8,7 +8,11 @@
 #include "storage/SimpleStore.h"
 #include "storage/TableGenerator.h"
 
-class RawTableTests : public ::hyrise::Test {
+namespace hyrise {
+namespace storage {
+namespace rawtable {
+
+class RawTableTests : public Test {
  public:
   metadata_vec_t intList(size_t num=2) {
     metadata_vec_t result;
@@ -42,7 +46,7 @@ TEST_F(RawTableTests, test_raw_table_constructor) {
 TEST_F(RawTableTests, test_write) {
   auto cols = allTypeMeta();
   RawTable main(cols);
-  auto toInsert = Loader::shortcuts::load("test/alltypes.tbl");
+  auto toInsert = io::Loader::shortcuts::load("test/alltypes.tbl");
   main.appendRows(toInsert);
 }
 
@@ -91,7 +95,7 @@ TYPED_TEST(RawWriteTests, write_default_value) {
   size_t column = TypeParam::column;
   const auto& values = testValues<ColumnType>::values;
 
-  table.appendRows(Loader::shortcuts::load("test/alltypes.tbl"));
+  table.appendRows(io::Loader::shortcuts::load("test/alltypes.tbl"));
   for(size_t row=0; row < table.size(); ++row) {
     table.setValue(column, row, values.at(row));
   }
@@ -204,20 +208,20 @@ TEST_F(RawTableTests, test_raw_table_record_builder_with_1k_rows_and_get_value) 
 }
 
 TEST_F(RawTableTests, simple_store_initialize_and_should_behave_like_normal_table) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   hyrise::storage::atable_ptr_t tab = std::make_shared<hyrise::storage::SimpleStore>(t);
   ASSERT_TABLE_EQUAL(tab, t);
 }
 
 TEST_F(RawTableTests, simple_store_throws_unsopported) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   hyrise::storage::SimpleStore tab(t);
 
   ASSERT_THROW(tab.copy(), std::runtime_error);
 }
 
 TEST_F(RawTableTests, simple_store_insert_new_row_in_delta) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   auto tab = std::make_shared<hyrise::storage::SimpleStore>(t);
   auto delta = tab->getDelta();
   auto meta = delta->metadata();
@@ -240,8 +244,8 @@ TEST_F(RawTableTests, simple_store_insert_new_row_in_delta) {
 
 
 TEST_F(RawTableTests, simple_store_insert_and_merge) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
-  hyrise::storage::atable_ptr_t ref = Loader::shortcuts::load("test/reference/lin_xxs_raw_merged.tbl");
+  hyrise::storage::atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t ref = io::Loader::shortcuts::load("test/reference/lin_xxs_raw_merged.tbl");
 
   auto tab = std::make_shared<hyrise::storage::SimpleStore>(t);
   auto delta = tab->getDelta();
@@ -263,8 +267,8 @@ TEST_F(RawTableTests, simple_store_insert_and_merge) {
 }
 
 TEST_F(RawTableTests, simple_store_insert_and_merge_new_values) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
-  hyrise::storage::atable_ptr_t ref = Loader::shortcuts::load("test/reference/lin_xxs_raw_merged2.tbl");
+  hyrise::storage::atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t ref = io::Loader::shortcuts::load("test/reference/lin_xxs_raw_merged2.tbl");
 
   auto tab = std::make_shared<hyrise::storage::SimpleStore>(t);
   auto delta = tab->getDelta();
@@ -282,4 +286,7 @@ TEST_F(RawTableTests, simple_store_insert_and_merge_new_values) {
 
   tab->merge();
   ASSERT_TABLE_EQUAL(ref, tab);
-  }
+}
+
+} } } // namespace hyrise::storage::rawtable
+

--- a/src/bin/units_storage/table_factory_tests.cpp
+++ b/src/bin/units_storage/table_factory_tests.cpp
@@ -4,7 +4,10 @@
 #include "storage/AbstractTable.h"
 #include "storage/TableFactory.h"
 
-class TableFactoryTests : public ::hyrise::Test {};
+namespace hyrise {
+namespace storage {
+
+class TableFactoryTests : public Test {};
 
 TEST_F(TableFactoryTests, number_of_column) {
   TableFactory t;
@@ -12,3 +15,5 @@ TEST_F(TableFactoryTests, number_of_column) {
   meta.push_back(new ColumnMetadata("basti", IntegerType));
   hyrise::storage::atable_ptr_t  table = t.generate(&meta);
 }
+
+} } // namespace hyrise::storage

--- a/src/bin/units_storage/table_tests.cpp
+++ b/src/bin/units_storage/table_tests.cpp
@@ -14,7 +14,7 @@
 
 namespace hyrise { namespace storage {
 
-class TableTests : public ::hyrise::Test {
+class TableTests : public Test {
 
 public:
   metadata_list intList(size_t num=2) {
@@ -34,7 +34,7 @@ public:
 };
 
 TEST_F(TableTests, does_copy_structure_copy_structure) {
-  hyrise::storage::atable_ptr_t  input = Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t  input = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   ASSERT_EQ(3u, input->partitionCount());
 
   hyrise::storage::atable_ptr_t  copy  = input->copy_structure();
@@ -42,7 +42,7 @@ TEST_F(TableTests, does_copy_structure_copy_structure) {
 }
 
 TEST_F(TableTests, copy_structure_replacement) {
-  auto input = Loader::shortcuts::load("test/lin_xxs.tbl", Loader::params().setReturnsMutableVerticalTable(true));
+  auto input = io::Loader::shortcuts::load("test/lin_xxs.tbl", io::Loader::params().setReturnsMutableVerticalTable(true));
   ASSERT_EQ(3u, input->partitionCount());
   auto order_indifferent = [](DataType dt) { return makeDictionary<OrderIndifferentDictionary>(dt); };
   auto order_preserving = [](DataType dt) { return makeDictionary<OrderPreservingDictionary>(dt); };
@@ -84,14 +84,14 @@ TEST_F(TableTests, generate_generates_layout) {
 }
 
 TEST_F(TableTests, number_of_column) {
-  hyrise::storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  hyrise::storage::atable_ptr_t t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   ASSERT_TRUE(t->numberOfColumn("col_0") == 0);
   ASSERT_TRUE(t->numberOfColumn("col_2") == 2);
   //ASSERT_TRUE( t->numberOfColumn("does_not_exist") == -1 );
 }
 
 TEST_F(TableTests, bit_compression_test) {
-  hyrise::storage::atable_ptr_t main = Loader::shortcuts::load("test/bittest.tbl");
+  hyrise::storage::atable_ptr_t main = io::Loader::shortcuts::load("test/bittest.tbl");
 
   ASSERT_TRUE(main->getValue<hyrise_int_t>(0, 0) == 4);
   ASSERT_TRUE(main->getValue<hyrise_int_t>(0, 1) == 0);
@@ -144,3 +144,4 @@ TEST_F(TableTests, test_table_copy) {
 
 
 }}
+

--- a/src/bin/units_storage/tablerangeview_tests.cpp
+++ b/src/bin/units_storage/tablerangeview_tests.cpp
@@ -9,15 +9,16 @@
 #include <io/shortcuts.h>
 #include <io/loaders.h>
 
-using namespace hyrise;
+namespace hyrise {
+namespace storage {
 
 class TableRangeViewTests : public ::hyrise::StorageManagerTest {};
 
 TEST_F(TableRangeViewTests, init_pc) {
   {
-    storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+    auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
 
-    auto trv = new storage::TableRangeView(t, 0, t->size());
+    auto trv = new TableRangeView(t, 0, t->size());
     ASSERT_EQ(t->size(), trv->size());
 
     size_t row = 2;
@@ -32,13 +33,13 @@ TEST_F(TableRangeViewTests, init_pc) {
 }
 
 TEST_F(TableRangeViewTests, pc_using_factory) {
-  storage::atable_ptr_t t = Loader::shortcuts::load("test/lin_xxs.tbl");
+  auto t = io::Loader::shortcuts::load("test/lin_xxs.tbl");
   size_t start = 5;
   size_t end = 20;
   size_t row = 10;
   size_t column = 1;
 
-  auto trv = storage::TableRangeView::create(t, start, end);
+  auto trv = TableRangeView::create(t, start, end);
 
   ASSERT_EQ(trv->size(), (end-start));
 
@@ -47,3 +48,6 @@ TEST_F(TableRangeViewTests, pc_using_factory) {
 
   ASSERT_EQ(i.valueId, i2.valueId);
 }
+
+} } // namespace hyrise::storage
+

--- a/src/bin/units_storage/visibility_tests.cpp
+++ b/src/bin/units_storage/visibility_tests.cpp
@@ -19,10 +19,10 @@ class VisibilityTests : public ::hyrise::Test {
 
 public:
 
-	hyrise::storage::c_atable_ptr_t data;
-	hyrise::storage::store_ptr_t linxxxs;
+	storage::c_atable_ptr_t data;
+	storage::store_ptr_t linxxxs;
 
-	hyrise::storage::atable_ptr_t one_row;
+	storage::atable_ptr_t one_row;
 
 	void SetUp() {
 		 TableBuilder::param_list list;
@@ -42,8 +42,8 @@ public:
 		 one_row->setValue<hyrise_int_t>(1,0, 999);
 
 		 // Convert to store
-		 data = std::make_shared<storage::Store>(TableBuilder::build(list));
-		 linxxxs = std::dynamic_pointer_cast<storage::Store>(Loader::shortcuts::load("test/lin_xxxs.tbl"));
+		 data = std::make_shared<storage::Store>(storage::TableBuilder::build(list));
+		 linxxxs = std::dynamic_pointer_cast<storage::Store>(io::Loader::shortcuts::load("test/lin_xxxs.tbl"));
 	}
 
 };
@@ -99,7 +99,7 @@ TEST_F(VisibilityTests, read_your_own_writes) {
 	ASSERT_EQ(linxxxs->size()-1, tmp2->size());
 
 	auto r = std::make_shared<PointerCalculator>(linxxxs, tmp2);
-	EXPECT_RELATION_EQ(Loader::shortcuts::load("test/lin_xxxs.tbl"), r);
+	EXPECT_RELATION_EQ(io::Loader::shortcuts::load("test/lin_xxxs.tbl"), r);
 }
 
 TEST_F (VisibilityTests, read_writes_after_commit) {
@@ -171,7 +171,7 @@ TEST_F (VisibilityTests, read_writes_after_commit_old_cid) {
 	ASSERT_EQ(linxxxs->size() -1, tmp2->size());
 
 	auto r = std::make_shared<PointerCalculator>(linxxxs, tmp2);
-	EXPECT_RELATION_EQ(Loader::shortcuts::load("test/lin_xxxs.tbl"), r);
+	EXPECT_RELATION_EQ(io::Loader::shortcuts::load("test/lin_xxxs.tbl"), r);
 }
 
 }}

--- a/src/bin/units_taskscheduler/taskscheduler.cpp
+++ b/src/bin/units_taskscheduler/taskscheduler.cpp
@@ -18,7 +18,7 @@
 
 
 namespace hyrise {
-namespace access {
+namespace taskscheduler {
 
 #if GTEST_HAS_PARAM_TEST
 
@@ -90,8 +90,8 @@ TEST_P(SchedulerTest, sync_task_test) {
 
   //scheduler->resize(2);
 
-  std::shared_ptr<NoOp> nop1 = std::make_shared<NoOp>();
-  std::shared_ptr<NoOp> nop2 = std::make_shared<NoOp>();
+  auto nop1 = std::make_shared<access::NoOp>();
+  auto nop2 = std::make_shared<access::NoOp>();
   std::shared_ptr<SyncTask> syn = std::make_shared<SyncTask>();
   std::shared_ptr<WaitTask> waiter = std::make_shared<WaitTask>();
   syn->addDependency(nop1);
@@ -108,8 +108,8 @@ TEST_P(SchedulerTest, million_dependencies_test) {
 #ifdef EXPENSIVE_TESTS
   int tasks_group1 = 1000;
   int tasks_group2 = 1000;
-  std::vector<std::shared_ptr<NoOp> > vtasks1;
-  std::vector<std::shared_ptr<NoOp> > vtasks2;
+  std::vector<std::shared_ptr<access::NoOp> > vtasks1;
+  std::vector<std::shared_ptr<access::NoOp> > vtasks2;
 
   SharedScheduler::getInstance().resetScheduler(scheduler_name);
   const auto& scheduler = SharedScheduler::getInstance().getScheduler();
@@ -119,10 +119,10 @@ TEST_P(SchedulerTest, million_dependencies_test) {
   std::shared_ptr<WaitTask> waiter = std::make_shared<WaitTask>();
 
   for (int i = 0; i < tasks_group1; ++i) {
-    vtasks1.push_back(std::make_shared<NoOp>());
+    vtasks1.push_back(std::make_shared<access::NoOp>());
   }
   for (int i = 0; i < tasks_group2; ++i) {
-    vtasks2.push_back(std::make_shared<NoOp>());
+    vtasks2.push_back(std::make_shared<access::NoOp>());
     for (int j = 0; j < tasks_group1; ++j) {
       vtasks2[i]->addDependency(vtasks1[j]);
     }
@@ -144,7 +144,7 @@ TEST_P(SchedulerTest, million_noops_test) {
 #ifdef EXPENSIVE_TESTS
   //chaned to 10.000, 1.000.000 takes too long on small computers
   int tasks_group1 = 10000;
-  std::vector<std::shared_ptr<NoOp> > vtasks1;
+  std::vector<std::shared_ptr<access::NoOp> > vtasks1;
 
   SharedScheduler::getInstance().resetScheduler(scheduler_name);
   const auto& scheduler = SharedScheduler::getInstance().getScheduler();
@@ -154,7 +154,7 @@ TEST_P(SchedulerTest, million_noops_test) {
   std::shared_ptr<WaitTask> waiter = std::make_shared<WaitTask>();
 
   for (int i = 0; i < tasks_group1; ++i) {
-    vtasks1.push_back(std::make_shared<NoOp>());
+    vtasks1.push_back(std::make_shared<access::NoOp>());
     waiter->addDependency(vtasks1[i]);
     scheduler->schedule(vtasks1[i]);
   }
@@ -169,8 +169,8 @@ TEST_P(SchedulerTest, wait_dependency_task_test) {
   const auto& scheduler = SharedScheduler::getInstance().getScheduler();
 
   //scheduler->resize(2);
-  std::shared_ptr<NoOp> nop = std::make_shared<NoOp>();
-  std::shared_ptr<WaitTask> waiter = std::make_shared<WaitTask>();
+  auto nop = std::make_shared<access::NoOp>();
+  auto waiter = std::make_shared<WaitTask>();
   waiter->addDependency(nop);
   scheduler->schedule(nop);
   scheduler->schedule(waiter);
@@ -189,9 +189,9 @@ TEST_P(SchedulerTest, wait_set_test) {
   auto waiter = std::make_shared<WaitTask>();
   auto sleeper = std::make_shared<SleepTask>(sleeptime);
 
-  std::vector<std::shared_ptr<NoOp> > vtasks;
+  std::vector<std::shared_ptr<access::NoOp> > vtasks;
   for (int i = 0; i < tasks; ++i) {
-    vtasks.push_back(std::make_shared<NoOp>());
+    vtasks.push_back(std::make_shared<access::NoOp>());
     sleeper->addDependency(vtasks[i]);
     scheduler->schedule(vtasks[i]);
   }
@@ -263,6 +263,5 @@ TEST(SchedulerBlockTest, dont_block_test_with_work_stealing) {
   long_block_test(scheduler.get());
 }
 
+} } // namespace hyrise::taskscheduler
 
-}
-}

--- a/src/lib/access/AggregateFunctions.cpp
+++ b/src/lib/access/AggregateFunctions.cpp
@@ -165,7 +165,9 @@ struct max_aggregate_functor : aggregate_functor{
   }
 };
 
-} } // namespace hyrise::storage
+} // namespace storage
+
+namespace access {
 
 aggregateFunctionMap_t getAggregateFunctionMap() {
   aggregateFunctionMap_t d;
@@ -209,7 +211,7 @@ AggregateFun *parseAggregateFunction(const Json::Value &data) {
   return aggregate;
 }
 
-void AggregateFun::walk(const AbstractTable &table) {
+void AggregateFun::walk(const storage::AbstractTable &table) {
   if (_field_name.size() > 0) { //either _field_name is set
     _field = table.numberOfColumn(_field_name);
   } else { //or _field
@@ -358,4 +360,6 @@ AggregateFun *MaxAggregateFun::parse(const Json::Value &f) {
   else if (f["field"].isString()) return new MaxAggregateFun(f["field"].asString());
   else throw std::runtime_error("Could not parse json");
 }
+
+} } // namespace hyrise::access
 

--- a/src/lib/access/AggregateFunctions.h
+++ b/src/lib/access/AggregateFunctions.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_AGGEGATEFUNCTIONS_H_
-#define SRC_LIB_ACCESS_AGGEGATEFUNCTIONS_H_
+#pragma once
 
 #include <vector>
 
@@ -9,6 +8,9 @@
 #include <storage/storage_types.h>
 
 #include <json.h>
+
+namespace hyrise {
+namespace access {
 
 struct AggregateFunctions {
   enum type {
@@ -40,7 +42,7 @@ class AggregateFun {
   explicit AggregateFun(field_name_t field_name) :
     _field_name(field_name) {}
 
-  virtual void walk(const AbstractTable &table);
+  virtual void walk(const storage::AbstractTable &table);
   field_t getField();// {
    // return _field;
   //}
@@ -88,7 +90,7 @@ class SumAggregateFun: public AggregateFun {
     return _dataType;
   }
 
-  virtual void walk(const AbstractTable &table) {
+  virtual void walk(const storage::AbstractTable &table) {
     AggregateFun::walk(table);
     _dataType = table.typeOfColumn(_field);
     if (_dataType == StringType) {
@@ -163,7 +165,7 @@ class AverageAggregateFun: public AggregateFun {
     return FloatType;
   }
 
-  virtual void walk(const AbstractTable &table) {
+  virtual void walk(const storage::AbstractTable &table) {
     AggregateFun::walk(table);
     _dataType = table.typeOfColumn(_field);
     if (_dataType == StringType) {
@@ -199,7 +201,7 @@ class MinAggregateFun: public AggregateFun {
     return _dataType;
   }
   
-  virtual void walk(const AbstractTable &table) {
+  virtual void walk(const storage::AbstractTable &table) {
     AggregateFun::walk(table);
     _dataType = table.typeOfColumn(_field);
   }
@@ -232,7 +234,7 @@ class MaxAggregateFun: public AggregateFun {
     return _dataType;
   }
   
-  virtual void walk(const AbstractTable &table) {
+  virtual void walk(const storage::AbstractTable &table) {
     AggregateFun::walk(table);
     _dataType = table.typeOfColumn(_field);
   }
@@ -244,5 +246,5 @@ class MaxAggregateFun: public AggregateFun {
   static AggregateFun *parse(const Json::Value &);
 };
 
-#endif // AGGEGATEFUNCTIONS
+} } // namespace hyrise::access
 

--- a/src/lib/access/CreateIndex.cpp
+++ b/src/lib/access/CreateIndex.cpp
@@ -21,7 +21,7 @@ namespace hyrise {
 namespace access {
 
 struct CreateIndexFunctor {
-  typedef std::shared_ptr<AbstractIndex> value_type;
+  typedef std::shared_ptr<storage::AbstractIndex> value_type;
   const storage::c_atable_ptr_t& in;
   size_t column;
 
@@ -30,7 +30,7 @@ struct CreateIndexFunctor {
 
   template<typename R>
   value_type operator()() {
-    return std::make_shared<InvertedIndex<R>>(in, column);
+    return std::make_shared<storage::InvertedIndex<R>>(in, column);
   }
 };
 
@@ -43,14 +43,14 @@ CreateIndex::~CreateIndex() {
 
 void CreateIndex::executePlanOperation() {
   const auto &in = input.getTable(0);
-  std::shared_ptr<AbstractIndex> _index;
+  std::shared_ptr<storage::AbstractIndex> _index;
   auto column = _field_definition[0];
 
   CreateIndexFunctor fun(in, column);
   storage::type_switch<hyrise_basic_types> ts;
   _index = ts(in->typeOfColumn(column), fun);
 
-  StorageManager *sm = StorageManager::getInstance();
+  auto sm = io::StorageManager::getInstance();
   sm->addInvertedIndex(_index_name, _index);
 }
 

--- a/src/lib/access/Delete.cpp
+++ b/src/lib/access/Delete.cpp
@@ -21,7 +21,7 @@ namespace {
 
 
 void DeleteOp::executePlanOperation() {
-	auto tab = checked_pointer_cast<const PointerCalculator>(input.getTable(0));
+	auto tab = checked_pointer_cast<const storage::PointerCalculator>(input.getTable(0));
 	auto store = std::const_pointer_cast<storage::Store>(checked_pointer_cast<const storage::Store>(tab->getActualTable()));
 
 	auto& txmgr = tx::TransactionManager::getInstance();

--- a/src/lib/access/Distinct.cpp
+++ b/src/lib/access/Distinct.cpp
@@ -46,7 +46,7 @@ void Distinct::executePlanOperation() {
     pos->push_back(e.second);
 
   // Return pointer calculator
-  addResult(PointerCalculator::create(input.getTable(0), pos));
+  addResult(storage::PointerCalculator::create(input.getTable(0), pos));
 }
 
 std::shared_ptr<PlanOperation> Distinct::parse(const Json::Value &data) {

--- a/src/lib/access/ExpressionScan.cpp
+++ b/src/lib/access/ExpressionScan.cpp
@@ -44,14 +44,14 @@ ExpressionScan::~ExpressionScan() {
 void ExpressionScan::executePlanOperation() {
   size_t input_size = input.getTable(0)->size();
 
-  metadata_list metadata;
-  ColumnMetadata *m = new ColumnMetadata(_column_name, _expression->getType());
+  storage::metadata_list metadata;
+  auto m = new storage::ColumnMetadata(_column_name, _expression->getType());
   metadata.push_back(m);
 
-  std::vector<AbstractTable::SharedDictionaryPtr> dicts;
-  dicts.push_back(storage::makeDictionary<OrderIndifferentDictionary>(_expression->getType()));
+  std::vector<storage::AbstractTable::SharedDictionaryPtr> dicts;
+  dicts.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(_expression->getType()));
 
-  storage::atable_ptr_t exp_result = std::make_shared<Table>(&metadata, &dicts, 0, false);
+  storage::atable_ptr_t exp_result = std::make_shared<storage::Table>(&metadata, &dicts, 0, false);
   exp_result->resize(input_size);
 
   for (size_t row = 0; row < input_size; ++row) {
@@ -60,7 +60,7 @@ void ExpressionScan::executePlanOperation() {
   }
 
   std::vector<storage::atable_ptr_t> vc;
-  vc.push_back(std::const_pointer_cast<AbstractTable>(input.getTable(0)));
+  vc.push_back(std::const_pointer_cast<storage::AbstractTable>(input.getTable(0)));
   vc.push_back(exp_result);
 
   addResult(std::make_shared<const storage::MutableVerticalTable>(vc));

--- a/src/lib/access/GroupByScan.cpp
+++ b/src/lib/access/GroupByScan.cpp
@@ -74,15 +74,15 @@ void GroupByScan::executePlanOperation() {
   if ((_field_definition.size() != 0) && (input.numberOfHashTables() >= 1)) {
     if (_globalAggregation) {
       if (_field_definition.size() == 1) {
-        return executeGroupBy<SingleJoinHashTable, join_single_hash_map_t, join_single_key_t>();
+        return executeGroupBy<storage::SingleJoinHashTable, storage::join_single_hash_map_t, storage::join_single_key_t>();
       } else {
-        return executeGroupBy<JoinHashTable, join_hash_map_t, join_key_t>();
+        return executeGroupBy<storage::JoinHashTable, storage::join_hash_map_t, storage::join_key_t>();
       }
     }
     if (_field_definition.size() == 1) {
-      return executeGroupBy<SingleAggregateHashTable, aggregate_single_hash_map_t, aggregate_single_key_t>();
+      return executeGroupBy<storage::SingleAggregateHashTable, storage::aggregate_single_hash_map_t, storage::aggregate_single_key_t>();
     } else {
-      return executeGroupBy<AggregateHashTable, aggregate_hash_map_t, aggregate_key_t>();
+      return executeGroupBy<storage::AggregateHashTable, storage::aggregate_hash_map_t, storage::aggregate_key_t>();
     }
   } else {
     auto resultTab = createResultTableLayout();
@@ -126,17 +126,17 @@ const std::string GroupByScan::vname() {
 }
 
 storage::atable_ptr_t GroupByScan::createResultTableLayout() {
-  metadata_list  metadata;
-  std::vector<AbstractTable::SharedDictionaryPtr> dictionaries;
+  storage::metadata_list  metadata;
+  std::vector<storage::AbstractTable::SharedDictionaryPtr> dictionaries;
   //creating fields from grouping fields
   storage::atable_ptr_t group_tab = getInputTable(0)->copy_structure_modifiable(&_field_definition);
   //creating fields from aggregate functions
   for (const auto & fun: _aggregate_functions) {
-    ColumnMetadata *m = new ColumnMetadata(fun->columnName(), fun->getType());
+    auto m = new storage::ColumnMetadata(fun->columnName(), fun->getType());
     metadata.push_back(m);
-    dictionaries.push_back(storage::makeDictionary<OrderIndifferentDictionary>(fun->getType()));
+    dictionaries.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(fun->getType()));
   }
-  storage::atable_ptr_t agg_tab = std::make_shared<Table>(&metadata, &dictionaries, 0, false);
+  storage::atable_ptr_t agg_tab = std::make_shared<storage::Table>(&metadata, &dictionaries, 0, false);
 
   //Clean the metadata
   for (auto e : metadata)
@@ -165,9 +165,9 @@ void GroupByScan::splitInput() {
     auto r = distribute(hashTables[0]->numKeys(), _part, _count);
 
     if ((_indexed_field_definition.size() + _named_field_definition.size()) == 1)
-      input.setHash(std::dynamic_pointer_cast<const SingleAggregateHashTable>(hashTables[0])->view(r.first, r.second), 0);
+      input.setHash(std::dynamic_pointer_cast<const storage::SingleAggregateHashTable>(hashTables[0])->view(r.first, r.second), 0);
     else
-      input.setHash(std::dynamic_pointer_cast<const AggregateHashTable>(hashTables[0])->view(r.first, r.second), 0);
+      input.setHash(std::dynamic_pointer_cast<const storage::AggregateHashTable>(hashTables[0])->view(r.first, r.second), 0);
   } else if(_count > 0 && hashTables.empty()){
     ParallelizablePlanOperation::splitInput();
   }
@@ -204,7 +204,7 @@ void GroupByScan::executeGroupBy() {
     it1 = aggregateHashTable->getMapBegin();
     end = aggregateHashTable->getMapEnd();
   } else {
-    auto hashTableView = std::dynamic_pointer_cast<const HashTableView<MapType, KeyType> >(groupResults);
+    auto hashTableView = std::dynamic_pointer_cast<const storage::HashTableView<MapType, KeyType> >(groupResults);
     it1 = hashTableView->getMapBegin();
     end = hashTableView->getMapEnd();
   }

--- a/src/lib/access/HashBuild.cpp
+++ b/src/lib/access/HashBuild.cpp
@@ -22,14 +22,14 @@ void HashBuild::executePlanOperation() {
     row_offset = input->getStart();
   if (_key == "groupby" || _key == "selfjoin" ) {
     if (_field_definition.size() == 1)
-        addResult(std::make_shared<SingleAggregateHashTable>(getInputTable(), _field_definition, row_offset));
+        addResult(std::make_shared<storage::SingleAggregateHashTable>(getInputTable(), _field_definition, row_offset));
       else
-        addResult(std::make_shared<AggregateHashTable>(getInputTable(), _field_definition, row_offset));
+        addResult(std::make_shared<storage::AggregateHashTable>(getInputTable(), _field_definition, row_offset));
   } else if (_key == "join") {
     if (_field_definition.size() == 1)
-      addResult(std::make_shared<SingleJoinHashTable>(getInputTable(), _field_definition, row_offset));
+      addResult(std::make_shared<storage::SingleJoinHashTable>(getInputTable(), _field_definition, row_offset));
     else
-      addResult(std::make_shared<JoinHashTable>(getInputTable(), _field_definition, row_offset));
+      addResult(std::make_shared<storage::JoinHashTable>(getInputTable(), _field_definition, row_offset));
   } else {
     throw std::runtime_error("Type in Plan operation HashBuild not supported; key: " + _key);
   }

--- a/src/lib/access/HashJoinProbe.cpp
+++ b/src/lib/access/HashJoinProbe.cpp
@@ -33,14 +33,14 @@ void HashJoinProbe::executePlanOperation() {
 
   if (_selfjoin) {
     if (_field_definition.size() == 1)
-      fetchPositions<SingleAggregateHashTable>(buildTablePosList, probeTablePosList);
+      fetchPositions<storage::SingleAggregateHashTable>(buildTablePosList, probeTablePosList);
     else
-      fetchPositions<AggregateHashTable>(buildTablePosList, probeTablePosList);
+      fetchPositions<storage::AggregateHashTable>(buildTablePosList, probeTablePosList);
   } else {
     if (_field_definition.size() == 1)
-      fetchPositions<SingleJoinHashTable>(buildTablePosList, probeTablePosList);
+      fetchPositions<storage::SingleJoinHashTable>(buildTablePosList, probeTablePosList);
     else
-      fetchPositions<JoinHashTable>(buildTablePosList, probeTablePosList);
+      fetchPositions<storage::JoinHashTable>(buildTablePosList, probeTablePosList);
   }
 
   addResult(buildResultTable(buildTablePosList, probeTablePosList));
@@ -100,8 +100,8 @@ storage::atable_ptr_t HashJoinProbe::buildResultTable(storage::pos_list_t *build
                                                       storage::pos_list_t *probeTablePosList) const {
   std::vector<storage::atable_ptr_t> parts;
 
-  auto buildTableRows = PointerCalculator::create(getBuildTable(), buildTablePosList);
-  auto probeTableRows = PointerCalculator::create(getProbeTable(), probeTablePosList);
+  auto buildTableRows = storage::PointerCalculator::create(getBuildTable(), buildTablePosList);
+  auto probeTableRows = storage::PointerCalculator::create(getProbeTable(), probeTablePosList);
 
   parts.push_back(probeTableRows);
   parts.push_back(buildTableRows);

--- a/src/lib/access/HashValueJoin.hpp
+++ b/src/lib/access/HashValueJoin.hpp
@@ -43,8 +43,8 @@ class HashValueJoin : public PlanOperation {
     T value;
 
     // always use the smaller table as the 'build' table
-    hyrise::storage::c_atable_ptr_t build_table;
-    hyrise::storage::c_atable_ptr_t probe_table;
+    storage::c_atable_ptr_t build_table;
+    storage::c_atable_ptr_t probe_table;
     field_t build_field, probe_field;
     if (input.getTable(0)->size() <= input.getTable(1)->size()) {
       build_table = input.getTable(0);
@@ -87,8 +87,8 @@ class HashValueJoin : public PlanOperation {
     // if it's the build table or not
     std::vector<hyrise::storage::atable_ptr_t > parts;
     // FIXME: Worst stuff ever
-    auto build_pc = std::const_pointer_cast<AbstractTable>(std::dynamic_pointer_cast<const AbstractTable>(PointerCalculator::create(build_table, build_pos)));
-    auto probe_pc = std::const_pointer_cast<AbstractTable>(std::dynamic_pointer_cast<const AbstractTable>(PointerCalculator::create(probe_table, probe_pos)));
+    auto build_pc = std::const_pointer_cast<storage::AbstractTable>(std::dynamic_pointer_cast<const storage::AbstractTable>(storage::PointerCalculator::create(build_table, build_pos)));
+    auto probe_pc = std::const_pointer_cast<storage::AbstractTable>(std::dynamic_pointer_cast<const storage::AbstractTable>(storage::PointerCalculator::create(probe_table, probe_pos)));
     if (build_table == input.getTable(0)) {
       parts.push_back(build_pc);
       parts.push_back(probe_pc);

--- a/src/lib/access/InsertScan.cpp
+++ b/src/lib/access/InsertScan.cpp
@@ -58,7 +58,7 @@ storage::atable_ptr_t InsertScan::buildFromJson() {
     for(size_t c=0; c < col_count; ++c) {
       if (serialFields.count(c) != 0) {
         auto serial_name = std::to_string(tab->getUuid()) + "_" + tab->nameOfColumn(c);
-        auto k = res_man.get<Serial>(serial_name)->next();
+        auto k = res_man.get<storage::Serial>(serial_name)->next();
         _generatedKeys->push_back(k);
         result->setValue<hyrise_int_t>(c, r, k);
         ++offset;

--- a/src/lib/access/IntersectPositions.cpp
+++ b/src/lib/access/IntersectPositions.cpp
@@ -15,14 +15,14 @@ std::shared_ptr<PlanOperation> IntersectPositions::parse(const Json::Value&) {
 
 void IntersectPositions::executePlanOperation() {
   const auto& tables = input.getTables();
-  std::vector<std::shared_ptr<const PointerCalculator>> pcs(tables.size());
+  std::vector<std::shared_ptr<const storage::PointerCalculator>> pcs(tables.size());
   std::transform(begin(tables), end(tables),
                  begin(pcs),
                  [] (decltype(*begin(tables)) table) {
-                   return std::dynamic_pointer_cast<const PointerCalculator>(table);
+                   return std::dynamic_pointer_cast<const storage::PointerCalculator>(table);
                  });
   if (std::all_of(begin(pcs), end(pcs), [] (decltype(*begin(tables)) pc) { return pc != nullptr; })) {
-    addResult(PointerCalculator::intersect_many(begin(pcs), end(pcs)));
+    addResult(storage::PointerCalculator::intersect_many(begin(pcs), end(pcs)));
   } else {
     throw std::runtime_error(_planOperationName + " is only supported for PointerCalculators (IntersectPositions.cpp)");
   }

--- a/src/lib/access/LayoutTable.cpp
+++ b/src/lib/access/LayoutTable.cpp
@@ -32,7 +32,7 @@ void LayoutTable::executePlanOperation() {
   std::vector<storage::c_atable_ptr_t> tables { main, store->getDeltaTable() };
   
   // Call the Merge
-  TableMerger merger(new DefaultMergeStrategy(), new SequentialHeapMerger());
+  storage::TableMerger merger(new storage::DefaultMergeStrategy(), new storage::SequentialHeapMerger());
 
   // Switch the tables
   auto ntables = merger.mergeToTable(dest, tables);
@@ -49,18 +49,18 @@ const std::string LayoutTable::vname() {
   return "LayoutTable";
 }
 
-std::shared_ptr<AbstractTable> LayoutTable::createEmptyLayoutedTable(const std::string &layout) const {
+storage::atable_ptr_t LayoutTable::createEmptyLayoutedTable(const std::string &layout) const {
   // Prepare the new table by defining an empty input and load the
   // partitioning for the table from the string header
-  EmptyInput input;
-  StringHeader header(layout);
+  io::EmptyInput input;
+  io::StringHeader header(layout);
 
-  Loader::params p;
+  io::Loader::params p;
   p.setInput(input);
   p.setHeader(header);
   p.setReturnsMutableVerticalTable(true);
   p.setReferenceTable(this->input.getTable());
-  return Loader::load(p);
+  return io::Loader::load(p);
 }
 
 }

--- a/src/lib/access/LayoutTableLoad.cpp
+++ b/src/lib/access/LayoutTableLoad.cpp
@@ -43,10 +43,10 @@ void LayoutTableLoad::executePlanOperation() {
 
     std::string table_description = joinString(description_lines, "\n");
 
-    StringHeader header(table_description);
-    CSVInput input(_file_name, CSVInput::params().setCSVParams(csv::HYRISE_FORMAT));
-    StorageManager *sm = StorageManager::getInstance();
-    sm->loadTable(_table_name, Loader::params().setHeader(header).setInput(input));
+    io::StringHeader header(table_description);
+    io::CSVInput input(_file_name, io::CSVInput::params().setCSVParams(io::csv::HYRISE_FORMAT));
+    auto sm = io::StorageManager::getInstance();
+    sm->loadTable(_table_name, io::Loader::params().setHeader(header).setInput(input));
     addResult(sm->getTable(_table_name));
   } else {
     throw std::runtime_error("Input of LayoutTableLoad doesn't have at least one field to begin with");

--- a/src/lib/access/Layouter.cpp
+++ b/src/lib/access/Layouter.cpp
@@ -54,25 +54,25 @@ void LayoutSingleTable::executePlanOperation() {
   size = bl->count();
 
   storage::atable_ptr_t result;
-  metadata_list vc;
-  vc.push_back(ColumnMetadata::metadataFromString("STRING", "content"));
-  vc.push_back(ColumnMetadata::metadataFromString("INTEGER", "numResults"));
-  vc.push_back(ColumnMetadata::metadataFromString("FLOAT", "totalCost"));
-  vc.push_back(ColumnMetadata::metadataFromString("INTEGER", "numContainer"));
-  vc.push_back(ColumnMetadata::metadataFromString("FLOAT", "columnCost"));
-  vc.push_back(ColumnMetadata::metadataFromString("FLOAT", "rowCost"));
+  storage::metadata_list vc;
+  vc.push_back(storage::ColumnMetadata::metadataFromString("STRING", "content"));
+  vc.push_back(storage::ColumnMetadata::metadataFromString("INTEGER", "numResults"));
+  vc.push_back(storage::ColumnMetadata::metadataFromString("FLOAT", "totalCost"));
+  vc.push_back(storage::ColumnMetadata::metadataFromString("INTEGER", "numContainer"));
+  vc.push_back(storage::ColumnMetadata::metadataFromString("FLOAT", "columnCost"));
+  vc.push_back(storage::ColumnMetadata::metadataFromString("FLOAT", "rowCost"));
 
 
-  std::vector<AbstractTable::SharedDictionaryPtr > vd;
-  vd.push_back(storage::makeDictionary<OrderIndifferentDictionary>(StringType));
-  vd.push_back(storage::makeDictionary<OrderIndifferentDictionary>(IntegerType));
-  vd.push_back(storage::makeDictionary<OrderIndifferentDictionary>(FloatType));
-  vd.push_back(storage::makeDictionary<OrderIndifferentDictionary>(IntegerType));
-  vd.push_back(storage::makeDictionary<OrderIndifferentDictionary>(FloatType));
-  vd.push_back(storage::makeDictionary<OrderIndifferentDictionary>(FloatType));
+  std::vector<storage::AbstractTable::SharedDictionaryPtr > vd;
+  vd.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(StringType));
+  vd.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(IntegerType));
+  vd.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(FloatType));
+  vd.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(IntegerType));
+  vd.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(FloatType));
+  vd.push_back(storage::makeDictionary<storage::OrderIndifferentDictionary>(FloatType));
 
   // Allocate a new Table
-  result = std::make_shared<Table>(&vc, &vd, _maxResults, false);
+  result = std::make_shared<storage::Table>(&vc, &vd, _maxResults, false);
 
   result->resize(r.size());
   for (size_t i = 0; i < r.size(); ++i) {
@@ -99,7 +99,7 @@ void LayoutSingleTable::executePlanOperation() {
 }
 
 std::shared_ptr<PlanOperation> LayoutSingleTable::parse(const Json::Value &data) {
-  std::shared_ptr<LayoutSingleTable> s = std::make_shared<LayoutSingleTable>();
+  auto s = std::make_shared<LayoutSingleTable>();
   s->setNumRows(data["num_rows"].asUInt());
 
   if (data.isMember("layouter")) {

--- a/src/lib/access/MaterializingScan.cpp
+++ b/src/lib/access/MaterializingScan.cpp
@@ -47,7 +47,7 @@ void MaterializingScan::setupPlanOperation() {
 
 void MaterializingScan::executePlanOperation() {
   const auto& in = input.getTable(0);
-  auto result = std::dynamic_pointer_cast<Table>(in->copy_structure(nullptr, true, in->size(), false));
+  auto result = std::dynamic_pointer_cast<storage::Table>(in->copy_structure(nullptr, true, in->size(), false));
 
   if (_num_samples == 0) {
     result->resize(in->size());

--- a/src/lib/access/MergeHashTables.cpp
+++ b/src/lib/access/MergeHashTables.cpp
@@ -16,14 +16,14 @@ void MergeHashTables::executePlanOperation() {
   // get first HashTable and merge subsequent tables into HashTable
   if (_key == "groupby" || _key == "selfjoin" ) {
   	if (getInputHashTable(0)->getFieldCount() == 1)
-  		addResult(std::make_shared<SingleAggregateHashTable>(input.getHashTables()));
+  		addResult(std::make_shared<storage::SingleAggregateHashTable>(input.getHashTables()));
   	else
-  		addResult(std::make_shared<AggregateHashTable>(input.getHashTables()));
+  		addResult(std::make_shared<storage::AggregateHashTable>(input.getHashTables()));
   } else if (_key == "join") {
   	if (getInputHashTable(0)->getFieldCount() == 1)
-  		addResult(std::make_shared<SingleJoinHashTable>(input.getHashTables()));
+  		addResult(std::make_shared<storage::SingleJoinHashTable>(input.getHashTables()));
   	else
-  		addResult(std::make_shared<JoinHashTable>(input.getHashTables()));
+  		addResult(std::make_shared<storage::JoinHashTable>(input.getHashTables()));
   } else {
     throw std::runtime_error("Type in Plan operation HashBuild not supported; key: " + _key);
   }

--- a/src/lib/access/MergeJoin.hpp
+++ b/src/lib/access/MergeJoin.hpp
@@ -86,8 +86,8 @@ public:
     }
 
     std::vector<storage::atable_ptr_t> parts({
-      std::dynamic_pointer_cast<AbstractTable>(PointerCalculator::create(input.getTable(0), left_pos)),
-      std::dynamic_pointer_cast<AbstractTable>(PointerCalculator::create(input.getTable(1), right_pos))
+      std::dynamic_pointer_cast<storage::AbstractTable>(storage::PointerCalculator::create(input.getTable(0), left_pos)),
+      std::dynamic_pointer_cast<storage::AbstractTable>(storage::PointerCalculator::create(input.getTable(1), right_pos))
     });
 
     addResult(std::make_shared<storage::MutableVerticalTable>(parts));

--- a/src/lib/access/MergeTable.cpp
+++ b/src/lib/access/MergeTable.cpp
@@ -29,7 +29,7 @@ void MergeTable::executePlanOperation() {
   }
 
   // Call the Merge
-  TableMerger merger(new DefaultMergeStrategy(), new SequentialHeapMerger());
+  storage::TableMerger merger(new storage::DefaultMergeStrategy(), new storage::SequentialHeapMerger());
   auto new_table = input.getTable(0)->copy_structure();
 
   // Switch the tables

--- a/src/lib/access/MetaData.cpp
+++ b/src/lib/access/MetaData.cpp
@@ -20,7 +20,8 @@ namespace {
   auto _ = QueryParser::registerTrivialPlanOperation<MetaData>("MetaData");
 }
 
-size_t addEntriesForTableToResultTable(std::shared_ptr<const AbstractTable> table, std::string tableName, std::shared_ptr<AbstractTable> result, size_t row_count) {
+size_t addEntriesForTableToResultTable(std::shared_ptr<const storage::AbstractTable> table, std::string tableName,
+                                       std::shared_ptr<storage::AbstractTable> result, size_t row_count) {
   result->resize(result->size() + table->columnCount());
   for (field_t i = 0; i != table->columnCount(); ++i) {
     result->setValue<hyrise_string_t>(result->numberOfColumn("table"), row_count, tableName);
@@ -41,7 +42,7 @@ void MetaData::executePlanOperation() {
   auto meta_data = storage::TableBuilder::build(list);
 
   size_t row_count = 0;
-  const auto &storageManager = StorageManager::getInstance();
+  const auto &storageManager = io::StorageManager::getInstance();
   const auto& loaded_tables = storageManager->all();
 
   if (input.numberOfTables() == 0) {

--- a/src/lib/access/MultiplyRefField.cpp
+++ b/src/lib/access/MultiplyRefField.cpp
@@ -25,8 +25,8 @@ void MultiplyRefField::executeMultiply() {
   const auto &itab = getInputTable();
   const auto &mulTab = getInputTable(1);
 
-  std::vector<const ColumnMetadata*> meta {new ColumnMetadata("value", D), new ColumnMetadata("pos", IntegerType)};
-  auto result = std::make_shared<Table>(&meta, nullptr, stop * stopInner, false, false);
+  std::vector<const storage::ColumnMetadata*> meta {new storage::ColumnMetadata("value", D), new storage::ColumnMetadata("pos", IntegerType)};
+  auto result = std::make_shared<storage::Table>(&meta, nullptr, stop * stopInner, false, false);
   result->resize(stop * stopInner);
 
   // Pos list for matching Rows
@@ -44,7 +44,7 @@ void MultiplyRefField::executeMultiply() {
     }
   }
 
-  auto left = PointerCalculator::create(getInputTable(), pos);
+  auto left = storage::PointerCalculator::create(getInputTable(), pos);
 
   std::vector<storage::atable_ptr_t> vc({left, result});
   storage::atable_ptr_t tt = std::make_shared<storage::MutableVerticalTable>(vc);

--- a/src/lib/access/PosUpdateScan.cpp
+++ b/src/lib/access/PosUpdateScan.cpp
@@ -11,7 +11,6 @@
 
 #include "storage/Store.h"
 #include "storage/PointerCalculator.h"
-#include "storage/AbstractTable.h"
 #include "storage/meta_storage.h"
 
 
@@ -29,7 +28,7 @@ PosUpdateScan::~PosUpdateScan() {
 
 
 void PosUpdateScan::executePlanOperation() {
-  auto c_pc = checked_pointer_cast<const PointerCalculator>(input.getTable(0));
+  auto c_pc = checked_pointer_cast<const storage::PointerCalculator>(input.getTable(0));
   auto c_store = checked_pointer_cast<const storage::Store>(c_pc->getActualTable());
 
   // Cast the constness away

--- a/src/lib/access/ProjectionScan.cpp
+++ b/src/lib/access/ProjectionScan.cpp
@@ -33,7 +33,7 @@ void ProjectionScan::executePlanOperation() {
 
   // copy the field definition
   std::vector<field_t> *tmp_fd = new std::vector<field_t>(_field_definition);
-  addResult(PointerCalculator::create(input.getTable(0), pos_list, tmp_fd));
+  addResult(storage::PointerCalculator::create(input.getTable(0), pos_list, tmp_fd));
 }
 
 std::shared_ptr<PlanOperation> ProjectionScan::parse(const Json::Value &data) {

--- a/src/lib/access/SimpleRawTableScan.cpp
+++ b/src/lib/access/SimpleRawTableScan.cpp
@@ -69,19 +69,19 @@ void SimpleRawTableScan::setupPlanOperation() {
 }
 
 void SimpleRawTableScan::executePlanOperation() {
-  auto table = std::dynamic_pointer_cast<const RawTable>(input.getTable(0));
+  auto table = std::dynamic_pointer_cast<const storage::RawTable>(input.getTable(0));
   if (!table)
     throw std::runtime_error("Input table is no uncompressed raw table");
 
   // Prepare a result that contains the result semi-compressed, and only row-wise
-  metadata_list meta(table->columnCount());
+  storage::metadata_list meta(table->columnCount());
   for(size_t i=0; i<table->columnCount(); ++i)
     meta[i] = table->metadataAt(i);
-  auto result = std::make_shared<Table>(&meta,
-                                          nullptr,
-                                          1,  /* initial size */
-                                          false, /* sorted */
-                                          false /* compressed */);
+  auto result = std::make_shared<storage::Table>(&meta,
+                                                 nullptr,
+                                                 1,  /* initial size */
+                                                 false, /* sorted */
+                                                 false /* compressed */);
 
   // Prepare the copy operator
   storage::copy_value_functor_raw_table fun(result, table);
@@ -107,7 +107,7 @@ void SimpleRawTableScan::executePlanOperation() {
   if (_materializing) {
     addResult(result);
   } else {
-    addResult(PointerCalculator::create(table, positions));
+    addResult(storage::PointerCalculator::create(table, positions));
   }
 }
 

--- a/src/lib/access/SimpleTableScan.cpp
+++ b/src/lib/access/SimpleTableScan.cpp
@@ -38,7 +38,7 @@ void SimpleTableScan::executePositional() {
       pos_list->push_back(row);
     }
   }
-  addResult(PointerCalculator::create(tbl, pos_list));
+  addResult(storage::PointerCalculator::create(tbl, pos_list));
 }
 
 void SimpleTableScan::executeMaterialized() {

--- a/src/lib/access/SortScan.cpp
+++ b/src/lib/access/SortScan.cpp
@@ -95,7 +95,7 @@ void SortScan::executePlanOperation() {
   // When table is not only a table but also using an ordered dictionary on sort field,
   // we can just sort by value_id
   // TODO: fix Table<> template
-  auto base_table = std::dynamic_pointer_cast<const Table>(table);
+  auto base_table = std::dynamic_pointer_cast<const storage::Table>(table);
   if ((table->dictionaryAt(_sort_field)->isOrdered()) && (base_table)) {
     sorted_pos = ColumnSorter<ValueId, ExtractValueId>(table, _sort_field, asc).sort();
   } else {
@@ -117,7 +117,7 @@ void SortScan::executePlanOperation() {
   storage::atable_ptr_t result;
 
   if (producesPositions) {
-    result = PointerCalculator::create(table, sorted_pos);
+    result = storage::PointerCalculator::create(table, sorted_pos);
   } else {
     result = table->copy_structure_modifiable(nullptr, true);
     size_t result_row = 0;

--- a/src/lib/access/TableScan.cpp
+++ b/src/lib/access/TableScan.cpp
@@ -4,7 +4,6 @@
 #include "access/expressions/ExampleExpression.h"
 #include "access/expressions/pred_SimpleExpression.h"
 #include "access/expressions/ExpressionRegistration.h"
-#include "storage/AbstractTable.h"
 #include "storage/PointerCalculator.h"
 #include "storage/TableRangeView.h"
 #include "helper/types.h"
@@ -44,12 +43,12 @@ void TableScan::executePlanOperation() {
   else
     positions = new pos_list_t();
 
-  std::shared_ptr<PointerCalculator> result;
+  std::shared_ptr<storage::PointerCalculator> result;
 
   if(tablerange)
-    result = PointerCalculator::create(tablerange->getActualTable(), positions);
+    result = storage::PointerCalculator::create(tablerange->getActualTable(), positions);
   else
-    result = PointerCalculator::create(getInputTable(), positions);
+    result = storage::PointerCalculator::create(getInputTable(), positions);
 
   addResult(result);
 }

--- a/src/lib/access/UnionAll.cpp
+++ b/src/lib/access/UnionAll.cpp
@@ -10,21 +10,21 @@ namespace { auto _ = QueryParser::registerTrivialPlanOperation<UnionAll>("UnionA
 
 void UnionAll::executePlanOperation() {
   const auto& tables = input.getTables();
-  auto pcs = convert<const PointerCalculator>(tables);
+  auto pcs = convert<const storage::PointerCalculator>(tables);
   if (allValid(pcs)) {
-    addResult(PointerCalculator::concatenate_many(begin(pcs), end(pcs)));
+    addResult(storage::PointerCalculator::concatenate_many(begin(pcs), end(pcs)));
     return;
   }
 
   auto mtvs = convert<const storage::MutableVerticalTable>(tables);
   if (allValid(mtvs)) {
-    auto left_pcs = functional::collect(mtvs, [] (const std::shared_ptr<const storage::MutableVerticalTable>& mtv) { return std::dynamic_pointer_cast<const PointerCalculator>(mtv->getContainer(0)); });
-    auto right_pcs = functional::collect(mtvs, [] (const std::shared_ptr<const storage::MutableVerticalTable>& mtv) { return std::dynamic_pointer_cast<const PointerCalculator>(mtv->getContainer(1)); });
+    auto left_pcs = functional::collect(mtvs, [] (const std::shared_ptr<const storage::MutableVerticalTable>& mtv) { return std::dynamic_pointer_cast<const storage::PointerCalculator>(mtv->getContainer(0)); });
+    auto right_pcs = functional::collect(mtvs, [] (const std::shared_ptr<const storage::MutableVerticalTable>& mtv) { return std::dynamic_pointer_cast<const storage::PointerCalculator>(mtv->getContainer(1)); });
 
 
     if (allValid(left_pcs) && allValid(right_pcs)) {
-      auto l_concat = PointerCalculator::concatenate_many(std::begin(left_pcs), std::end(left_pcs));
-      auto r_concat = PointerCalculator::concatenate_many(std::begin(right_pcs), std::end(right_pcs));
+      auto l_concat = storage::PointerCalculator::concatenate_many(std::begin(left_pcs), std::end(left_pcs));
+      auto r_concat = storage::PointerCalculator::concatenate_many(std::begin(right_pcs), std::end(right_pcs));
       std::vector<storage::atable_ptr_t> pcs = {l_concat, r_concat};
       addResult(std::make_shared<storage::MutableVerticalTable>(pcs));
       return;

--- a/src/lib/access/UnionScan.cpp
+++ b/src/lib/access/UnionScan.cpp
@@ -15,14 +15,14 @@ auto _2 = QueryParser::registerTrivialPlanOperation<UnionScan>("Union");
 
 void UnionScan::executePlanOperation() {
   const auto& tables = input.getTables();
-  std::vector<std::shared_ptr<const PointerCalculator>> pcs(tables.size());
+  std::vector<std::shared_ptr<const storage::PointerCalculator>> pcs(tables.size());
   std::transform(begin(tables), end(tables),
                  begin(pcs),
                  [] (decltype(*begin(tables)) table) {
-                   return std::dynamic_pointer_cast<const PointerCalculator>(table);
+                   return std::dynamic_pointer_cast<const storage::PointerCalculator>(table);
                  });
   if (std::all_of(begin(pcs), end(pcs), [] (decltype(*begin(tables)) pc) { return pc != nullptr; })) {
-    addResult(PointerCalculator::unite_many(begin(pcs), end(pcs)));
+    addResult(storage::PointerCalculator::unite_many(begin(pcs), end(pcs)));
   } else {
     throw std::runtime_error(_planOperationName + " is only supported for PointerCalculators (UnionScan.cpp)");
     // We need to implement duplicate elimination here to make this a true union

--- a/src/lib/access/expressions/ExampleExpression.cpp
+++ b/src/lib/access/expressions/ExampleExpression.cpp
@@ -29,8 +29,8 @@ pos_list_t* ExampleExpression::match(const size_t start, const size_t stop) {
 void ExampleExpression::walk(const std::vector<hyrise::storage::c_atable_ptr_t> &tables) {
   _table = tables.at(0);
   const auto& avs = _table->getAttributeVectors(_column);
-  _vector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(avs.at(0).attribute_vector);
-  _dict = std::dynamic_pointer_cast<OrderPreservingDictionary<hyrise_int_t>>(_table->dictionaryAt(_column));
+  _vector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(avs.at(0).attribute_vector);
+  _dict = std::dynamic_pointer_cast<storage::OrderPreservingDictionary<hyrise_int_t>>(_table->dictionaryAt(_column));
   if (!(_vector && _dict)) throw std::runtime_error("Could not extract proper structures");
   _valueid = _dict->getValueIdForValue(_value);
 }

--- a/src/lib/access/expressions/ExampleExpression.h
+++ b/src/lib/access/expressions/ExampleExpression.h
@@ -14,8 +14,8 @@ namespace hyrise { namespace access {
 
 class ExampleExpression : public AbstractExpression {
   storage::c_atable_ptr_t _table;
-  std::shared_ptr<FixedLengthVector<value_id_t>> _vector;
-  std::shared_ptr<OrderPreservingDictionary<hyrise_int_t>> _dict;
+  std::shared_ptr<storage::FixedLengthVector<value_id_t>> _vector;
+  std::shared_ptr<storage::OrderPreservingDictionary<hyrise_int_t>> _dict;
   const size_t _column;
   const hyrise_int_t _value;
   value_id_t _valueid;
@@ -23,7 +23,7 @@ class ExampleExpression : public AbstractExpression {
   ExampleExpression(const size_t& column, const hyrise_int_t& value);
   bool operator()(const size_t& row);
   virtual pos_list_t* match(const size_t start, const size_t stop);
-  virtual void walk(const std::vector<hyrise::storage::c_atable_ptr_t> &l);
+  virtual void walk(const std::vector<storage::c_atable_ptr_t> &l);
   static std::unique_ptr<ExampleExpression> parse(const Json::Value& data);
 };
 

--- a/src/lib/access/expressions/GenericExpressions.inc
+++ b/src/lib/access/expressions/GenericExpressions.inc
@@ -17,8 +17,8 @@
 
 #define EXPRESSION_EXTRACT_AV_AND_OFFSET(r, data, name) \
 	const	auto& BOOST_PP_CAT(tmp, name) = _store->getAttributeVectors(name); \
-	BOOST_PP_CAT(_vector_,name) = hyrise::functional::collect(BOOST_PP_CAT(tmp, name), [](const attr_vector_offset_t& v) { return checked_pointer_cast<VectorType>(v.attribute_vector); }); \
-	BOOST_PP_CAT(_of_, name) = hyrise::functional::collect(BOOST_PP_CAT(tmp, name), [](const attr_vector_offset_t& v) { return v.attribute_offset; });
+	BOOST_PP_CAT(_vector_,name) = hyrise::functional::collect(BOOST_PP_CAT(tmp, name), [](const storage::attr_vector_offset_t& v) { return checked_pointer_cast<VectorType>(v.attribute_vector); }); \
+	BOOST_PP_CAT(_of_, name) = hyrise::functional::collect(BOOST_PP_CAT(tmp, name), [](const storage::attr_vector_offset_t& v) { return v.attribute_offset; });
 
 
 #define EXPR_DATA_VECTOR_NAME(name) BOOST_PP_CAT(_vector_, name)
@@ -103,7 +103,7 @@
 
 #define DEFINE_EXPRESSION_CLASS(name, seq_of_fields,seq_logic) \
 	class name : public AbstractExpression { \
-		using VectorType = AbstractFixedLengthVector<value_id_t>;\
+		using VectorType = storage::AbstractFixedLengthVector<value_id_t>;\
 		using SharedVectorType = std::shared_ptr<VectorType>;\
 		hyrise::storage::c_store_ptr_t _store;\
 		bool _with_delta=true;\

--- a/src/lib/access/expressions/expression_types.cpp
+++ b/src/lib/access/expressions/expression_types.cpp
@@ -3,6 +3,9 @@
 
 #include <stdexcept>
 
+namespace hyrise {
+namespace access {
+
 expression_map_t getExpressionMap() {
   expression_map_t d;
   d["AND"] = AND;
@@ -47,3 +50,6 @@ ExpressionType parseExpressionType(const Json::Value &value) {
   else if (value.isNumeric()) return (ExpressionType) value.asInt();
   else throw std::runtime_error("Expression '" + value.asString() + "' could not be parsed");
 }
+
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/expression_types.h
+++ b/src/lib/access/expressions/expression_types.h
@@ -1,11 +1,13 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_EXPRESSION_TYPES_H_
-#define SRC_LIB_ACCESS_EXPRESSION_TYPES_H_
+#pragma once
 
 #include <map>
 #include <string>
 
 #include <json.h>
+
+namespace hyrise {
+namespace access {
 
 enum ExpressionType { AND = 0, OR = 1, NOT = 2, EXP_EQ = 3 };
 
@@ -40,5 +42,5 @@ typedef std::map<std::string, ExpressionType> expression_map_t;
 PredicateType::type parsePredicateType(const Json::Value &value);
 ExpressionType parseExpressionType(const Json::Value &value);
 
+} } // namespace hyrise::access
 
-#endif  // SRC_LIB_ACCESS_EXPRESSION_TYPES_H_

--- a/src/lib/access/expressions/join_predicates.h
+++ b/src/lib/access/expressions/join_predicates.h
@@ -1,9 +1,11 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_JOIN_PREDICATES_H_
-#define SRC_LIB_ACCESS_JOIN_PREDICATES_H_
+#pragma once
 
 #include <helper/types.h>
 #include "expression_types.h"
+
+namespace hyrise {
+namespace access {
 
 /*
  * @brief Basice Join Expression like left.a == right.b
@@ -140,5 +142,5 @@ class EqualsJoinExpression : public JoinExpression {
   }
 };
 
+} } // namespace hyrise::access
 
-#endif  // SRC_LIB_ACCESS_JOIN_PREDICATES_H_

--- a/src/lib/access/expressions/pred_BetweenOperation.h
+++ b/src/lib/access/expressions/pred_BetweenOperation.h
@@ -1,9 +1,11 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-  #ifndef SRC_LIB_ACCESS_PRED_BETWEENOPERATION_H_
-#define SRC_LIB_ACCESS_PRED_BETWEENOPERATION_H_
+#pragma once
 
 #include "helper/types.h"
 #include "pred_common.h"
+
+namespace hyrise {
+namespace access {
 
 template <typename T>
 class BetweenExpression : public SimpleFieldExpression {
@@ -12,7 +14,7 @@ class BetweenExpression : public SimpleFieldExpression {
   ValueId upper_bound;
   T lower_value;
   T upper_value;
-  std::shared_ptr<BaseDictionary<T>> valueIdMap;
+  std::shared_ptr<storage::BaseDictionary<T>> valueIdMap;
   bool lower_value_exists;
   bool upper_value_exists;
  public:
@@ -32,7 +34,7 @@ class BetweenExpression : public SimpleFieldExpression {
   virtual void walk(const std::vector<hyrise::storage::c_atable_ptr_t > &l) {
     SimpleFieldExpression::walk(l);
 
-    valueIdMap = std::dynamic_pointer_cast<BaseDictionary<T>>(table->dictionaryAt(field));
+    valueIdMap = std::dynamic_pointer_cast<storage::BaseDictionary<T>>(table->dictionaryAt(field));
 
     lower_bound.table = 0;
     lower_bound.valueId = valueIdMap->getValueIdForValue(lower_value);
@@ -66,4 +68,6 @@ class BetweenExpression : public SimpleFieldExpression {
     return (value <= upper_value) && (value >= lower_value);
   }
 };
-#endif  // SRC_LIB_ACCESS_PRED_BETWEENOPERATION_H_
+
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/pred_CompoundExpression.h
+++ b/src/lib/access/expressions/pred_CompoundExpression.h
@@ -1,8 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_COMPOUNDEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_COMPOUNDEXPRESSION_H_
+#pragma once
 
 #include "pred_common.h"
+
+namespace hyrise {
+namespace access {
 
 class CompoundExpression : public SimpleExpression {
  private:
@@ -72,4 +74,5 @@ class CompoundExpression : public SimpleExpression {
   }
 };
 
-#endif  // SRC_LIB_ACCESS_PRED_COMPOUNDEXPRESSION_H_
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/pred_EqualsExpression.h
+++ b/src/lib/access/expressions/pred_EqualsExpression.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_EQUALSEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_EQUALSEXPRESSION_H_
+#pragma once
 
 #include "helper/types.h"
 
@@ -9,11 +8,14 @@
 // Required for Raw Table Scan
 #include <storage/RawTable.h>
 
+namespace hyrise {
+namespace access {
+
 template <typename T>
 class EqualsExpression : public SimpleFieldExpression {
  private:
   ValueId lower_bound;
-  std::shared_ptr<BaseDictionary<T>> valueIdMap;
+  std::shared_ptr<storage::BaseDictionary<T>> valueIdMap;
   bool value_exists;
 
  public:
@@ -34,7 +36,7 @@ class EqualsExpression : public SimpleFieldExpression {
 
   virtual void walk(const std::vector<hyrise::storage::c_atable_ptr_t > &l) {
     SimpleFieldExpression::walk(l);
-    valueIdMap = std::dynamic_pointer_cast<BaseDictionary<T>>(table->dictionaryAt(field));
+    valueIdMap = std::dynamic_pointer_cast<storage::BaseDictionary<T>>(table->dictionaryAt(field));
 
     value_exists = valueIdMap->valueExists(value);
 
@@ -76,9 +78,9 @@ class EqualsExpressionRaw : public SimpleFieldExpression {
   virtual ~EqualsExpressionRaw() { }
 
   inline virtual bool operator()(size_t row) {
-    return (std::dynamic_pointer_cast<const RawTable>(table))->template getValue<T>(field, row) == value;
+    return (std::dynamic_pointer_cast<const storage::RawTable>(table))->template getValue<T>(field, row) == value;
   }
 };
 
-#endif  // SRC_LIB_ACCESS_PRED_EQUALSEXPRESSION_H_
+} } // namespace hyrise::access
 

--- a/src/lib/access/expressions/pred_GreaterThanExpression.h
+++ b/src/lib/access/expressions/pred_GreaterThanExpression.h
@@ -1,15 +1,17 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_GREATERTHANEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_GREATERTHANEXPRESSION_H_
+#pragma once
 
 #include "pred_common.h"
+
+namespace hyrise {
+namespace access {
 
 template <typename T>
 class GreaterThanExpression : public SimpleFieldExpression {
  private:
   ValueId lower_bound;
   T value;
-  std::shared_ptr<BaseDictionary<T>> valueIdMap;
+  std::shared_ptr<storage::BaseDictionary<T>> valueIdMap;
   bool value_exists;
 
  public:
@@ -30,7 +32,7 @@ class GreaterThanExpression : public SimpleFieldExpression {
   virtual void walk(const std::vector<hyrise::storage::c_atable_ptr_t > &l) {
     SimpleFieldExpression::walk(l);
 
-    valueIdMap = std::dynamic_pointer_cast<BaseDictionary<T>>(table->dictionaryAt(field));
+    valueIdMap = std::dynamic_pointer_cast<storage::BaseDictionary<T>>(table->dictionaryAt(field));
     lower_bound.table = 0;
     lower_bound.valueId = valueIdMap->getValueIdForValue(value);
     value_exists = valueIdMap->isValueIdValid(lower_bound.valueId) &&
@@ -83,8 +85,9 @@ class GreaterThanExpressionRaw : public SimpleFieldExpression {
   virtual ~GreaterThanExpressionRaw() { }
 
   inline virtual bool operator()(size_t row) {
-    return (std::dynamic_pointer_cast<const RawTable>(table))->template getValue<T>(field, row) > value;
+    return (std::dynamic_pointer_cast<const storage::RawTable>(table))->template getValue<T>(field, row) > value;
   }
 };
 
-#endif  // SRC_LIB_ACCESS_PRED_GREATERTHANEXPRESSION_H_
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/pred_InExpression.h
+++ b/src/lib/access/expressions/pred_InExpression.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_INEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_INEXPRESSION_H_
+#pragma once
 
 #include "pred_common.h"
 #include <vector>
@@ -8,6 +7,9 @@
 #include <json.h>
 #include "../json_converters.h"
 #include "helper/stringhelpers.h"
+
+namespace hyrise {
+namespace access {
 
 ///
 /// IN Expression for comparing a column to multiple values
@@ -19,7 +21,6 @@
 ///     }
 /// This is equal to the mysql syntax: SELECT * FROM table WHERE quarter IN(2,3,4);
 ///
-
 template <typename T>
 class InExpression : public SimpleFieldExpression {
 public:
@@ -65,4 +66,5 @@ private:
   }
 };
 
-#endif  // SRC_LIB_ACCESS_PRED_INEXPRESSION_H_
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/pred_LessThanExpression.h
+++ b/src/lib/access/expressions/pred_LessThanExpression.h
@@ -1,15 +1,17 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_LESSTHANEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_LESSTHANEXPRESSION_H_
+#pragma once
 
 #include "pred_common.h"
+
+namespace hyrise {
+namespace access {
 
 template <typename T>
 class LessThanExpression : public SimpleFieldExpression {
  private:
   ValueId lower_bound;
   T value;
-  std::shared_ptr<BaseDictionary<T>> valueIdMap;
+  std::shared_ptr<storage::BaseDictionary<T>> valueIdMap;
   bool value_exists;
 
  public:
@@ -29,7 +31,7 @@ class LessThanExpression : public SimpleFieldExpression {
   virtual void walk(const std::vector<hyrise::storage::c_atable_ptr_t > &l) {
 
     SimpleFieldExpression::walk(l);
-    valueIdMap = std::dynamic_pointer_cast<BaseDictionary<T>>(table->dictionaryAt(field));
+    valueIdMap = std::dynamic_pointer_cast<storage::BaseDictionary<T>>(table->dictionaryAt(field));
     lower_bound.table = 0;
     lower_bound.valueId = valueIdMap->getValueIdForValue(value);
     value_exists = valueIdMap->isValueIdValid(lower_bound.valueId) && value == valueIdMap->getValueForValueId(lower_bound.valueId);
@@ -70,8 +72,9 @@ class LessThanExpressionRaw : public SimpleFieldExpression {
   virtual ~LessThanExpressionRaw() { }
 
   inline virtual bool operator()(size_t row) {
-    return (std::dynamic_pointer_cast<const RawTable>(table))->template getValue<T>(field, row) < value;
+    return (std::dynamic_pointer_cast<const storage::RawTable>(table))->template getValue<T>(field, row) < value;
   }
 };
 
-#endif  // SRC_LIB_ACCESS_PRED_LESSTHANEXPRESSION_H_
+} } // pragma once
+

--- a/src/lib/access/expressions/pred_LikeExpression.h
+++ b/src/lib/access/expressions/pred_LikeExpression.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_LIKEEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_LIKEEXPRESSION_H_
+#pragma once
 
 #include <boost/regex.hpp>
 
@@ -8,6 +7,8 @@
 #include <helper/types.h>
 #include <boost/regex.hpp>
 
+namespace hyrise {
+namespace access {
 
 /// LIKE expression for string comparison using regular expressions.
 
@@ -51,4 +52,5 @@ private:
   const boost::regex regExpr;
 };
 
-#endif // SRC_LIB_ACCESS_PRED_LIKEEXPRESSION_H_
+} } // namesapce hyrise::access
+

--- a/src/lib/access/expressions/pred_PredicateBuilder.cpp
+++ b/src/lib/access/expressions/pred_PredicateBuilder.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "pred_PredicateBuilder.h"
 
+namespace hyrise {
+namespace access {
+
 PredicateBuilder::PredicateBuilder(): root(nullptr) {
 }
 
@@ -33,3 +36,5 @@ void PredicateBuilder::add(CompoundExpression *e) {
 SimpleExpression *PredicateBuilder::build() {
   return root;
 }
+
+} } // namespace hyrise::access

--- a/src/lib/access/expressions/pred_PredicateBuilder.h
+++ b/src/lib/access/expressions/pred_PredicateBuilder.h
@@ -1,19 +1,20 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_PREDICATEBUILDER_H_
-#define SRC_LIB_ACCESS_PRED_PREDICATEBUILDER_H_
+#pragma once
 #include <stack>
 
 #include "pred_common.h"
 #include "pred_CompoundExpression.h"
 
-/*
+namespace hyrise {
+namespace access {
+
+/**
  * @brief Creates the predicate tree required for Selections
  *
  * All predicates both SimpleFieldExpression and CompoundExpression
  * have to be added in the correct execution order using prefix
  * notation.
  */
-
 class PredicateBuilder {
   std::stack<CompoundExpression *> previous;
   SimpleExpression *root;
@@ -26,4 +27,5 @@ class PredicateBuilder {
   SimpleExpression *build();
 };
 
-#endif  // SRC_LIB_ACCESS_PRED_PREDICATEBUILDER_H_
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/pred_SimpleExpression.h
+++ b/src/lib/access/expressions/pred_SimpleExpression.h
@@ -1,10 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_SIMPLEEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_SIMPLEEXPRESSION_H_
+#pragma once
 
 #include "storage/storage_types.h"
 #include "helper/types.h"
 #include "access/expressions/AbstractExpression.h"
+
+namespace hyrise {
+namespace access {
 
 class SimpleExpression : public hyrise::access::AbstractExpression {
  public:
@@ -25,5 +27,5 @@ class SimpleExpression : public hyrise::access::AbstractExpression {
   }
 };
 
+} } // namespace hyrise::access
 
-#endif  // SRC_LIB_ACCESS_PRED_SIMPLEEXPRESSION_H_

--- a/src/lib/access/expressions/pred_SimpleFieldExpression.h
+++ b/src/lib/access/expressions/pred_SimpleFieldExpression.h
@@ -1,9 +1,11 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_SIMPLEFIELDEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_SIMPLEFIELDEXPRESSION_H_
+#pragma once
 
 #include "helper/types.h"
 #include "pred_common.h"
+
+namespace hyrise {
+namespace access {
 
 class SimpleFieldExpression : public SimpleExpression {
  protected:
@@ -75,5 +77,5 @@ class GenericExpressionValue : public SimpleFieldExpression {
   }
 };
 
+} } // namespace hyrise::access
 
-#endif  // SRC_LIB_ACCESS_PRED_SIMPLEFIELDEXPRESSION_H_

--- a/src/lib/access/expressions/pred_buildExpression.cpp
+++ b/src/lib/access/expressions/pred_buildExpression.cpp
@@ -9,6 +9,9 @@
 #include "pred_expression_factory.h"
 #include "storage/meta_storage.h"
 
+namespace hyrise {
+namespace access {
+
 SimpleFieldExpression *buildFieldExpression(PredicateType::type pred_type, const Json::Value &predicate) {
   hyrise::storage::type_switch<hyrise_basic_types> ts;
   hyrise::access::expression_factory fun;
@@ -51,3 +54,6 @@ SimpleExpression *buildExpression(const Json::Value &predicates) {
   }
   return b.build();
 };
+
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/pred_buildExpression.h
+++ b/src/lib/access/expressions/pred_buildExpression.h
@@ -1,8 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_BUILDEXPRESSION_H_
-#define SRC_LIB_ACCESS_PRED_BUILDEXPRESSION_H_
+#pragma once
 
 #include "pred_common.h"
+
+namespace hyrise {
+namespace access {
 
 class ExpressionBuildError : public std::runtime_error {
  public:
@@ -12,4 +14,5 @@ class ExpressionBuildError : public std::runtime_error {
 SimpleFieldExpression *buildFieldExpression(PredicateType::type,const Json::Value &);
 SimpleExpression *buildExpression(const Json::Value &);
 
-#endif  // SRC_LIB_ACCESS_PRED_BUILDEXPRESSION_H_
+} } // namespace hyrise::access
+

--- a/src/lib/access/expressions/pred_common.h
+++ b/src/lib/access/expressions/pred_common.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_COMMON_H_
-#define SRC_LIB_ACCESS_PRED_COMMON_H_
+#pragma once
 
 #include <vector>
 #include <stdexcept>
@@ -18,7 +17,3 @@
 #include "pred_SimpleExpression.h"
 #include "pred_SimpleFieldExpression.h"
 
-
-
-
-#endif  // SRC_LIB_ACCESS_PRED_COMMON_H_

--- a/src/lib/access/expressions/pred_expression_factory.h
+++ b/src/lib/access/expressions/pred_expression_factory.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PRED_EXPRESSION_FACTORY_H_
-#define SRC_LIB_ACCESS_PRED_EXPRESSION_FACTORY_H_
+#pragma once
 
 #include "expression_types.h"
 #include "../json_converters.h"
@@ -92,7 +91,6 @@ struct expression_factory {
     }
   }
 };
-} /*ns access*/
-} /*ns hyrise*/
+} /*namespace access*/
+} /*namessace hyrise*/
 
-#endif  // SRC_LIB_ACCESS_PRED_EXPRESSION_FACTORY_H_

--- a/src/lib/access/expressions/predicates.h
+++ b/src/lib/access/expressions/predicates.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_PREDICATES_H_
-#define SRC_LIB_ACCESS_PREDICATES_H_
+#pragma once
 
 #include "pred_BetweenOperation.h"
 #include "pred_CompoundExpression.h"
@@ -16,6 +15,4 @@
 #include "pred_buildExpression.h"
 #include "pred_expression_factory.h"
 #include "pred_PredicateBuilder.h"
-
-#endif  // SRC_LIB_ACCESS_PREDICATES_H_
 

--- a/src/lib/access/radixjoin/Histogram.cpp
+++ b/src/lib/access/radixjoin/Histogram.cpp
@@ -76,9 +76,9 @@ uint32_t Histogram::significantOffset() const {
   return _significantOffset;
 }
 
-std::shared_ptr<Table> Histogram::createOutputTable(const size_t size) const {
-  std::vector<const ColumnMetadata*> meta {ColumnMetadata::metadataFromString(types::integer_t, "count")};
-  auto result = std::make_shared<Table>(&meta, nullptr, size, true, false);
+std::shared_ptr<storage::Table> Histogram::createOutputTable(const size_t size) const {
+  std::vector<const storage::ColumnMetadata*> meta {storage::ColumnMetadata::metadataFromString(types::integer_t, "count")};
+  auto result = std::make_shared<storage::Table>(&meta, nullptr, size, true, false);
   result->resize(size);
   for (auto* c: meta) delete c;
   return result;

--- a/src/lib/access/radixjoin/Histogram.h
+++ b/src/lib/access/radixjoin/Histogram.h
@@ -12,7 +12,7 @@ namespace hyrise {
 namespace access {
 
 // Extracts the AV from the table at given column
-template<typename Table, typename VectorType=FixedLengthVector<value_id_t>>
+template<typename Table, typename VectorType = storage::FixedLengthVector<value_id_t>>
 inline std::pair<std::shared_ptr<VectorType>, size_t> _getDataVector(const Table &tab,
                                                                      const size_t column = 0) {
   const auto &avs = tab->getAttributeVectors(column);
@@ -21,7 +21,7 @@ inline std::pair<std::shared_ptr<VectorType>, size_t> _getDataVector(const Table
   return {data, avs.at(0).attribute_offset};
 }
 
-template<typename VectorType=FixedLengthVector<value_id_t> >
+template<typename VectorType = storage::FixedLengthVector<value_id_t> >
 inline std::pair<std::shared_ptr<VectorType>, size_t> getDataVector(const storage::c_atable_ptr_t &tab,
                                                                     const size_t column = 0) {
   return _getDataVector<decltype(tab), VectorType>(tab, column);
@@ -53,7 +53,7 @@ public:
   uint32_t significantOffset() const;
 
 protected:
-  std::shared_ptr<Table> createOutputTable(const size_t size) const;
+  std::shared_ptr<storage::Table> createOutputTable(const size_t size) const;
 
   uint32_t _bits;
   uint32_t _significantOffset;
@@ -84,11 +84,11 @@ void Histogram::executeHistogram() {
   }
 
   // check if tab is PointerCalculator; if yes, get underlying table and actual rows and columns
-  auto p = std::dynamic_pointer_cast<const PointerCalculator>(tab);
+  auto p = std::dynamic_pointer_cast<const storage::PointerCalculator>(tab);
   if (p) {
     auto ipair = getDataVector(p->getActualTable(), p->getTableColumnForColumn(field));
     const auto &ivec = ipair.first;
-    const auto &dict = std::dynamic_pointer_cast<OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
+    const auto &dict = std::dynamic_pointer_cast<storage::OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
     const auto &offset = ipair.second;
 
     auto hasher = std::hash<T>();
@@ -102,11 +102,11 @@ void Histogram::executeHistogram() {
     auto mvt = std::dynamic_pointer_cast<const storage::MutableVerticalTable>(tab);
     if(mvt){
       auto pc = mvt->containerAt(field);
-      auto p = std::dynamic_pointer_cast<const PointerCalculator>(pc);
+      auto p = std::dynamic_pointer_cast<const storage::PointerCalculator>(pc);
       if(p){
         auto ipair = getDataVector(p->getActualTable(), p->getTableColumnForColumn(field));
         const auto &ivec = ipair.first;
-        const auto &dict = std::dynamic_pointer_cast<OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
+        const auto &dict = std::dynamic_pointer_cast<storage::OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
         const auto &offset = ipair.second;
 
         auto hasher = std::hash<T>();
@@ -121,7 +121,7 @@ void Histogram::executeHistogram() {
       // else; we expect a raw table
       auto ipair = getDataVector(tab, field);
       const auto &ivec = ipair.first;
-      const auto &dict = std::dynamic_pointer_cast<OrderPreservingDictionary<T>>(tab->dictionaryAt(field));
+      const auto &dict = std::dynamic_pointer_cast<storage::OrderPreservingDictionary<T>>(tab->dictionaryAt(field));
       const auto &offset =  ipair.second;
 
       auto hasher = std::hash<T>();

--- a/src/lib/access/radixjoin/NestedLoopEquiJoin.cpp
+++ b/src/lib/access/radixjoin/NestedLoopEquiJoin.cpp
@@ -30,22 +30,22 @@ void NestedLoopEquiJoin::executePlanOperation() {
 
   // cast down left hash table, first column contains hashes (value_id_t), second column contains pos_t
   const auto &lavs0 = hleft->getAttributeVectors(0);
-  const auto &lhvector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(lavs0.at(0).attribute_vector);
+  const auto &lhvector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(lavs0.at(0).attribute_vector);
   const auto &lavs1 = hleft->getAttributeVectors(1);
-  const auto &lpvector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(lavs1.at(0).attribute_vector);
+  const auto &lpvector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(lavs1.at(0).attribute_vector);
   // cast down left prefix sum table
   const auto &lavsp = pleft->getAttributeVectors(0);
-  const auto &lprefixvector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(lavsp.at(0).attribute_vector);
+  const auto &lprefixvector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(lavsp.at(0).attribute_vector);
   const size_t lprefixvector_size = lprefixvector->size();
 
   // cast down right hash table
   const auto &ravs0 = hright->getAttributeVectors(0);
-  const auto &rhvector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(ravs0.at(0).attribute_vector);
+  const auto &rhvector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(ravs0.at(0).attribute_vector);
   const auto &ravs1 = hright->getAttributeVectors(1);
-  const auto &rpvector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(ravs1.at(0).attribute_vector);
+  const auto &rpvector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(ravs1.at(0).attribute_vector);
   // cast down right first prefix sum table
   const auto &ravsp = pright->getAttributeVectors(0);
-  const auto &rprefixvector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(ravsp.at(0).attribute_vector);
+  const auto &rprefixvector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(ravsp.at(0).attribute_vector);
   const size_t rprefixvector_size = rprefixvector->size();
 
   // Prepare mask for right prefix sum
@@ -98,8 +98,8 @@ void NestedLoopEquiJoin::executePlanOperation() {
   }
 
   // if underlying table is pointer calc, get Actual Table as base for output pointer calc
-  const auto &rp = std::dynamic_pointer_cast<const PointerCalculator>(right);
-  const auto &lp = std::dynamic_pointer_cast<const PointerCalculator>(left);
+  const auto &rp = std::dynamic_pointer_cast<const storage::PointerCalculator>(right);
+  const auto &lp = std::dynamic_pointer_cast<const storage::PointerCalculator>(left);
 
   if(lp)
     left = lp->getActualTable();
@@ -107,8 +107,8 @@ void NestedLoopEquiJoin::executePlanOperation() {
     right = rp->getActualTable();
 
   // create PointerCalculator and pos_lists for output
-  auto loutput = PointerCalculator::create(left, lpos_list);
-  auto routput = PointerCalculator::create(right, rpos_list);
+  auto loutput = storage::PointerCalculator::create(left, lpos_list);
+  auto routput = storage::PointerCalculator::create(right, rpos_list);
 
   // build output table
   std::vector<storage::atable_ptr_t > vc;

--- a/src/lib/access/radixjoin/PrefixSum.cpp
+++ b/src/lib/access/radixjoin/PrefixSum.cpp
@@ -20,12 +20,12 @@ void PrefixSum::executePlanOperation() {
   const size_t table_size = in->size();
 
   // get attribute vector of output table
-  std::vector<const ColumnMetadata *> metadata;
+  std::vector<const storage::ColumnMetadata *> metadata;
   metadata.push_back(in->metadataAt(0));
-  auto output = std::make_shared<Table>(&metadata, nullptr, table_size, true, false);
+  auto output = std::make_shared<storage::Table>(&metadata, nullptr, table_size, true, false);
   output->resize(table_size);
   const auto &oavs = output->getAttributeVectors(0);
-  auto ovector = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(oavs.at(0).attribute_vector);
+  auto ovector = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(oavs.at(0).attribute_vector);
 
   // Build ivector list to avoid lock contention while getting the vectors
   const size_t ivec_size = input.numberOfTables();
@@ -94,13 +94,13 @@ void MergePrefixSum::executePlanOperation() {
   }
 
   const auto resultSize = getInputTable()->size();
-  std::vector<const ColumnMetadata *> meta {ColumnMetadata::metadataFromString(types::integer_t, "count")};
-  auto result = std::make_shared<Table>(&meta, nullptr, resultSize, true, false);
+  std::vector<const storage::ColumnMetadata *> meta {storage::ColumnMetadata::metadataFromString(types::integer_t, "count")};
+  auto result = std::make_shared<storage::Table>(&meta, nullptr, resultSize, true, false);
   result->resize(resultSize);
 
   const auto &res_vec = getDataVector(result).first;
 
-  std::vector<std::shared_ptr<FixedLengthVector<value_id_t>>> vecs;
+  std::vector<std::shared_ptr<storage::FixedLengthVector<value_id_t>>> vecs;
   for(size_t i=0, stop=input.numberOfTables(); i < stop; ++i) {
     vecs.emplace_back(getDataVector(getInputTable(i)).first);
   }

--- a/src/lib/access/radixjoin/PrefixSum.h
+++ b/src/lib/access/radixjoin/PrefixSum.h
@@ -17,7 +17,7 @@ public:
   void splitInput();
 
 private:
-  typedef std::shared_ptr<FixedLengthVector<storage::value_id_t>> vec_ref_t;
+  typedef std::shared_ptr<storage::FixedLengthVector<storage::value_id_t>> vec_ref_t;
   storage::value_id_t sumForIndex(const size_t ivec_size,
                                   const std::vector<vec_ref_t> &ivecs,
                                   const size_t index) const;

--- a/src/lib/access/radixjoin/RadixCluster.cpp
+++ b/src/lib/access/radixjoin/RadixCluster.cpp
@@ -18,14 +18,14 @@ void CreateRadixTable::executePlanOperation() {
   auto tableSize = getInputTable()->size();
 
   // Prepare output
-  std::vector<const ColumnMetadata*> meta1 {ColumnMetadata::metadataFromString(types::integer_t, "hash")};
-  std::vector<const ColumnMetadata*> meta2 {ColumnMetadata::metadataFromString(types::integer_t, "pos")};
+  std::vector<const storage::ColumnMetadata*> meta1 {storage::ColumnMetadata::metadataFromString(types::integer_t, "hash")};
+  std::vector<const storage::ColumnMetadata*> meta2 {storage::ColumnMetadata::metadataFromString(types::integer_t, "pos")};
 
   // Create the result tables
-  auto hashes = std::make_shared<Table>(&meta1, nullptr, tableSize, true, false);
+  auto hashes = std::make_shared<storage::Table>(&meta1, nullptr, tableSize, true, false);
   hashes->resize(tableSize);
 
-  auto positions = std::make_shared<Table>(&meta2, nullptr, tableSize, true, false);
+  auto positions = std::make_shared<storage::Table>(&meta2, nullptr, tableSize, true, false);
   positions->resize(tableSize);
 
   std::vector<storage::atable_ptr_t> tmp {hashes, positions};
@@ -132,7 +132,7 @@ void RadixCluster2ndPass::executePlanOperation() {
   // Get the prefix sum from the input
   const auto& in_data = getDataVector(getInputTable(2)).first;
 
-  auto prefix = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(in_data->copy());
+  auto prefix = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(in_data->copy());
 
   // Cast the vectors to the lowest part in the hierarchy
   auto data_hash = getDataVector(result).first;

--- a/src/lib/access/radixjoin/RadixCluster.h
+++ b/src/lib/access/radixjoin/RadixCluster.h
@@ -59,7 +59,7 @@ void RadixCluster::executeClustering() {
 
   // Get the prefix sum from the input
   const auto &prefix_sum = getInputTable(2);
-  const auto &data_prefix_sum = std::dynamic_pointer_cast<FixedLengthVector<value_id_t>>(getDataVector(prefix_sum).first->copy());
+  const auto &data_prefix_sum = std::dynamic_pointer_cast<storage::FixedLengthVector<value_id_t>>(getDataVector(prefix_sum).first->copy());
 
   // Prepare mask
   auto mask = ((1 << bits()) - 1) << significantOffset();
@@ -76,12 +76,12 @@ void RadixCluster::executeClustering() {
   }
 
   // check if tab is PointerCalculator; if yes, get underlying table and actual rows and columns
-  auto p = std::dynamic_pointer_cast<const PointerCalculator>(tab);
+  auto p = std::dynamic_pointer_cast<const storage::PointerCalculator>(tab);
   if (p) {
     auto ipair = getDataVector(p->getActualTable());
     const auto &ivec = ipair.first;
 
-    const auto &dict = std::dynamic_pointer_cast<OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
+    const auto &dict = std::dynamic_pointer_cast<storage::OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
     const auto &offset = p->getTableColumnForColumn(field) + ipair.second;
 
     auto hasher = std::hash<T>();
@@ -102,12 +102,12 @@ void RadixCluster::executeClustering() {
     if(mvt){
 
       auto pc = mvt->containerAt(field);
-      auto p = std::dynamic_pointer_cast<const PointerCalculator>(pc);
+      auto p = std::dynamic_pointer_cast<const storage::PointerCalculator>(pc);
       if(p){
         auto ipair = getDataVector(p->getActualTable());
         const auto &ivec = ipair.first;
 
-        const auto &dict = std::dynamic_pointer_cast<OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
+        const auto &dict = std::dynamic_pointer_cast<storage::OrderPreservingDictionary<T>>(tab->dictionaryAt(p->getTableColumnForColumn(field)));
         const auto &offset = p->getTableColumnForColumn(field) + ipair.second;
 
         auto hasher = std::hash<T>();
@@ -128,7 +128,7 @@ void RadixCluster::executeClustering() {
     } else {
       auto ipair = getDataVector(tab);
       const auto &ivec = ipair.first;
-      const auto &dict = std::dynamic_pointer_cast<OrderPreservingDictionary<T>>(tab->dictionaryAt(field));
+      const auto &dict = std::dynamic_pointer_cast<storage::OrderPreservingDictionary<T>>(tab->dictionaryAt(field));
       const auto &offset = field + ipair.second;
 
       std::hash<T> hasher;

--- a/src/lib/access/storage/GetTable.cpp
+++ b/src/lib/access/storage/GetTable.cpp
@@ -19,7 +19,7 @@ GetTable::~GetTable() {
 }
 
 void GetTable::executePlanOperation() {
-  output.add(StorageManager::getInstance()->getTable(_name));
+  output.add(io::StorageManager::getInstance()->getTable(_name));
 }
 
 std::shared_ptr<PlanOperation> GetTable::parse(const Json::Value& data) {

--- a/src/lib/access/storage/JsonTable.cpp
+++ b/src/lib/access/storage/JsonTable.cpp
@@ -75,7 +75,7 @@ void JsonTable::executePlanOperation() {
 	auto& res_man = io::ResourceManager::getInstance();
 	for(const auto& f : _serialFields) {
 		auto serial_name = std::to_string(result->getUuid()) + "_" + f;
-		res_man.add(serial_name, std::make_shared<Serial>());
+		res_man.add(serial_name, std::make_shared<storage::Serial>());
 	}
 
 	// Add the rows if any
@@ -103,7 +103,7 @@ void JsonTable::executePlanOperation() {
 			for(size_t j=0, rs = _names.size(); j < rs; ++j) {
 				if (std::find(_serialFields.begin(), _serialFields.end(), _names[j]) != _serialFields.end()) {
 					auto serial_name = std::to_string(result->getUuid()) + "_" + _names[j];
-					auto ser = res_man.get<Serial>(serial_name);
+					auto ser = res_man.get<storage::Serial>(serial_name);
 					result->setValue<hyrise_int_t>(j, i, ser->next());
 					offset++;
 				} else {

--- a/src/lib/access/storage/LoadFile.cpp
+++ b/src/lib/access/storage/LoadFile.cpp
@@ -22,7 +22,7 @@ LoadFile::~LoadFile() {
 }
 
 void LoadFile::executePlanOperation() {
-  output.add(Loader::shortcuts::load(StorageManager::getInstance()->makePath(_filename)));
+  output.add(io::Loader::shortcuts::load(io::StorageManager::getInstance()->makePath(_filename)));
 }
 
 std::shared_ptr<PlanOperation> LoadFile::parse(const Json::Value &data) {

--- a/src/lib/access/storage/MySQLTableLoad.cpp
+++ b/src/lib/access/storage/MySQLTableLoad.cpp
@@ -21,16 +21,16 @@ MySQLTableLoad::~MySQLTableLoad() {
 }
 
 void MySQLTableLoad::executePlanOperation() {
-  StorageManager *sm = StorageManager::getInstance();
+  auto sm = io::StorageManager::getInstance();
   storage::atable_ptr_t t;
   if (sm->exists(_table_name)) {
     t = sm->getTable(_table_name);
     addResult(t);
   } else {
-    t = Loader::load(
-          Loader::params().setInput(
-            MySQLInput(
-              MySQLInput::params()
+    t = io::Loader::load(
+          io::Loader::params().setInput(
+            io::MySQLInput(
+              io::MySQLInput::params()
               .setSchema(_database_name)
               .setTable(_table_name)
               .setLimit(_load_limit)

--- a/src/lib/access/storage/ReplaceTable.cpp
+++ b/src/lib/access/storage/ReplaceTable.cpp
@@ -22,7 +22,7 @@ void ReplaceTable::executePlanOperation() {
   auto table = input.getTable();
 
   // TODO: For now do the bad way, SM should have const tables
-  StorageManager::getInstance()->replaceTable(_name, std::const_pointer_cast<AbstractTable>(table));
+  io::StorageManager::getInstance()->replaceTable(_name, std::const_pointer_cast<storage::AbstractTable>(table));
   output.add(table);
 }
 

--- a/src/lib/access/storage/SetTable.cpp
+++ b/src/lib/access/storage/SetTable.cpp
@@ -21,7 +21,7 @@ SetTable::~SetTable() {
 void SetTable::executePlanOperation() {
   auto table = input.getTable();
   // TODO: For now do the bad way, SM should have const tables
-  StorageManager::getInstance()->loadTable(_name, std::const_pointer_cast<AbstractTable>(table));
+  io::StorageManager::getInstance()->loadTable(_name, std::const_pointer_cast<storage::AbstractTable>(table));
   output.add(table);
 }
 

--- a/src/lib/access/storage/TableIO.cpp
+++ b/src/lib/access/storage/TableIO.cpp
@@ -34,15 +34,15 @@ void DumpTable::executePlanOperation() {
 
 std::shared_ptr<PlanOperation> DumpTable::parse(const Json::Value& data) {
   const auto& pop = std::make_shared<DumpTable>();
-  pop->_name = data["name"].asString();
+  pop->_name = data["name"].asString(); 
   return pop;
 }
 
 void LoadDumpedTable::executePlanOperation() {
-  hyrise::storage::TableDumpLoader input(Settings::getInstance()->getDBPath(), _name);
-  CSVHeader header(Settings::getInstance()->getDBPath() + "/" + _name + "/header.dat", CSVHeader::params().setCSVParams(csv::HYRISE_FORMAT));
+  io::TableDumpLoader input(Settings::getInstance()->getDBPath(), _name);
+  io::CSVHeader header(Settings::getInstance()->getDBPath() + "/" + _name + "/header.dat", io::CSVHeader::params().setCSVParams(io::csv::HYRISE_FORMAT));
 
-  hyrise::storage::atable_ptr_t  t = Loader::load(Loader::params().setInput(input).setHeader(header));
+  auto t = io::Loader::load(io::Loader::params().setInput(input).setHeader(header));
   addResult(checked_pointer_cast<storage::Store>(t));
 }
 

--- a/src/lib/access/storage/TableLoad.cpp
+++ b/src/lib/access/storage/TableLoad.cpp
@@ -27,19 +27,19 @@ TableLoad::~TableLoad() {
 }
 
 void TableLoad::executePlanOperation() {
-  StorageManager *sm = StorageManager::getInstance();
+  auto sm = io::StorageManager::getInstance();
   if (!sm->exists(_table_name)) {
 
     // Load Raw Table
     if (_raw) {
-      Loader::params p;
-      p.setHeader(CSVHeader(_file_name));
+      io::Loader::params p;
+      p.setHeader(io::CSVHeader(_file_name));
       p.setInput(io::RawTableLoader(_file_name));
       sm->loadTable(_table_name, p);
 
     } else if (!_header_string.empty()) {
       // Load based on header string
-      Loader::params p = Loader::shortcuts::loadWithStringHeaderParams(_file_name, _header_string);
+      auto p = io::Loader::shortcuts::loadWithStringHeaderParams(_file_name, _header_string);
       sm->loadTable(_table_name, p);
 
     } else if (_header_file_name.empty()) {
@@ -48,13 +48,13 @@ void TableLoad::executePlanOperation() {
 
     } else if ((!_table_name.empty()) && (!_file_name.empty()) && (!_header_file_name.empty())) {
       // Load with dedicated header file
-      Loader::params p;
+      io::Loader::params p;
       p.setCompressed(false);
-      p.setHeader(CSVHeader(_header_file_name));
-      auto params = CSVInput::params().setUnsafe(_unsafe);
+      p.setHeader(io::CSVHeader(_header_file_name));
+      auto params = io::CSVInput::params().setUnsafe(_unsafe);
       if (_hasDelimiter)
-        params.setCSVParams(csv::params().setDelimiter(_delimiter.at(0)));
-      p.setInput(CSVInput(_file_name, params));
+        params.setCSVParams(io::csv::params().setDelimiter(_delimiter.at(0)));
+      p.setInput(io::CSVInput(_file_name, params));
       sm->loadTable(_table_name, p);
     }
 

--- a/src/lib/access/storage/TableUnload.cpp
+++ b/src/lib/access/storage/TableUnload.cpp
@@ -16,11 +16,11 @@ TableUnload::~TableUnload() {
 }
 
 void TableUnload::executePlanOperation() {
-  StorageManager::getInstance()->removeTable(_table_name);
+  io::StorageManager::getInstance()->removeTable(_table_name);
 }
 
 std::shared_ptr<PlanOperation> TableUnload::parse(const Json::Value &data) {
-  std::shared_ptr<TableUnload> s = std::make_shared<TableUnload>();
+  auto s = std::make_shared<TableUnload>();
   s->setTableName(data["table"].asString());
   return s;
 }

--- a/src/lib/access/storage/UnloadAll.cpp
+++ b/src/lib/access/storage/UnloadAll.cpp
@@ -16,7 +16,7 @@ UnloadAll::~UnloadAll() {
 }
 
 void UnloadAll::executePlanOperation() {
-  StorageManager::getInstance()->removeAll();
+  io::StorageManager::getInstance()->removeAll();
 }
 
 std::shared_ptr<PlanOperation> UnloadAll::parse(const Json::Value &data) {

--- a/src/lib/access/system/OperationData.cpp
+++ b/src/lib/access/system/OperationData.cpp
@@ -22,12 +22,12 @@ const OperationData::aresource_vec_t& OperationData::all() const {
 }
 
 table_list_t OperationData::getTables() const {
-  return allOf<AbstractTable>();
+  return allOf<storage::AbstractTable>();
 }
 
 
 hash_table_list_t OperationData::getHashTables() const {
-  return allOf<AbstractHashTable>();
+  return allOf<storage::AbstractHashTable>();
 }
 
 void OperationData::add(storage::c_atable_ptr_t input) {
@@ -51,19 +51,19 @@ void OperationData::setHash(storage::c_ahashtable_ptr_t input, size_t index) {
 }
 
 storage::c_atable_ptr_t OperationData::getTable(const size_t index) const {
-  return nthOf<AbstractTable>(index);
+  return nthOf<storage::AbstractTable>(index);
 }
 
 storage::c_ahashtable_ptr_t OperationData::getHashTable(const size_t index) const {
-  return nthOf<AbstractHashTable>(index);
+  return nthOf<storage::AbstractHashTable>(index);
 }
 
 size_t OperationData::numberOfTables() const {
-  return sizeOf<AbstractTable>();
+  return sizeOf<storage::AbstractTable>();
 }
 
 size_t OperationData::numberOfHashTables() const {
-  return sizeOf<AbstractHashTable>();
+  return sizeOf<storage::AbstractHashTable>();
 }
 
 bool OperationData::emptyTables() const {

--- a/src/lib/access/system/OutputTask.h
+++ b/src/lib/access/system/OutputTask.h
@@ -39,7 +39,7 @@ typedef struct {
 
 typedef std::vector<std::unique_ptr<performance_attributes_t>> performance_vector_t;
 
-class OutputTask : public Task {
+class OutputTask : public taskscheduler::Task {
  protected:
 
   performance_attributes_t *_performance_attr = nullptr;

--- a/src/lib/access/system/ParallelizablePlanOperation.cpp
+++ b/src/lib/access/system/ParallelizablePlanOperation.cpp
@@ -18,7 +18,7 @@ void ParallelizablePlanOperation::splitInput() {
   const auto& tables = input.getTables();
   if (_count > 0 && !tables.empty()) {
     auto r = distribute(tables[0]->size(), _part, _count);
-    input.setTable(storage::TableRangeView::create(std::const_pointer_cast<AbstractTable>(tables[0]), r.first, r.second), 0);
+    input.setTable(storage::TableRangeView::create(std::const_pointer_cast<storage::AbstractTable>(tables[0]), r.first, r.second), 0);
   }
 }
 

--- a/src/lib/access/system/QueryParser.cpp
+++ b/src/lib/access/system/QueryParser.cpp
@@ -17,10 +17,10 @@ QueryParser::~QueryParser() {
       delete t.second;
 }
 
-std::vector<std::shared_ptr<Task> > QueryParser::deserialize(
+std::vector<std::shared_ptr<taskscheduler::Task> > QueryParser::deserialize(
     const Json::Value& query,
-    std::shared_ptr<Task> *result) const {
-  std::vector<std::shared_ptr<Task> > tasks;
+    std::shared_ptr<taskscheduler::Task> *result) const {
+  std::vector<std::shared_ptr<taskscheduler::Task> > tasks;
   task_map_t task_map;
 
   buildTasks(query, tasks, task_map);
@@ -32,7 +32,7 @@ std::vector<std::shared_ptr<Task> > QueryParser::deserialize(
 
 void QueryParser::buildTasks(
     const Json::Value &query,
-    std::vector<std::shared_ptr<Task> > &tasks,
+    std::vector<std::shared_ptr<taskscheduler::Task> > &tasks,
     task_map_t &task_map) const {
   Json::Value::Members members = query["operators"].getMemberNames();
   std::string papiEventName = getPapiEventName(query);
@@ -68,7 +68,7 @@ void QueryParser::setInputs(
     const Json::Value &planOperationSpec) const {
   //  TODO: input implies table input at this moment
   for (unsigned j = 0; j < planOperationSpec["input"].size(); ++j) {
-    planOperation->addInput(StorageManager::getInstance()->getTable(
+    planOperation->addInput(io::StorageManager::getInstance()->getTable(
         planOperationSpec["input"][j].asString()));
   }
 }
@@ -98,18 +98,18 @@ void QueryParser::setDependencies(
     if (task_map.count(currentEdge[1u].asString()) == 0)
       throw std::runtime_error("Edege with operator name " + currentEdge[1u].asString() + " not found");
 
-    std::shared_ptr<Task> src = task_map[currentEdge[0u].asString()];
-    std::shared_ptr<Task> dst = task_map[currentEdge[1u].asString()];
+    auto src = task_map[currentEdge[0u].asString()];
+    auto dst = task_map[currentEdge[1u].asString()];
     if (src != dst) {
       dst->addDependency(src);
     }
   }
 }
 
-std::shared_ptr<Task>  QueryParser::getResultTask(
+std::shared_ptr<taskscheduler::Task>  QueryParser::getResultTask(
     const task_map_t &task_map) const {
-  std::map<Json::Value, std::shared_ptr<Task> >::const_iterator it;
-  std::shared_ptr<Task> currentTask, resultTask = nullptr;
+  std::map<Json::Value, std::shared_ptr<taskscheduler::Task> >::const_iterator it;
+  std::shared_ptr<taskscheduler::Task> currentTask, resultTask = nullptr;
 
   for (it = task_map.begin(); it != task_map.end(); ++it) {
     currentTask = it->second;

--- a/src/lib/access/system/QueryParser.h
+++ b/src/lib/access/system/QueryParser.h
@@ -15,9 +15,12 @@
 
 const std::string autojsonReferenceTableId = "-1";
 
+namespace hyrise {
+namespace taskscheduler {
 class Task;
+} // namespace taskscheduler
 
-namespace hyrise { namespace access {
+namespace access {
 
 class PlanOperation;
 
@@ -62,7 +65,7 @@ struct QueryParserFactory<T, default_construct> : public AbstractQueryParserFact
  */
 class QueryParser {
   typedef std::map< std::string, AbstractQueryParserFactory * > factory_map_t;
-  typedef std::map< Json::Value, std::shared_ptr<Task> > task_map_t;
+  typedef std::map< Json::Value, std::shared_ptr<taskscheduler::Task> > task_map_t;
 
   factory_map_t _factory;
   QueryParser();
@@ -71,7 +74,7 @@ class QueryParser {
       tasks and task_map for further processing. */
   void buildTasks(
       const Json::Value &query,
-      std::vector<std::shared_ptr<Task> > &tasks,
+      std::vector<std::shared_ptr<taskscheduler::Task> > &tasks,
       task_map_t &task_map) const;
 
   /*  Defines operations input based on their types.  */
@@ -90,7 +93,7 @@ class QueryParser {
       task_map_t &task_map) const;
 
   //  Output of task without successor is query's result.
-  std::shared_ptr<Task> getResultTask(
+  std::shared_ptr<taskscheduler::Task> getResultTask(
       const task_map_t &task_map) const;
 
  public:
@@ -123,9 +126,9 @@ class QueryParser {
   /*  Main method. Builds and returns executable PlanOperation tasks based on the
       query's specifications and constructs their dependency graph. The task
       delivering the final result will be determined, too.   */
-  std::vector<std::shared_ptr<Task> > deserialize(
+  std::vector<std::shared_ptr<taskscheduler::Task> > deserialize(
       const Json::Value& query,
-      std::shared_ptr<Task> *result) const;
+      std::shared_ptr<taskscheduler::Task> *result) const;
 };
 
 }}

--- a/src/lib/access/system/RequestParseTask.cpp
+++ b/src/lib/access/system/RequestParseTask.cpp
@@ -68,7 +68,7 @@ std::string hash(const std::string &v) {
 
 void RequestParseTask::operator()() {
   assert((_responseTask != nullptr) && "Response needs to be set");
-  const auto& scheduler = SharedScheduler::getInstance().getScheduler();
+  const auto& scheduler = taskscheduler::SharedScheduler::getInstance().getScheduler();
 
   performance_vector_t& performance_data = _responseTask->getPerformanceData();
 

--- a/src/lib/access/system/ResponseTask.cpp
+++ b/src/lib/access/system/ResponseTask.cpp
@@ -69,9 +69,9 @@ Json::Value generateRowsJsonT(const T& table, const size_t transmitLimit, const 
   return rows;
 }
 
-Json::Value generateRowsJson(const std::shared_ptr<const AbstractTable>& table,
+Json::Value generateRowsJson(const std::shared_ptr<const storage::AbstractTable>& table,
                              const size_t transmitLimit, const size_t transmitOffset) {
-  if (const auto& store = std::dynamic_pointer_cast<const hyrise::storage::SimpleStore>(table)) {
+  if (const auto& store = std::dynamic_pointer_cast<const storage::SimpleStore>(table)) {
     return generateRowsJsonT(store, transmitLimit, transmitOffset);
   } else {
     return generateRowsJsonT(table, transmitLimit, transmitOffset);

--- a/src/lib/access/system/ResponseTask.h
+++ b/src/lib/access/system/ResponseTask.h
@@ -15,7 +15,7 @@ namespace access {
 
 class PlanOperation;
 
-class ResponseTask : public Task {
+class ResponseTask : public taskscheduler::Task {
  private:
   net::AbstractConnection *connection;
 

--- a/src/lib/access/tx/ValidatePositions.cpp
+++ b/src/lib/access/tx/ValidatePositions.cpp
@@ -24,18 +24,18 @@ void ValidatePositions::executePlanOperation() {
 
     const auto& tab = checked_pointer_cast<const storage::Store>(getInputTable(0));
     auto pc = tab->buildValidPositions(_txContext.lastCid, _txContext.tid);
-    addResult(std::make_shared<PointerCalculator>(tab, new pos_list_t(std::move(pc))));
+    addResult(std::make_shared<storage::PointerCalculator>(tab, new pos_list_t(std::move(pc))));
 
   } else {
     // If it's no store it has to be a pointer calculator otherwise there is
     // no data structure to work with
-    const auto& tab = checked_pointer_cast<const PointerCalculator>(getInputTable(0));
+    const auto& tab = checked_pointer_cast<const storage::PointerCalculator>(getInputTable(0));
     const auto& store = tab->getActualTable();
-    auto pc = std::const_pointer_cast<PointerCalculator>(tab);
+    auto pc = std::const_pointer_cast<storage::PointerCalculator>(tab);
     pc->validate(_txContext.tid, _txContext.lastCid);
 
     // Get Modifications
-    const auto& modifications = hyrise::tx::TransactionManager::getInstance()[_txContext.tid];
+    const auto& modifications = tx::TransactionManager::getInstance()[_txContext.tid];
     if (modifications.hasDeleted(store))
       pc->remove(modifications.getDeleted(store));
     addResult(getInputTable(0));

--- a/src/lib/helper/ConfigFile.cpp
+++ b/src/lib/helper/ConfigFile.cpp
@@ -3,8 +3,6 @@
 
 #include "ConfigFile.h"
 
-
-
 ConfigFile::ConfigFile(std::string filename, std::string delimiter,
                        std::string comment, std::string sentry)
     : myDelimiter(delimiter), myComment(comment), mySentry(sentry) {
@@ -160,3 +158,4 @@ std::istream &operator>>(std::istream &is, ConfigFile &cf) {
 
   return is;
 }
+

--- a/src/lib/helper/ConfigFile.h
+++ b/src/lib/helper/ConfigFile.h
@@ -41,8 +41,7 @@
 //
 // See file example.cpp for more examples.
 
-#ifndef SRC_LIB_HELPER_CONFIGFILE_H_
-#define SRC_LIB_HELPER_CONFIGFILE_H_
+#pragma once
 
 #include <string>
 #include <map>
@@ -257,8 +256,6 @@ void ConfigFile::add(std::string key, const T &value) {
   myContents[key] = v;
   return;
 }
-
-#endif  // SRC_LIB_HELPER_CONFIGFILE_H_
 
 // Release notes:
 // v1.0  21 May 1999

--- a/src/lib/helper/Environment.cpp
+++ b/src/lib/helper/Environment.cpp
@@ -2,9 +2,9 @@
 #include "Environment.h"
 #include <stdlib.h>
 
-
 std::string getEnv(std::string var, std::string _default) {
   const char *value = getenv(var.c_str());
   if (value == nullptr) return _default;
   return value;
 }
+

--- a/src/lib/helper/Environment.h
+++ b/src/lib/helper/Environment.h
@@ -1,9 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_ENVIRONMENT_H_
-#define SRC_LIB_HELPER_ENVIRONMENT_H_
+#pragma once
 
 #include <string>
 
 std::string getEnv(std::string var, std::string _default);
 
-#endif  // SRC_LIB_HELPER_ENVIRONMENT_H_

--- a/src/lib/helper/HttpHelper.h
+++ b/src/lib/helper/HttpHelper.h
@@ -5,3 +5,4 @@
 std::map<std::string, std::string> parseHTTPFormData(std::string formData, const std::string elem_sep = "&");
 
 std::string urldecode(const std::string &input);
+

--- a/src/lib/helper/HwlocHelper.cpp
+++ b/src/lib/helper/HwlocHelper.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <memory>
+
 int getNumberOfCoresOnSystem(){
   hwloc_topology_t topology = getHWTopology();
   static int NUM_PROCS = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);

--- a/src/lib/helper/HwlocHelper.h
+++ b/src/lib/helper/HwlocHelper.h
@@ -6,8 +6,7 @@
  *      Author: jwust
  */
 
-#ifndef HWLOCHELPER_H_
-#define HWLOCHELPER_H_
+#pragma once
 
 #include <hwloc.h>
 #include <vector>
@@ -19,4 +18,3 @@ std::vector<unsigned> getCoresForNode(hwloc_topology_t topology, unsigned node);
 unsigned getNumberOfNodes(hwloc_topology_t topology);
 unsigned getNumberOfCoresPerNumaNode();
 
-#endif /* HWLOCHELPER_H_ */

--- a/src/lib/helper/MemoryHelper.h
+++ b/src/lib/helper/MemoryHelper.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_MEMORYHELPER_H_
-#define SRC_LIB_HELPER_MEMORYHELPER_H_
+#pragma once
 
 /* reallocs space and fills with value if needed */
 void *realloc_and_fill(size_t fill, void *pBuffer, size_t oldSize, size_t newSize) {
@@ -24,4 +23,3 @@ size_t round_to_8(size_t bits) {
   return bits;
 }
 
-#endif  // SRC_LIB_HELPER_MEMORYHELPER_H_

--- a/src/lib/helper/PapiTracer.h
+++ b/src/lib/helper/PapiTracer.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_PAPITRACER_H_
-#define SRC_LIB_HELPER_PAPITRACER_H_
+#pragma once
 
 #include <stdio.h>
 #include <sys/time.h>
@@ -194,5 +193,3 @@ typedef FallbackTracer PapiTracer;
 
 #endif
 
-
-#endif  // SRC_LIB_HELPER_PAPITRACER_H_

--- a/src/lib/helper/PositionsIntersect.h
+++ b/src/lib/helper/PositionsIntersect.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_POSITIONSINTERESECT_H_
-#define SRC_LIB_HELPER_POSITIONSINTERESECT_H_
+#pragma once
 
 #include <algorithm>
 #include <iterator>
@@ -76,4 +75,3 @@ void intersect_pos_list(IterT beg1, IterT end1, IterT beg2, IterT end2, OutputIt
   }
 }
 
-#endif

--- a/src/lib/helper/Progress.h
+++ b/src/lib/helper/Progress.h
@@ -1,7 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-
-#ifndef SRC_LIB_HELPER_PROGRESS_H_
-#define SRC_LIB_HELPER_PROGRESS_H_
+#pragma once
 
 
 class Progress {
@@ -43,5 +41,3 @@ class Progress {
 
 };
 
-
-#endif  // SRC_LIB_HELPER_PROGRESS_H_

--- a/src/lib/helper/RangeIter.h
+++ b/src/lib/helper/RangeIter.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_RANGEITER_H_
-#define SRC_LIB_HELPER_RANGEITER_H_
+#pragma once
 
 /// Range iterator to be used for numerical ranges
 ///
@@ -31,4 +30,3 @@ class RangeIter {
   }
 };
 
-#endif

--- a/src/lib/helper/RollingAverage.h
+++ b/src/lib/helper/RollingAverage.h
@@ -1,8 +1,7 @@
+// Copyright (c) 2013 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#pragma once
 
 #include <vector>
-
-#ifndef ROLLINGAVERAGE_H_
-#define ROLLINGAVERAGE_H_
 
 template <class T>
 class RollingAverage {
@@ -49,4 +48,3 @@ public:
 	}
 };
 
-#endif /* ROLLINGAVERAGE_H_ */

--- a/src/lib/helper/Settings.h
+++ b/src/lib/helper/Settings.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_SETTINGS_H_
-#define SRC_LIB_HELPER_SETTINGS_H_
+#pragma once
 
 #include <cstddef>
 #include <string>
@@ -40,6 +39,4 @@ class Settings {
   size_t getThreadpoolSize() const;
   void setThreadpoolSize(const size_t newSize);
 };
-
-#endif  // SRC_LIB_HELPER_SETTINGS_H_
 

--- a/src/lib/helper/SharedFactory.h
+++ b/src/lib/helper/SharedFactory.h
@@ -1,5 +1,4 @@
-#ifndef SRC_LIB_HELPER_SHAREDFACTORY_H
-#define SRC_LIB_HELPER_SHAREDFACTORY_H
+#pragma once
 
 #include <memory>
 
@@ -12,5 +11,3 @@ class SharedFactory : public std::enable_shared_from_this<T> {
   }
 };
 
-
-#endif

--- a/src/lib/helper/Synchronized.h
+++ b/src/lib/helper/Synchronized.h
@@ -1,5 +1,4 @@
-#ifndef SYNCHRONIZED_H_
-#define SYNCHRONIZED_H_
+#pragma once
 
 #include <memory>
 
@@ -24,4 +23,3 @@ struct Synchronized {
   Synchronized(Synchronized &&) = delete;
 };
 
-#endif

--- a/src/lib/helper/base.h
+++ b/src/lib/helper/base.h
@@ -1,2 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#pragma once
+
 #define WIDTH_PLUS_OFFSET(w) (w + 4)
+

--- a/src/lib/helper/cas.h
+++ b/src/lib/helper/cas.h
@@ -1,9 +1,7 @@
-#ifndef SRC_LIB_HELPER_CAS_H_
-#define SRC_LIB_HELPER_CAS_H_
+#pragma once
 
 template <typename T>
 inline bool atomic_cas(T* ptr, T oldV, T newV) {
 	return __sync_bool_compare_and_swap(ptr, oldV, newV);
 }
 
-#endif

--- a/src/lib/helper/checked_cast.h
+++ b/src/lib/helper/checked_cast.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_CHECKED_CAST_H_
-#define SRC_LIB_HELPER_CHECKED_CAST_H_
+#pragma once
 
 #include <memory>
 #include <stdexcept>
@@ -12,4 +11,3 @@ inline std::shared_ptr<T> checked_pointer_cast (const std::shared_ptr<U>& sp) {
   return result;
 }
 
-#endif

--- a/src/lib/helper/demangle.h
+++ b/src/lib/helper/demangle.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_DEMANGLE_H_
-#define SRC_LIB_HELPER_DEMANGLE_H_
+#pragma once
+
 const char *demangle(const char *name);
-#endif  // SRC_LIB_HELPER_DEMANGLE_H_
+

--- a/src/lib/helper/epoch.h
+++ b/src/lib/helper/epoch.h
@@ -1,10 +1,7 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-
-#ifndef SRC_LIB_HELPER_EPOCH_H_
-#define SRC_LIB_HELPER_EPOCH_H_
+#pragma once
 
 #include <stdint.h>
 typedef uint64_t epoch_t; // time in nanoseconds since some undefined starting point (use differences only)
 epoch_t get_epoch_nanoseconds();
 
-#endif  // SRC_LIB_HELPER_EPOCH_H_

--- a/src/lib/helper/fs.h
+++ b/src/lib/helper/fs.h
@@ -1,5 +1,4 @@
-#ifndef SRC_LIB_HELPER_FS_H_
-#define SRC_LIB_HELPER_FS_H_
+#pragma once
 
 #include <string>
 
@@ -7,6 +6,3 @@ namespace hyrise { namespace helper {
 	std::string sys_getcwd();
 }}
 
-
-
-#endif // SRC_LIB_HELPER_FS_H_

--- a/src/lib/helper/hash.h
+++ b/src/lib/helper/hash.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_HASH_H_
-#define SRC_LIB_HELPER_HASH_H_
+#pragma once
 
 #include <sys/types.h>
 
@@ -32,7 +31,3 @@
 u_int64_t
 fnv_64a_int(u_int64_t hash, u_int64_t integer, size_t size);
 
-
-
-
-#endif  // SRC_LIB_HELPER_HASH_H_

--- a/src/lib/helper/locking.h
+++ b/src/lib/helper/locking.h
@@ -1,5 +1,4 @@
-#ifndef SRC_LIB_HELPER_LOCKING_H_
-#define SRC_LIB_HELPER_LOCKING_H_
+#pragma once
 
 #include <thread>
 #include <atomic>
@@ -37,4 +36,3 @@ class Spinlock {
 
 }}
 
-#endif // SRC_LIB_HELPER_LOCKING_H_

--- a/src/lib/helper/make_unique.h
+++ b/src/lib/helper/make_unique.h
@@ -1,5 +1,4 @@
-#ifndef SRC_LIB_HELPER_MAKE_UNIQUE
-#define SRC_LIB_HELPER_MAKE_UNIQUE
+#pragma once
 
 #include <memory>
 #include <type_traits>
@@ -26,4 +25,3 @@ std::unique_ptr<T> make_unique(Args&&... args) {
   return make_unique_helper<T>(std::is_array<T>(), std::forward<Args>(args)...);
 }
 
-#endif 

--- a/src/lib/helper/noncopyable.h
+++ b/src/lib/helper/noncopyable.h
@@ -1,5 +1,4 @@
-#ifndef SRC_LIB_HELPER_NONCOPYABLE_H_
-#define SRC_LIB_HELPER_NONCOPYABLE_H_
+#pragma once
 
 /// Non-copyable baseclass, use to protect your class from copying
 class noncopyable {
@@ -9,4 +8,3 @@ class noncopyable {
   noncopyable& operator=( const noncopyable& ) = delete; // non copyable
 };
 
-#endif

--- a/src/lib/helper/not_implemented.h
+++ b/src/lib/helper/not_implemented.h
@@ -1,2 +1,3 @@
 #pragma once
+
 #define NOT_IMPLEMENTED throw std::runtime_error("not implemented");

--- a/src/lib/helper/numerical_converter.h
+++ b/src/lib/helper/numerical_converter.h
@@ -1,5 +1,4 @@
-#ifndef NUMERICAL_CONVERTER_H
-#define NUMERICAL_CONVERTER_H
+#pragma once
 
 #include "boost/optional.hpp"
 
@@ -34,4 +33,3 @@ boost::optional<toType> parseNumeric(const std::string& s) {
   return value;
 }
 
-#endif

--- a/src/lib/helper/parallel_sort.hpp
+++ b/src/lib/helper/parallel_sort.hpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_PARALLEL_SORT_HPP_
-#define SRC_LIB_HELPER_PARALLEL_SORT_HPP_
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,7 +9,6 @@
 #include <sys/time.h>
 #include <queue>
 #include <assert.h>
-
 
 
 template<class T, void(T::*mem_fn)(void *)>
@@ -299,4 +297,3 @@ class ParallelSort {
   }
 };
 
-#endif  // SRC_LIB_HELPER_PARALLEL_SORT_HPP_

--- a/src/lib/helper/prefetching.h
+++ b/src/lib/helper/prefetching.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_PREFETCHING_H_
-#define SRC_LIB_HELPER_PREFETCHING_H_
+#pragma once
 
 #include <stdint.h>
 
@@ -22,4 +21,3 @@ void prefetch_data_logic(int cpu);
 
 void prefetch_stream(int cpu);
 
-#endif  // SRC_LIB_HELPER_PREFETCHING_H_

--- a/src/lib/helper/sha1.h
+++ b/src/lib/helper/sha1.h
@@ -5,6 +5,7 @@
   By Steve Reid <steve@edmweb.com>
   100% Public Domain
 */
+#pragma once
 
 typedef struct {
   u_int32_t state[5];
@@ -16,3 +17,4 @@ void SHA1Transform(u_int32_t state[5], const unsigned char buffer[64]);
 void SHA1Init(SHA1_CTX *context);
 void SHA1Update(SHA1_CTX *context, const unsigned char *data, u_int32_t len);
 void SHA1Final(unsigned char digest[20], SHA1_CTX *context);
+

--- a/src/lib/helper/stringhelpers.h
+++ b/src/lib/helper/stringhelpers.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_STRINGHELPERS_H_
-#define SRC_LIB_HELPER_STRINGHELPERS_H_
+#pragma once
 
 #include <string>
 #include <sstream>
@@ -56,4 +55,3 @@ struct infix {
   }
 };
 
-#endif  // SRC_LIB_HELPER_STRINGHELPERS_H_

--- a/src/lib/helper/types.h
+++ b/src/lib/helper/types.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_HELPER_TYPES_H_
-#define SRC_LIB_HELPER_TYPES_H_
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -8,11 +7,13 @@
 #include <memory>
 #include <vector>
 
+namespace hyrise { namespace storage {
 class AbstractResource;
 class AbstractTable;
 class AbstractIndex;
 class AbstractHashTable;
 class AbstractDictionary;
+} } // namespace hyrise::storage
 
 
 class PointerCalculator;
@@ -101,6 +102,3 @@ static_assert(std::is_same<tx::transaction_id_t, storage::hyrise_int_t>::value,
               "transaction_id_t and hyrise_int_t need to be of the same type");
 }
 
-
-
-#endif

--- a/src/lib/helper/unique_id.cpp
+++ b/src/lib/helper/unique_id.cpp
@@ -23,3 +23,4 @@ string to_string(const unique_id& id) {
 }
 
 }
+

--- a/src/lib/helper/unique_id.h
+++ b/src/lib/helper/unique_id.h
@@ -1,5 +1,4 @@
-#ifndef HYRISE_UNIQUE_ID_H_
-#define HYRISE_UNIQUE_ID_H_
+#pragma once
 
 #include <cstdint>
 #include <array>
@@ -24,4 +23,3 @@ struct unique_id {
   type value;
 };
 
-#endif

--- a/src/lib/helper/vector_helpers.h
+++ b/src/lib/helper/vector_helpers.h
@@ -1,5 +1,4 @@
-#ifndef SRC_LIB_HELPERS_VECTOR_HELPERS_H_
-#define SRC_LIB_HELPERS_VECTOR_HELPERS_H_
+#pragma once
 
 #include <algorithm>
 #include <functional>
@@ -72,5 +71,3 @@ auto getOrDefault(const MapType& map, typename MapType::key_type key, typename M
   return def;
 }
 
-
-#endif

--- a/src/lib/io/AbstractLoader.cpp
+++ b/src/lib/io/AbstractLoader.cpp
@@ -1,5 +1,3 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "io/AbstractLoader.h"
 
-
-

--- a/src/lib/io/AbstractLoader.h
+++ b/src/lib/io/AbstractLoader.h
@@ -1,10 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_ABSTRACTLOADER_H_
-#define SRC_LIB_IO_ABSTRACTLOADER_H_
+#pragma once
 
 #include "io/Loader.h"
 #include "storage/storage_types.h"
 #include "helper/types.h"
+
+namespace hyrise {
+namespace io {
 
 class cloneable {
  public:
@@ -26,7 +28,9 @@ class AbstractInput : public cloneable {
     @param metadata The original metadata
     @param args Loader arguments that may influence loading
   */
-  virtual std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable> intable, const compound_metadata_list *metadata, const Loader::params &args) = 0;
+  virtual std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable> intable,
+                                                       const storage::compound_metadata_list *metadata,
+                                                       const Loader::params &args) = 0;
 
   virtual AbstractInput *clone() const = 0;
 
@@ -43,9 +47,9 @@ class AbstractHeader : public cloneable {
   /*! Construct metadata.
     @param args Loader arguments that may influence header creation
   */
-  virtual compound_metadata_list *load(const Loader::params &args) = 0;
+  virtual storage::compound_metadata_list *load(const Loader::params &args) = 0;
   virtual AbstractHeader *clone() const = 0;
 };
 
+} } // namesapce hyrise::io
 
-#endif  // SRC_LIB_IO_ABSTRACTLOADER_H_

--- a/src/lib/io/CSVLoader.cpp
+++ b/src/lib/io/CSVLoader.cpp
@@ -8,7 +8,8 @@
 #include "storage/AbstractTable.h"
 #include "storage/ColumnMetadata.h"
 
-
+namespace hyrise {
+namespace io {
 
 param_member_impl(CSVInput::params, csv::params, CSVParams);
 param_member_impl(CSVInput::params, bool, Unsafe);
@@ -19,7 +20,7 @@ struct cb_data {
   size_t column;
   const size_t table_columns;
   const bool unsafe;
-  std::shared_ptr<AbstractTable> table;
+  std::shared_ptr<storage::AbstractTable> table;
 
   cb_data(size_t columns, bool unsafe): row(0), column(0), table_columns(columns), unsafe(unsafe) {
   }
@@ -85,7 +86,7 @@ bool detectHeader(const std::string &filename) {
   return "===" == line;
 }
 
-std::shared_ptr<AbstractTable> CSVInput::load(std::shared_ptr<AbstractTable> intable, const compound_metadata_list *meta, const Loader::params &args) {
+std::shared_ptr<storage::AbstractTable> CSVInput::load(std::shared_ptr<storage::AbstractTable> intable, const storage::compound_metadata_list *meta, const Loader::params &args) {
   cb_data data(intable->columnCount(), _parameters.getUnsafe());
   data.table = intable;
   csv::params params(_parameters.getCSVParams());
@@ -117,7 +118,7 @@ CSVHeader *CSVHeader::clone() const {
   return new CSVHeader(*this);
 }
 
-compound_metadata_list *CSVHeader::load(const Loader::params &args) {
+storage::compound_metadata_list *CSVHeader::load(const Loader::params &args) {
   csv::params p(_parameters.getCSVParams());
   p.setLineCount(4);
   try {
@@ -128,3 +129,6 @@ compound_metadata_list *CSVHeader::load(const Loader::params &args) {
   }
 
 }
+
+} } // namespace hyrise::io
+

--- a/src/lib/io/CSVLoader.h
+++ b/src/lib/io/CSVLoader.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_CSVLOADER_H_
-#define SRC_LIB_IO_CSVLOADER_H_
+#pragma once
 
 #include <memory>
 
@@ -8,9 +7,8 @@
 #include "io/GenericCSV.h"
 #include "io/LoaderException.h"
 
-
-
-
+namespace hyrise {
+namespace io {
 
 bool detectHeader(const std::string &filename);
 
@@ -29,13 +27,12 @@ class CSVInput : public AbstractInput {
     params() : CSVParams(), Unsafe(false) {}
   };
 
-  CSVInput(std::string filename,
-           const params &parameters = params()) :
+  CSVInput(std::string filename, const params &parameters = params()) :
       _filename(filename),
       _parameters(parameters)
   {}
 
-  std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable>, const compound_metadata_list *, const Loader::params &args);
+  std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable>, const storage::compound_metadata_list *, const Loader::params &args);
 
   CSVInput *clone() const;
  private:
@@ -54,11 +51,12 @@ class CSVHeader : public AbstractHeader {
 
   CSVHeader(std::string filename, const params &parameters = params()) : _filename(filename), _parameters(parameters) {
   }
-  compound_metadata_list *load(const Loader::params &args);
+  storage::compound_metadata_list *load(const Loader::params &args);
   CSVHeader *clone() const;
  private:
   std::string _filename;
   params _parameters;
 };
 
-#endif  // SRC_LIB_IO_CSVLOADER_H_
+} } // namepsace hyrise::io
+

--- a/src/lib/io/ColumnLoader.h
+++ b/src/lib/io/ColumnLoader.h
@@ -1,8 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_COLUMNLOADER_H_
-#define SRC_LIB_IO_COLUMNLOADER_H_
+#pragma once
 
 #include "storage/AbstractTable.h"
+
+namespace hyrise {
+namespace io {
 
 class AbstractColumnLoader {
  public:
@@ -26,14 +28,14 @@ class ColumnLoader : public AbstractColumnLoader {
     _values.push_back(value);
   }
 
-  void write_to_table(AbstractTable *table, size_t column) {
+  void write_to_table(storage::AbstractTable *table, size_t column) {
 
     if (_values.size() == 0) {
       return;
     }
 
 
-    BaseDictionary<T> *dict = (BaseDictionary<T> *)table->dictionaryAt(column);
+    auto *dict = (storage::BaseDictionary<T> *)table->dictionaryAt(column);
 
     if (dict->isOrdered()) {
       // Create the sorted list for the input
@@ -67,4 +69,5 @@ class ColumnLoader : public AbstractColumnLoader {
   }
 };
 
-#endif  // SRC_LIB_IO_COLUMNLOADER_H_
+} } // namespace hyrise::io
+

--- a/src/lib/io/EmptyLoader.cpp
+++ b/src/lib/io/EmptyLoader.cpp
@@ -1,7 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "io/EmptyLoader.h"
 
-std::shared_ptr<AbstractTable> EmptyInput::load(std::shared_ptr<AbstractTable> table, const compound_metadata_list *t, const Loader::params &args) {
+namespace hyrise {
+namespace io {
+
+std::shared_ptr<storage::AbstractTable> EmptyInput::load(std::shared_ptr<storage::AbstractTable> table,
+                                                         const storage::compound_metadata_list *t,
+                                                         const Loader::params &args) {
   return table;
 }
 
@@ -9,11 +14,14 @@ EmptyInput *EmptyInput::clone() const {
   return new EmptyInput(*this);
 }
 
-compound_metadata_list *EmptyHeader::load(const Loader::params &args) {
-  compound_metadata_list *l = new compound_metadata_list();
+storage::compound_metadata_list *EmptyHeader::load(const Loader::params &args) {
+  auto *l = new storage::compound_metadata_list();
   return l;
 }
 
 EmptyHeader *EmptyHeader::clone() const {
   return new EmptyHeader(*this);
 }
+
+} } // namespace hyrise::io
+

--- a/src/lib/io/EmptyLoader.h
+++ b/src/lib/io/EmptyLoader.h
@@ -1,17 +1,19 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_EMPTYLOADER_H_
-#define SRC_LIB_IO_EMPTYLOADER_H_
+#pragma once
 
 #include <memory>
 
 #include "io/AbstractLoader.h"
+
+namespace hyrise {
+namespace io {
 
 class EmptyInput : public AbstractInput {
  public:
   EmptyInput() {
   }
   EmptyInput *clone() const;
-  std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable>, const compound_metadata_list *, const Loader::params &args);
+  std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable>, const storage::compound_metadata_list *, const Loader::params &args);
 };
 
 class EmptyHeader : public AbstractHeader {
@@ -19,8 +21,8 @@ class EmptyHeader : public AbstractHeader {
   EmptyHeader() {
   }
   EmptyHeader *clone() const;
-  compound_metadata_list *load(const Loader::params &args);
+  storage::compound_metadata_list *load(const Loader::params &args);
 };
 
+} } // namespace hyrise::io
 
-#endif  // SRC_LIB_IO_EMPTYLOADER_H_

--- a/src/lib/io/GenericCSV.cpp
+++ b/src/lib/io/GenericCSV.cpp
@@ -13,6 +13,8 @@
 #include <string.h>
 #include <libcsv/csv.h>
 
+namespace hyrise {
+namespace io {
 
 param_member_impl(csv::params, unsigned char, Delimiter);
 param_member_impl(csv::params, ssize_t, LineStart);
@@ -180,6 +182,5 @@ std::vector< line_t > parse_file(const std::string &filename, const params &para
   return data.lines;
 }
 
+} } } // namespace hyrise::io::csv
 
-
-}

--- a/src/lib/io/GenericCSV.h
+++ b/src/lib/io/GenericCSV.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_GENERICCSV_H_
-#define SRC_LIB_IO_GENERICCSV_H_
+#pragma once
 
 #include <iosfwd>
 #include <stdexcept>
@@ -11,8 +10,8 @@
 
 #include "storage/storage_types.h"
 
-
-
+namespace hyrise {
+namespace io {
 
 typedef std::vector<std::string> line_t;
 typedef void (*field_cb_t)(void *, size_t, void *);
@@ -70,7 +69,7 @@ void vector_cb_per_field(char *field_buffer, size_t field_length, struct vector_
 void vector_cb_per_line(int separator, struct vector_cb_data *data);
 
 
-} //ns csv
+} //namespace csv
 
+} } // namespace hyrise::io
 
-#endif  // SRC_LIB_IO_GENERICCSV_H_

--- a/src/lib/io/Loader.cpp
+++ b/src/lib/io/Loader.cpp
@@ -14,14 +14,15 @@
 #include "storage/TableGenerator.h"
 #include "storage/MutableVerticalTable.h"
 
-using namespace hyrise;
+namespace hyrise {
+namespace io {
 
 log4cxx::LoggerPtr logger(log4cxx::Logger::getLogger("hyrise.io.Loader"));
 
 param_ref_member_impl(Loader::params, AbstractInput, Input)
 param_ref_member_impl(Loader::params, AbstractHeader, Header)
 param_member_impl(Loader::params, std::string, BasePath)
-param_member_impl(Loader::params, AbstractTableFactory *, Factory)
+param_member_impl(Loader::params, storage::AbstractTableFactory *, Factory)
 param_member_impl(Loader::params, bool, ModifiableMutableVerticalTable)
 param_member_impl(Loader::params, bool, ReturnsMutableVerticalTable)
 param_member_impl(Loader::params, bool, Compressed)
@@ -84,9 +85,9 @@ Loader::params::~params() {
   if (Input != nullptr) delete Header;
 }
 
-std::shared_ptr<AbstractTable> Loader::load(const params &args) {
+std::shared_ptr<storage::AbstractTable> Loader::load(const params &args) {
   AbstractHeader *header = args.getHeader();
-  AbstractTableFactory *factory = args.getFactory();
+  auto *factory = args.getFactory();
   AbstractInput *input = args.getInput();
 
   //TODO avoid leakage
@@ -97,14 +98,14 @@ std::shared_ptr<AbstractTable> Loader::load(const params &args) {
     header = new EmptyHeader();
   }
   if (factory == nullptr) {
-    factory = new TableFactory();
+    factory = new storage::TableFactory();
   }
 
   LOG4CXX_DEBUG(logger, "Loading header");
-  compound_metadata_list *meta = header->load(args);
+  storage::compound_metadata_list *meta = header->load(args);
   LOG4CXX_DEBUG(logger, "Header done");
 
-  std::shared_ptr<AbstractTable>
+  std::shared_ptr<storage::AbstractTable>
   result, //initialize empty
       table = std::make_shared<storage::MutableVerticalTable>(*meta, nullptr, 0, false, factory, args.getCompressed());
 
@@ -132,7 +133,7 @@ std::shared_ptr<AbstractTable> Loader::load(const params &args) {
 
   if (!args.getModifiableMutableVerticalTable() && input->needs_store_wrap()) {
     auto s = std::make_shared<storage::Store>(result);
-    TableMerger *merger = new TableMerger(new DefaultMergeStrategy(), new SequentialHeapMerger(), args.getCompressed());
+    auto merger = new storage::TableMerger(new storage::DefaultMergeStrategy(), new storage::SequentialHeapMerger(), args.getCompressed());
     s->setMerger(merger);
     s->merge();
     result = s;
@@ -154,3 +155,6 @@ std::shared_ptr<AbstractTable> Loader::load(const params &args) {
 
   return result;
 }
+
+} } // namespace hyrise::io
+

--- a/src/lib/io/Loader.h
+++ b/src/lib/io/Loader.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_LOADER_H_
-#define SRC_LIB_IO_LOADER_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -9,10 +8,17 @@
 #include "storage/storage_types.h"
 
 
+namespace hyrise {
+
+namespace storage {
 class AbstractTable;
+class AbstractTableFactory;
+} // namespace storage
+
+namespace io {
 class AbstractInput;
 class AbstractHeader;
-class AbstractTableFactory;
+
 
 typedef struct {
   bool InsertOnly;
@@ -28,7 +34,7 @@ private:
   /// Header import
   param_ref_member(AbstractHeader, Header);
   /// Factory for tables
-  param_member(AbstractTableFactory *, Factory);
+  param_member(storage::AbstractTableFactory *, Factory);
   /// Base path for imports
   param_member(std::string, BasePath);
   /// Currently no effect:
@@ -38,7 +44,7 @@ private:
   /// Use bitcompressed table
   param_member(bool, Compressed);
   /// Reference table used for type detection
-  param_member(hyrise::storage::c_atable_ptr_t , ReferenceTable);
+  param_member(storage::c_atable_ptr_t , ReferenceTable);
 public:
   params();
   ~params();
@@ -47,7 +53,8 @@ public:
   params *clone() const;
 };
 
-std::shared_ptr<AbstractTable> load(const params &args);
+std::shared_ptr<storage::AbstractTable> load(const params &args);
 };
 
-#endif  // SRC_LIB_IO_LOADER_H_
+} } // namespace hyrise::io
+

--- a/src/lib/io/LoaderException.h
+++ b/src/lib/io/LoaderException.h
@@ -1,16 +1,18 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_LOADEREXCEPTION_H_
-#define SRC_LIB_IO_LOADEREXCEPTION_H_
+#pragma once
 
 #include <stdexcept>
 #include <string>
 
+namespace hyrise {
+namespace io {
 namespace Loader {
+
 class Error : public std::runtime_error {
  public:
   explicit Error(std::string msg) : std::runtime_error(msg)
   {}
 };
-}
 
-#endif  // SRC_LIB_IO_LOADEREXCEPTION_H_
+} } } // namespace hyrise::io::Loader
+

--- a/src/lib/io/MPassCSVLoader.cpp
+++ b/src/lib/io/MPassCSVLoader.cpp
@@ -22,14 +22,14 @@
 #include "storage/ColumnMetadata.h"
 #include "storage/meta_storage.h"
 
+namespace hyrise {
+namespace io {
+
 param_member_impl(MPassCSVInput::params, bool, Unsafe);
 
 #define LOAD_SIZE (4096 * 10)
 
-namespace hyrise {
-namespace io {
 namespace MPassLoader {
-
 
 struct parallel_data {
   void *vector;
@@ -107,11 +107,11 @@ struct cast_functor {
 struct do_load_functor {
   typedef void value_type;
 
-  std::shared_ptr<AbstractTable> table;
+  std::shared_ptr<storage::AbstractTable> table;
   parallel_data *data;
   size_t col;
 
-  do_load_functor(std::shared_ptr<AbstractTable> t, parallel_data *d, size_t c):
+  do_load_functor(std::shared_ptr<storage::AbstractTable> t, parallel_data *d, size_t c):
     table(t), data(d), col(c) {}
 
 
@@ -126,7 +126,7 @@ struct do_load_functor {
 for (auto e : *t)
       s.insert(e);
 
-    auto dict = std::make_shared<OrderPreservingDictionary<R>>();
+    auto dict = std::make_shared<storage::OrderPreservingDictionary<R>>();
 for (auto e : s)
       dict->addValue(e);
 
@@ -145,12 +145,10 @@ for (auto e : s)
 
 };
 
-}
-}
-}
+} // namespace MPassLoader
 
 
-void parallel_load(std::shared_ptr<AbstractTable> intable, size_t attr, std::string fn, hyrise::io::MPassLoader::parallel_data *data) {
+void parallel_load(std::shared_ptr<storage::AbstractTable> intable, size_t attr, std::string fn, MPassLoader::parallel_data *data) {
   int fp = open(fn.c_str(), O_RDONLY);
 
   if (fp == -1)
@@ -194,14 +192,14 @@ void parallel_load(std::shared_ptr<AbstractTable> intable, size_t attr, std::str
   free(data->buffer);
 }
 
-void pass2(std::shared_ptr<AbstractTable> intable, hyrise::io::MPassLoader::parallel_data *data, size_t attr) {
+void pass2(std::shared_ptr<storage::AbstractTable> intable, MPassLoader::parallel_data *data, size_t attr) {
   hyrise::storage::type_switch<hyrise_basic_types> global_ts;
   hyrise::io::MPassLoader::do_load_functor loader(intable, data, attr);
   global_ts(intable->typeOfColumn(attr), loader);
 }
 
 
-std::shared_ptr<AbstractTable> MPassCSVInput::load(std::shared_ptr<AbstractTable> intable, const compound_metadata_list *meta, const Loader::params &args) {
+std::shared_ptr<storage::AbstractTable> MPassCSVInput::load(std::shared_ptr<storage::AbstractTable> intable, const storage::compound_metadata_list *meta, const Loader::params &args) {
 
   std::vector<std::thread> kThreads(intable->columnCount());
   auto buckets = std::vector<hyrise::io::MPassLoader::parallel_data *>(intable->columnCount());
@@ -233,3 +231,6 @@ std::shared_ptr<AbstractTable> MPassCSVInput::load(std::shared_ptr<AbstractTable
 MPassCSVInput *MPassCSVInput::clone() const {
   return new MPassCSVInput(*this);
 }
+
+} } // namespace hyrise::io
+

--- a/src/lib/io/MPassCSVLoader.h
+++ b/src/lib/io/MPassCSVLoader.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_MPASSCSVLOADER_H_
-#define SRC_LIB_IO_MPASSCSVLOADER_H_
+#pragma once
 
 #include <memory>
 
@@ -9,8 +8,8 @@
 #include "GenericCSV.h"
 #include "CSVLoader.h"
 
-
-
+namespace hyrise {
+namespace io {
 
 class MPassCSVInput : public AbstractInput {
  public:
@@ -25,7 +24,7 @@ class MPassCSVInput : public AbstractInput {
       _parameters(parameters)
   {}
 
-  std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable>, const compound_metadata_list *, const Loader::params &args);
+  std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable>, const storage::compound_metadata_list *, const Loader::params &args);
 
   bool needs_store_wrap() {
     return false;
@@ -37,5 +36,5 @@ class MPassCSVInput : public AbstractInput {
   params _parameters;
 };
 
+} } // namespace hyrise::io
 
-#endif  // SRC_LIB_IO_MPASSCSVLOADER_H_

--- a/src/lib/io/MetadataCreation.cpp
+++ b/src/lib/io/MetadataCreation.cpp
@@ -6,6 +6,9 @@
 #include "storage/AbstractTable.h"
 #include "storage/ColumnMetadata.h"
 
+namespace hyrise {
+namespace io {
+
 const std::string RowType = "R";
 const std::string ColType = "C";
 const std::string TypeSeparator = "_";
@@ -22,8 +25,8 @@ void checkTypePartErrors(const std::vector<std::string> &type_parts, const std::
 
 typedef std::vector<std::string> line_t;
 
-compound_metadata_list *createMetadata(const std::vector<std::vector<std::string> > &lines,
-                                       hyrise::storage::c_atable_ptr_t tab) {
+storage::compound_metadata_list *createMetadata(const std::vector<std::vector<std::string> > &lines,
+                                                storage::c_atable_ptr_t tab) {
   line_t names(lines[0]);
   line_t types(lines[1]);
   line_t structure(lines[2]);
@@ -34,8 +37,8 @@ compound_metadata_list *createMetadata(const std::vector<std::vector<std::string
   }
 
   int last_part = 0;
-  metadata_list *current = new metadata_list();
-  std::vector<metadata_list * > *result = new std::vector<metadata_list *>();
+  auto *current = new storage::metadata_list();
+  auto *result = new std::vector<storage::metadata_list *>();
   for (size_t i = 0; i < names.size(); ++i) {
     std::vector<std::string> type_parts;
     splitString(type_parts, structure[i], TypeSeparator);
@@ -45,15 +48,15 @@ compound_metadata_list *createMetadata(const std::vector<std::vector<std::string
 
     if (part != last_part && current->size() > 0) {
       result->push_back(current);
-      current = new metadata_list();
+      current = new storage::metadata_list();
       last_part = part;
     }
 
-    ColumnMetadata *metadata;
+    storage::ColumnMetadata *metadata;
     if (tab == nullptr)
-      metadata = ColumnMetadata::metadataFromString(types[i], names[i]);
+      metadata = storage::ColumnMetadata::metadataFromString(types[i], names[i]);
     else
-      metadata = new ColumnMetadata(names[i], tab->typeOfColumn(tab->numberOfColumn(names[i])));
+      metadata = new storage::ColumnMetadata(names[i], tab->typeOfColumn(tab->numberOfColumn(names[i])));
 
     current->push_back(metadata);
   }
@@ -65,4 +68,5 @@ compound_metadata_list *createMetadata(const std::vector<std::vector<std::string
   return result;
 }
 
+} } // namespace hyrise::io
 

--- a/src/lib/io/MetadataCreation.h
+++ b/src/lib/io/MetadataCreation.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_METADATACREATION_H_
-#define SRC_LIB_IO_METADATACREATION_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -10,8 +9,12 @@
 #include "io/LoaderException.h"
 #include "storage/storage_types.h"
 
-
+namespace hyrise {
+namespace storage {
 class AbstractTable;
+} // namespace storage
+
+namespace io {
 
 class MetadataCreationError : public Loader::Error {
  public:
@@ -22,7 +25,8 @@ class MetadataCreationError : public Loader::Error {
 /**
  * Transforms a nested std::vector<std::vector<std::string> > into metadata vector
  **/
-compound_metadata_list *createMetadata(const std::vector<std::vector<std::string> > &lines,
-                                       hyrise::storage::c_atable_ptr_t tab = std::shared_ptr<const AbstractTable>());
+storage::compound_metadata_list *createMetadata(const std::vector<std::vector<std::string> > &lines,
+                                                storage::c_atable_ptr_t tab = nullptr);
 
-#endif  // SRC_LIB_IO_METADATACREATION_H_
+} } // namespace hyrise::io
+

--- a/src/lib/io/MySQLLoader.cpp
+++ b/src/lib/io/MySQLLoader.cpp
@@ -19,6 +19,9 @@
 #include "storage/storage_types.h"
 #include "storage/TableBuilder.h"
 
+namespace hyrise {
+namespace io {
+
 param_member_impl(MySQLInput::params, std::string, Host);
 param_member_impl(MySQLInput::params, std::string, Port);
 param_member_impl(MySQLInput::params, std::string, User);
@@ -43,31 +46,31 @@ using namespace boost::assign;
   * sql::ResultSet* column access is 1-based, thus all accesses should use col+1
   */
 
-typedef void (*conversion_func)(MYSQL_ROW *, size_t, size_t, AbstractTable *);
+typedef void (*conversion_func)(MYSQL_ROW *, size_t, size_t, storage::AbstractTable *);
 
-void var_to_string(MYSQL_ROW *r, size_t col, size_t row, AbstractTable *t) {
+void var_to_string(MYSQL_ROW *r, size_t col, size_t row, storage::AbstractTable *t) {
   if ((*r)[col] == 0)
     t->setValue<hyrise_string_t>(col, row, "");
   else
     t->setValue<hyrise_string_t>(col, row, std::string((const char *)(*r)[col]));
 }
 
-void bigint_to_integer(MYSQL_ROW *r, size_t col, size_t row, AbstractTable *t) {
+void bigint_to_integer(MYSQL_ROW *r, size_t col, size_t row, storage::AbstractTable *t) {
   hyrise_int_t data = (*r)[col] == 0 ? 0 : atoll((*r)[col]);
   t->setValue<hyrise_int_t>(col, row, data);
 }
 
-void int_to_integer(MYSQL_ROW *r, size_t col, size_t row, AbstractTable *t) {
+void int_to_integer(MYSQL_ROW *r, size_t col, size_t row, storage::AbstractTable *t) {
   hyrise_int_t data = (*r)[col] == 0 ? 0 : atoi((*r)[col]);
   t->setValue<hyrise_int_t>(col, row, data);
 }
 
-void double_to_float(MYSQL_ROW *r, size_t col, size_t row, AbstractTable *t) {
+void double_to_float(MYSQL_ROW *r, size_t col, size_t row, storage::AbstractTable *t) {
   hyrise_float_t data = (*r)[col] == 0 ? 0 : atof((*r)[col]);
   t->setValue<hyrise_float_t>(col, row, data);
 }
 
-void date_to_int(MYSQL_ROW *r, size_t col, size_t row, AbstractTable *t) {
+void date_to_int(MYSQL_ROW *r, size_t col, size_t row, storage::AbstractTable *t) {
   // Replace dashes with nothing and we have the int
   if ((*r)[col] == 0)
     t->setValue<hyrise_int_t>(col, row, 1);// std::stoll(s));
@@ -95,10 +98,10 @@ std::map<std::string, std::pair<hyrise::types::type_t, conversion_func> > transl
     ("time",     make_pair(hyrise::types::string_t, var_to_string))
     ("datetime", make_pair(hyrise::types::string_t, var_to_string));
 
-std::shared_ptr<AbstractTable> MySQLInput::load(
-    std::shared_ptr<AbstractTable> intable,
-    const compound_metadata_list *meta,
-    const Loader::params &args) {
+std::shared_ptr<storage::AbstractTable> MySQLInput::load(
+    std::shared_ptr<storage::AbstractTable> intable,
+    const storage::compound_metadata_list *meta,
+    const io::Loader::params &args) {
 
 
   /** Initialize the MySQL connection with the parameters given to the
@@ -166,5 +169,7 @@ std::shared_ptr<AbstractTable> MySQLInput::load(
 MySQLInput *MySQLInput::clone() const {
   return new MySQLInput(*this);
 }
+
+} } // namespace hyrise::io
 
 #endif

--- a/src/lib/io/MySQLLoader.h
+++ b/src/lib/io/MySQLLoader.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_MYSQLLOADER_H_
-#define SRC_LIB_IO_MYSQLLOADER_H_
+#pragma once
 
 #ifdef WITH_MYSQL
 
@@ -8,6 +7,9 @@
 
 #include "helper/Environment.h"
 #include "io/AbstractLoader.h"
+
+namespace hyrise {
+namespace io {
 
 const std::string ENV_MYSQL_HOST = "HYRISE_MYSQL_HOST";
 const std::string ENV_MYSQL_PORT = "HYRISE_MYSQL_PORT";
@@ -38,7 +40,9 @@ public:
     _parameters(parameters)
   {}
 
-  std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable>, const compound_metadata_list *, const Loader::params &args);
+  std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable>,
+                                               const storage::compound_metadata_list *,
+                                               const io::Loader::params &args);
 
   MySQLInput *clone() const;
 
@@ -46,6 +50,7 @@ private:
   params _parameters;
 };
 
+} } // namespace hyrise::io
+
 #endif
 
-#endif  // SRC_LIB_IO_MYSQLLOADER_H_

--- a/src/lib/io/RawTableLoader.cpp
+++ b/src/lib/io/RawTableLoader.cpp
@@ -10,11 +10,11 @@
 namespace hyrise { namespace io {
 
 struct raw_table_cb_data {
-  std::shared_ptr<RawTable> table;
-  hyrise::storage::rawtable::RowHelper rh;
+  std::shared_ptr<storage::RawTable> table;
+  storage::rawtable::RowHelper rh;
   size_t column;
 
-  raw_table_cb_data(const metadata_vec_t& meta) : rh(meta), column(0) {
+  raw_table_cb_data(const storage::metadata_vec_t& meta) : rh(meta), column(0) {
   }
 };
 
@@ -44,9 +44,9 @@ void raw_table_cb_per_line(int separator, struct raw_table_cb_data *data) {
 }
 
 
-std::shared_ptr<AbstractTable> RawTableLoader::load(std::shared_ptr<AbstractTable> in,
-                                    const compound_metadata_list *ml,
-                                    const Loader::params &args) {
+std::shared_ptr<storage::AbstractTable> RawTableLoader::load(std::shared_ptr<storage::AbstractTable> in,
+                                                             const storage::compound_metadata_list *ml,
+                                                             const Loader::params &args) {
 
 
 
@@ -54,11 +54,11 @@ std::shared_ptr<AbstractTable> RawTableLoader::load(std::shared_ptr<AbstractTabl
   if (detectHeader(args.getBasePath() + _filename)) params.setLineStart(5);
 
   // Create the result table
-  metadata_vec_t v(in->columnCount());
+  storage::metadata_vec_t v(in->columnCount());
   for(size_t i=0; i < in->columnCount(); ++i) {
     v[i] = *in->metadataAt(i);
   }
-  auto result = std::make_shared<RawTable>(v);
+  auto result = std::make_shared<storage::RawTable>(v);
 
   // CSV Parsing
   std::ifstream file(args.getBasePath() + _filename, std::ios::binary);
@@ -126,3 +126,4 @@ std::shared_ptr<AbstractTable> RawTableLoader::load(std::shared_ptr<AbstractTabl
 }
 
 }}
+

--- a/src/lib/io/RawTableLoader.h
+++ b/src/lib/io/RawTableLoader.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_RAWTABLELOADER_H_
-#define SRC_LIB_IO_RAWTABLELOADER_H_
+#pragma once
 
 #include "io/AbstractLoader.h"
 #include "io/GenericCSV.h"
@@ -28,9 +27,9 @@ public:
 
   virtual ~RawTableLoader() {}
 
-  std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable>,
-                                      const compound_metadata_list *,
-                                      const Loader::params &args);
+  std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable>,
+                                               const storage::compound_metadata_list *,
+                                               const Loader::params &args);
 
 
   /// Never wrap a raw table with a store
@@ -45,7 +44,5 @@ public:
 
 };
 
-} }
+} } // namespace hyrise::io
 
-
-#endif // SRC_LIB_IO_RAWTABLELOADER_H_

--- a/src/lib/io/ResourceManager.cpp
+++ b/src/lib/io/ResourceManager.cpp
@@ -46,20 +46,20 @@ void ResourceManager::remove(const std::string& name) const {
   _resources.erase(name);
 }
 
-void ResourceManager::replace(const std::string& name, const  std::shared_ptr<AbstractResource>& resource) const {
+void ResourceManager::replace(const std::string& name, const  std::shared_ptr<storage::AbstractResource>& resource) const {
   auto lock = lock_guard(_resource_mutex) ;
   assureExists(name);
   _resources.at(name) = resource;
 }
 
-void ResourceManager::add(const std::string& name, const std::shared_ptr<AbstractResource>& resource) const {
+void ResourceManager::add(const std::string& name, const std::shared_ptr<storage::AbstractResource>& resource) const {
   auto lock = lock_guard(_resource_mutex) ;
   if (exists(name))
     throw ResourceAlreadyExistsException("ResourceManager: Resource '" + name + "' already exists");
   _resources.insert(make_pair(name, resource));
 }
 
-std::shared_ptr<AbstractResource> ResourceManager::getResource(const std::string& name) const {
+std::shared_ptr<storage::AbstractResource> ResourceManager::getResource(const std::string& name) const {
   auto lock = lock_guard(_resource_mutex) ;
   assureExists(name);
   return _resources.at(name);
@@ -70,6 +70,5 @@ ResourceManager::resource_map ResourceManager::all() const {
   return _resources;
 }
 
-}
-} // namespace hyrise::io
+} } // namespace hyrise::io
 

--- a/src/lib/io/ResourceManager.h
+++ b/src/lib/io/ResourceManager.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_RESOURCEMANAGER_H_
-#define SRC_LIB_IO_RESOURCEMANAGER_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -14,6 +13,10 @@
 class AbstractResource;
 
 namespace hyrise {
+namespace storage {
+class AbstractRessource;
+} // namespace storage
+
 namespace io {
 
 class ResourceManagerException :  public std::runtime_error {
@@ -39,15 +42,15 @@ class ResourceNotExistsException : public ResourceManagerException {
 /// *need* to be thread-safe.
 class ResourceManager {
  public:
-  typedef std::map<std::string, std::shared_ptr<AbstractResource> > resource_map;
+  typedef std::map<std::string, std::shared_ptr<storage::AbstractResource> > resource_map;
   /// Retrieve singleton ResourceManager instance
   static ResourceManager& getInstance();
 
   /// Adds a new resource
-  void add(const std::string& name, const std::shared_ptr<AbstractResource>& resource) const;
+  void add(const std::string& name, const std::shared_ptr<storage::AbstractResource>& resource) const;
 
   /// Retrieves a resource by name
-  std::shared_ptr<AbstractResource> getResource(const std::string& name) const;
+  std::shared_ptr<storage::AbstractResource> getResource(const std::string& name) const;
 
   /// Retrieves a resource by name and assures its type T
   template <typename T>
@@ -59,7 +62,7 @@ class ResourceManager {
   void remove(const std::string& name) const;
 
   /// Replaces an existing resource
-  void replace(const std::string& name, const std::shared_ptr<AbstractResource>& resource) const;
+  void replace(const std::string& name, const std::shared_ptr<storage::AbstractResource>& resource) const;
   
   /// Removes all resources
   void clear() const;
@@ -92,6 +95,4 @@ class ResourceManager {
 };
 
 }}  // namespace hyrise::io
-
-#endif  // SRC_LIB_IO_RESOURCEMANAGER_H_
 

--- a/src/lib/io/StorageManager.cpp
+++ b/src/lib/io/StorageManager.cpp
@@ -38,11 +38,11 @@ StorageManager *StorageManager::getInstance() {
   return static_cast<StorageManager*>(&ResourceManager::getInstance());
 }
 
-void StorageManager::loadTable(std::string name, std::shared_ptr<AbstractTable> table) {
+void StorageManager::loadTable(std::string name, std::shared_ptr<storage::AbstractTable> table) {
   add(name, table);
 }
 
-void StorageManager::replaceTable(std::string name, std::shared_ptr<AbstractTable> table) {
+void StorageManager::replaceTable(std::string name, std::shared_ptr<storage::AbstractTable> table) {
   replace(name, table);
 }
 
@@ -76,7 +76,7 @@ std::string StorageManager::makePath(std::string fileName) {
   return Settings::getInstance()->getDBPath() + "/" + fileName;
 }
 
-std::shared_ptr<AbstractTable> StorageManager::getTable(std::string name) {
+std::shared_ptr<storage::AbstractTable> StorageManager::getTable(std::string name) {
   if (!exists(name)) {
     std::string tbl_file = Settings::getInstance()->getDBPath() + "/" + name + ".tbl";
     struct stat stFileInfo;
@@ -84,7 +84,7 @@ std::shared_ptr<AbstractTable> StorageManager::getTable(std::string name) {
     if (stat(tbl_file.c_str(), &stFileInfo) == 0)
       loadTableFile(name, name + ".tbl");
   }
-  return get<AbstractTable>(name);
+  return get<storage::AbstractTable>(name);
 }
 
 void StorageManager::removeTable(std::string name) {
@@ -95,7 +95,7 @@ void StorageManager::removeTable(std::string name) {
 std::vector<std::string> StorageManager::getTableNames() const {
   std::vector<std::string> ret;
   for (const auto &resource : all())
-    if (std::dynamic_pointer_cast<AbstractTable>(resource.second) != nullptr)
+    if (std::dynamic_pointer_cast<storage::AbstractTable>(resource.second) != nullptr)
       ret.push_back(resource.first);
   return ret;
 }
@@ -109,7 +109,7 @@ void StorageManager::printResources() const {
   for (const auto &kv : all()) {
     const auto &name = kv.first;
     const auto &resource = kv.second;
-    if (auto table = std::dynamic_pointer_cast<AbstractTable>(resource)) {
+    if (auto table = std::dynamic_pointer_cast<storage::AbstractTable>(resource)) {
       std::cout << "Table "
                 << table->size() << " rows "
                 << table->columnCount() << " columns" << std::endl
@@ -117,7 +117,7 @@ void StorageManager::printResources() const {
 
       for (field_t i = 0; i != table->columnCount(); i++)
          std::cout << " " << table->metadataAt(i)->getName();
-    } else if (std::dynamic_pointer_cast<AbstractIndex>(resource)) {
+    } else if (std::dynamic_pointer_cast<storage::AbstractIndex>(resource)) {
       std::cout << "Index " << name;
     } else {
       std::cout << "Unknown resource type " << name;
@@ -127,14 +127,13 @@ void StorageManager::printResources() const {
   std::cout << "====================" << std::endl;
 }
 
-void StorageManager::addInvertedIndex(std::string name, std::shared_ptr<AbstractIndex> index) {
+void StorageManager::addInvertedIndex(std::string name, std::shared_ptr<storage::AbstractIndex> index) {
   add(name, index);
 }
 
-std::shared_ptr<AbstractIndex> StorageManager::getInvertedIndex(std::string name) {
-  return get<AbstractIndex>(name);
+std::shared_ptr<storage::AbstractIndex> StorageManager::getInvertedIndex(std::string name) {
+  return get<storage::AbstractIndex>(name);
 }
 
-}
-} // namespace hyrise::io
+} } // namespace hyrise::io
 

--- a/src/lib/io/StorageManager.h
+++ b/src/lib/io/StorageManager.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_STORAGEMANAGER_H_
-#define SRC_LIB_IO_STORAGEMANAGER_H_
+#pragma once
 
 #include <atomic>
 #include <map>
@@ -11,14 +10,18 @@
 
 #include "io/ResourceManager.h"
 
+namespace hyrise {
+
+namespace storage {
 class AbstractTable;
 class AbstractIndex;
 class AbstractResource;
+} // namespace storage
 
-namespace Loader { class params; }                                            
-
-namespace hyrise {
 namespace io {
+namespace Loader { 
+class params;
+} // namespace Loader                          
 
 /// Central holder of schema information
 class StorageManager : public ResourceManager {
@@ -44,7 +47,7 @@ class StorageManager : public ResourceManager {
   /// Table loading with table
   /// @param[in] name Table name
   /// @param[in] table Shared table pointer
-  void loadTable(std::string name, std::shared_ptr<AbstractTable> table);
+  void loadTable(std::string name, std::shared_ptr<storage::AbstractTable> table);
 
   /// Convenience loading from fileName
   /// @param[in] name Table name
@@ -60,7 +63,7 @@ class StorageManager : public ResourceManager {
   /// Replace existing table
   /// @param[in] name Table name to be replaced
   /// @param[in] table Shared table pointer
-  void replaceTable(std::string name, std::shared_ptr<AbstractTable> table);
+  void replaceTable(std::string name, std::shared_ptr<storage::AbstractTable> table);
 
   void removeTable(std::string name);
 
@@ -68,13 +71,13 @@ class StorageManager : public ResourceManager {
 
   /// Get a table
   /// @param[in] name Table name
-  std::shared_ptr<AbstractTable> getTable(std::string name);
+  std::shared_ptr<storage::AbstractTable> getTable(std::string name);
 
   /// saves the inverted index as name.
-  void addInvertedIndex(std::string name, std::shared_ptr<AbstractIndex> _index);
+  void addInvertedIndex(std::string name, std::shared_ptr<storage::AbstractIndex> _index);
 
   /// returns the index stored under name name.
-  std::shared_ptr<AbstractIndex> getInvertedIndex(std::string name);
+  std::shared_ptr<storage::AbstractIndex> getInvertedIndex(std::string name);
 
   /// Retrieve all table names
   std::vector<std::string> getTableNames() const;
@@ -87,12 +90,5 @@ class StorageManager : public ResourceManager {
   std::string makePath(std::string fileName);
 };
 
-}
-}  // namespace hyrise::io
-
-
-
-typedef hyrise::io::StorageManager StorageManager;
-
-#endif  // SRC_LIB_IO_STORAGEMANAGER_H_
+} }  // namespace hyrise::io
 

--- a/src/lib/io/StringLoader.cpp
+++ b/src/lib/io/StringLoader.cpp
@@ -6,7 +6,10 @@
 #include "io/GenericCSV.h"
 #include "io/MetadataCreation.h"
 
-compound_metadata_list *StringHeader::load(const Loader::params &args) {
+namespace hyrise {
+namespace io {
+
+storage::compound_metadata_list *StringHeader::load(const Loader::params &args) {
   std::istringstream is(_header);
   std::vector<line_t>lines(csv::parse_stream(is, csv::HYRISE_FORMAT));
   return createMetadata(lines, args.getReferenceTable());
@@ -15,3 +18,6 @@ compound_metadata_list *StringHeader::load(const Loader::params &args) {
 StringHeader *StringHeader::clone() const {
   return new StringHeader(*this);
 }
+
+} } // namespace hyrise::io
+

--- a/src/lib/io/StringLoader.h
+++ b/src/lib/io/StringLoader.h
@@ -1,18 +1,21 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_STRINGLOADER_H_
-#define SRC_LIB_IO_STRINGLOADER_H_
+#pragma once
 
 #include "io/AbstractLoader.h"
+
+namespace hyrise {
+namespace io {
 
 class StringHeader : public AbstractHeader {
  public:
   explicit StringHeader(std::string header) :
       _header(header) {
   }
-  compound_metadata_list *load(const Loader::params &args);
+  storage::compound_metadata_list *load(const Loader::params &args);
   StringHeader *clone() const;
  private:
   std::string _header;
 };
 
-#endif  // SRC_LIB_IO_STRINGLOADER_H_
+} } // namespace hyrise::io
+

--- a/src/lib/io/TXContext.h
+++ b/src/lib/io/TXContext.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_TXCONTEXT_H_
-#define SRC_LIB_IO_TXCONTEXT_H_
+#pragma once
 
 #include <helper/types.h>
 #include "cereal/cereal.hpp"
@@ -30,4 +29,3 @@ struct TXContext {
 
 }}
 
-#endif //SRC_LIB_IO_TXCONTEXT_H_

--- a/src/lib/io/TableDump.cpp
+++ b/src/lib/io/TableDump.cpp
@@ -211,9 +211,12 @@ bool SimpleTableDump::dump(std::string name, std::shared_ptr<AbstractTable> tabl
   return true;
 }
 
+} // namespace storage
+
+namespace io {
 
 size_t TableDumpLoader::getSize() {
-  std::string path = DumpHelper::buildPath({_base, _table, DumpHelper::META_DATA_EXT});
+  std::string path = storage::DumpHelper::buildPath({_base, _table, storage::DumpHelper::META_DATA_EXT});
   std::ifstream data (path, std::ios::binary);
   size_t numRows;
   data >> numRows;
@@ -222,23 +225,19 @@ size_t TableDumpLoader::getSize() {
 }
 
 
-void TableDumpLoader::loadDictionary(std::string name, 
-                                                      size_t col, std::shared_ptr<AbstractTable> intable) {
-  std::string path = DumpHelper::buildPath({_base, _table, name}) + DumpHelper::DICT_EXT;
+void TableDumpLoader::loadDictionary(std::string name, size_t col, std::shared_ptr<storage::AbstractTable> intable) {
+  std::string path = storage::DumpHelper::buildPath({_base, _table, name}) + storage::DumpHelper::DICT_EXT;
   std::ifstream data (path, std::ios::binary);
 
-  write_to_dict_functor fun(data, intable, col);
-  type_switch<hyrise_basic_types> ts;
+  storage::write_to_dict_functor fun(data, intable, col);
+  storage::type_switch<hyrise_basic_types> ts;
   ts(intable->typeOfColumn(col), fun);
 
   data.close();
 }
 
-void TableDumpLoader::loadAttribute(std::string name, 
-                                                     size_t col, 
-                                                     size_t size,
-                                                     std::shared_ptr<AbstractTable> intable) {
-  std::string path = DumpHelper::buildPath({_base, _table, name}) + DumpHelper::ATTR_EXT;
+void TableDumpLoader::loadAttribute(std::string name, size_t col, size_t size, std::shared_ptr<storage::AbstractTable> intable) {
+  std::string path = storage::DumpHelper::buildPath({_base, _table, name}) + storage::DumpHelper::ATTR_EXT;
   std::ifstream data (path, std::ios::binary);
   
   ValueId vid;
@@ -251,9 +250,9 @@ void TableDumpLoader::loadAttribute(std::string name,
 }
 
 
-std::shared_ptr<AbstractTable> TableDumpLoader::load(std::shared_ptr<AbstractTable> intable, 
-                                      const compound_metadata_list *meta, 
-                                      const Loader::params &args)
+std::shared_ptr<storage::AbstractTable> TableDumpLoader::load(std::shared_ptr<storage::AbstractTable> intable, 
+                                                              const storage::compound_metadata_list *meta, 
+                                                              const Loader::params &args)
 {
 
   // First extract the dictionaries
@@ -274,4 +273,5 @@ std::shared_ptr<AbstractTable> TableDumpLoader::load(std::shared_ptr<AbstractTab
   return intable;
 }
 
-}}
+} } // namespace hyrise::io
+

--- a/src/lib/io/TableDump.h
+++ b/src/lib/io/TableDump.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_TABLE_DUMP_H_
-#define SRC_LIB_IO_TABLE_DUMP_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -8,9 +7,10 @@
 
 #include "io/AbstractLoader.h"
 
-class AbstractTable;
 
 namespace hyrise { namespace storage {
+
+class AbstractTable;
 /**
  * This is the class that allows dumping a table instance in a very
  * simple way directly to the file system without using a third party
@@ -70,27 +70,31 @@ public:
   bool dump(std::string name, std::shared_ptr<AbstractTable> table);
 };
 
+} // namespace storage
+
+namespace io {
+
 class TableDumpLoader : public AbstractInput {
   std::string _base;
   std::string _table;
 
   size_t getSize();
 
-  void loadDictionary(std::string name, size_t col, std::shared_ptr<AbstractTable> intable);
+  void loadDictionary(std::string name, size_t col, std::shared_ptr<storage::AbstractTable> intable);
 
   void loadAttribute(std::string name,
                      size_t col,
                      size_t size,
-                     std::shared_ptr<AbstractTable> intable);
+                     std::shared_ptr<storage::AbstractTable> intable);
 
 public:
   TableDumpLoader(std::string base, std::string table) :
     _base(base), _table(table) {
   }
 
-  std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable>,
-                                      const compound_metadata_list *,
-                                      const Loader::params &args);
+  std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable>,
+                                               const storage::compound_metadata_list *,
+                                               const Loader::params &args);
 
   bool needs_store_wrap() {
     return true;
@@ -101,6 +105,5 @@ public:
   }
 };
 
-}}
+} } // namespace hyrise::io
 
-#endif // SRC_LIB_IO_TABLE_DUMP_H_

--- a/src/lib/io/TransactionManager.cpp
+++ b/src/lib/io/TransactionManager.cpp
@@ -239,3 +239,4 @@ transaction_cid_t TransactionManager::commitTransaction(TXContext ctx) {
 }
 
 }}
+

--- a/src/lib/io/TransactionManager.h
+++ b/src/lib/io/TransactionManager.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_TRANSACTIONMANAGER_H_
-#define SRC_LIB_IO_TRANSACTIONMANAGER_H_
+#pragma once
 
 #include <algorithm>
 #include <atomic>
@@ -21,9 +20,9 @@ namespace tx {
 class TXModifications {
  public:
   // Map type to store position list per table
-  using map_t = std::map<std::weak_ptr<const AbstractTable>,
+  using map_t = std::map<std::weak_ptr<const storage::AbstractTable>,
                          storage::pos_list_t,
-                         std::owner_less<std::weak_ptr<const AbstractTable> > >;
+                         std::owner_less<std::weak_ptr<const storage::AbstractTable> > >;
 
   // TID identifier for the context
   transaction_id_t tid = UNKNOWN;
@@ -165,4 +164,3 @@ class TransactionManager {
 
 }}
 
-#endif

--- a/src/lib/io/TransactionRouteHandler.h
+++ b/src/lib/io/TransactionRouteHandler.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_TRANSACTIONROUTEHANDLER_
-#define SRC_LIB_IO_TRANSACTIONROUTEHANDLER_
+#pragma once
 
 #include <string>
 
@@ -28,4 +27,3 @@ class TransactionStatusHandler : public RequestHandler {
 
 }}
 
-#endif  // SRC_LIB_IO_TRANSACTIONROUTEHANDLER_

--- a/src/lib/io/VectorLoader.cpp
+++ b/src/lib/io/VectorLoader.cpp
@@ -2,15 +2,18 @@
 #include "io/VectorLoader.h"
 #include "storage/AbstractTable.h"
 
+namespace hyrise {
+namespace io {
+
 VectorInput::VectorInput(value_vectors_t vectors) : _vectors(vectors) {}
 
 VectorInput* VectorInput::clone() const {
   return new VectorInput(*this);
 }
 
-std::shared_ptr<AbstractTable> VectorInput::load(std::shared_ptr<AbstractTable> table,
-                                                 const compound_metadata_list * meta,
-                                                 const Loader::params &args) {
+std::shared_ptr<storage::AbstractTable> VectorInput::load(std::shared_ptr<storage::AbstractTable> table,
+                                                          const storage::compound_metadata_list * meta,
+                                                          const Loader::params &args) {
   size_t column = 0;
   for (const auto& column_values: _vectors) {
     size_t row = 0;
@@ -23,3 +26,6 @@ std::shared_ptr<AbstractTable> VectorInput::load(std::shared_ptr<AbstractTable> 
   }
   return table;
 }
+
+} } // namespace hyrise::io
+

--- a/src/lib/io/VectorLoader.h
+++ b/src/lib/io/VectorLoader.h
@@ -1,8 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_VECTORLOADER_H_
-#define SRC_LIB_IO_VECTORLOADER_H_
+#pragma once
 
 #include "io/AbstractLoader.h"
+
+namespace hyrise {
+namespace io {
 
 class VectorInput : public AbstractInput {
  public:
@@ -10,11 +12,12 @@ class VectorInput : public AbstractInput {
   typedef std::vector<value_vec_t> value_vectors_t;
   VectorInput(value_vectors_t vectors);
   VectorInput *clone() const;
-  std::shared_ptr<AbstractTable> load(std::shared_ptr<AbstractTable>,
-                                      const compound_metadata_list *,
-                                      const Loader::params &args);
+  std::shared_ptr<storage::AbstractTable> load(std::shared_ptr<storage::AbstractTable>,
+                                               const storage::compound_metadata_list *,
+                                               const Loader::params &args);
  private:
   const value_vectors_t _vectors;
 };
 
-#endif
+} } // namespace hyrise::io
+

--- a/src/lib/io/loaders.h
+++ b/src/lib/io/loaders.h
@@ -1,7 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_LOADERS_H_
-#define SRC_LIB_IO_LOADERS_H_
-
+#pragma once
 
 #include "Loader.h"
 #include "CSVLoader.h"
@@ -11,4 +9,3 @@
 #include "MySQLLoader.h"
 #include "RawTableLoader.h"
 
-#endif  // SRC_LIB_IO_LOADERS_H_

--- a/src/lib/io/shortcuts.cpp
+++ b/src/lib/io/shortcuts.cpp
@@ -5,8 +5,11 @@
 #include "storage/AbstractTable.h"
 #include "storage/Store.h"
 
+namespace hyrise {
+namespace io {
 namespace Loader {
 namespace shortcuts {
+
 Loader::params loadParams(const std::string &filename, Loader::params &p) {
   CSVInput input(filename);
   CSVHeader header(filename);
@@ -36,23 +39,22 @@ Loader::params loadWithStringHeaderParams(const std::string &datafilepath, const
   return p;
 }
 
-}
-}
+} } // namesapce Loader::shortcuts
 
-std::shared_ptr<AbstractTable> Loader::shortcuts::load(const std::string &filepath) {
+std::shared_ptr<storage::AbstractTable> Loader::shortcuts::load(const std::string &filepath) {
   Loader::params p;
   return Loader::load(loadParams(filepath, p));
 };
 
-std::shared_ptr<AbstractTable> Loader::shortcuts::load(const std::string &filepath, Loader::params &params) {
+std::shared_ptr<storage::AbstractTable> Loader::shortcuts::load(const std::string &filepath, Loader::params &params) {
   return Loader::load(loadParams(filepath, params));
 };
 
-std::shared_ptr<AbstractTable> Loader::shortcuts::loadWithHeader(const std::string &datafilepath, const std::string &headerfilepath) {
+std::shared_ptr<storage::AbstractTable> Loader::shortcuts::loadWithHeader(const std::string &datafilepath, const std::string &headerfilepath) {
   return Loader::load(loadWithHeaderParams(datafilepath, headerfilepath));
 };
 
-std::shared_ptr<AbstractTable> Loader::shortcuts::loadWithStringHeader(const std::string &datafilepath, const std::string &header) {
+std::shared_ptr<storage::AbstractTable> Loader::shortcuts::loadWithStringHeader(const std::string &datafilepath, const std::string &header) {
   return Loader::load(loadWithStringHeaderParams(datafilepath, header));
 };
 
@@ -60,7 +62,7 @@ std::shared_ptr<hyrise::storage::Store> Loader::shortcuts::loadMainDelta(const s
   std::vector<std::string> filenames;
   filenames.push_back(mainfilepath);
   filenames.push_back(deltafilepath);
-  std::vector<std::shared_ptr<AbstractTable>> tables;
+  std::vector<std::shared_ptr<storage::AbstractTable>> tables;
 
   for (int i = 0; i < 2; ++i) {
     CSVInput input(filenames[i]);
@@ -69,7 +71,7 @@ std::shared_ptr<hyrise::storage::Store> Loader::shortcuts::loadMainDelta(const s
     p.setInput(input);
     p.setHeader(header);
     p.setReturnsMutableVerticalTable(true);
-    std::shared_ptr<AbstractTable> table = Loader::load(p);
+    std::shared_ptr<storage::AbstractTable> table = Loader::load(p);
     tables.push_back(table);
   }
   auto s = std::make_shared<hyrise::storage::Store>(tables[0]);
@@ -77,7 +79,7 @@ std::shared_ptr<hyrise::storage::Store> Loader::shortcuts::loadMainDelta(const s
   return s;
 };
 
-std::shared_ptr<AbstractTable> Loader::shortcuts::loadRaw(const std::string &file) {
+std::shared_ptr<storage::AbstractTable> Loader::shortcuts::loadRaw(const std::string &file) {
   hyrise::io::RawTableLoader input(file);
   CSVHeader header(file);
 
@@ -87,3 +89,5 @@ std::shared_ptr<AbstractTable> Loader::shortcuts::loadRaw(const std::string &fil
   p.setReturnsMutableVerticalTable(false);
   return Loader::load(p);
 }
+
+} } // namespace hyrise::io

--- a/src/lib/io/shortcuts.h
+++ b/src/lib/io/shortcuts.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_IO_SHORTCUTS_H_
-#define SRC_LIB_IO_SHORTCUTS_H_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -8,8 +7,9 @@
 #include "helper/types.h"
 #include "Loader.h"
 
+namespace hyrise {
+namespace io {
 namespace Loader {
-
 namespace shortcuts {
 
 Loader::params loadWithStringHeaderParams(const std::string &datafilepath, const std::string &header);
@@ -17,32 +17,31 @@ Loader::params loadWithStringHeaderParams(const std::string &datafilepath, const
 /*! Loads a table for a given filename, assuming it contains header and data in HYRISE format.
   @param filepath
 */
-std::shared_ptr<AbstractTable> load(const std::string &filepath);
-std::shared_ptr<AbstractTable> load(const std::string &filepath, Loader::params &params);
+std::shared_ptr<storage::AbstractTable> load(const std::string &filepath);
+std::shared_ptr<storage::AbstractTable> load(const std::string &filepath, Loader::params &params);
 
 /*! Load a table from a given filename, while supplying the header from another file. Must be HYRISE formatted.
   @param datafilepath
   @param headerfilepath
 */
-std::shared_ptr<AbstractTable> loadWithHeader(const std::string &datafilepath, const std::string &headerfilepath);
+std::shared_ptr<storage::AbstractTable> loadWithHeader(const std::string &datafilepath, const std::string &headerfilepath);
 
 /*! Load a table from a given filename, while supplying the header from the second input parameter. Must be HYRISE formatted.
   @param datafilepath
   @param header
 */
-std::shared_ptr<AbstractTable> loadWithStringHeader(const std::string &datafilepath, const std::string &header);
+std::shared_ptr<storage::AbstractTable> loadWithStringHeader(const std::string &datafilepath, const std::string &header);
 
 /*! Load store with main and delta from separate files
   @param mainfilepath
   @param deltafilepath
 */
-std::shared_ptr<hyrise::storage::Store> loadMainDelta(const std::string &mainfilepath, const std::string &deltafilepath, Loader::params p = Loader::params());
+std::shared_ptr<hyrise::storage::Store> loadMainDelta(const std::string &mainfilepath, const std::string &deltafilepath, params p = params());
 
 /**
  * Load a table into a raw table container
  */
-std::shared_ptr<AbstractTable> loadRaw(const std::string &file);
+std::shared_ptr<storage::AbstractTable> loadRaw(const std::string &file);
 
-}} // end namespace Loader::shortcuts
+} } } } // end namespace hyrise::io::Loader::shortcuts
 
-#endif  // SRC_LIB_IO_SHORTCUTS_H_

--- a/src/lib/layouter/base.cpp
+++ b/src/lib/layouter/base.cpp
@@ -24,7 +24,6 @@
 
 #include <metis.h>
 
-using namespace layouter;
 using namespace boost::assign;
 
 
@@ -32,7 +31,7 @@ using namespace boost::assign;
 namespace std {
 
 template<>
-struct hash<subset_t> {
+struct hash<hyrise::layouter::subset_t> {
 public:
 
   size_t operator()(const std::vector<unsigned> &ref) const {
@@ -44,10 +43,10 @@ for (auto t : ref)
   }
 };
 
-}
+} // namespace std
 
-
-
+namespace hyrise {
+namespace layouter {
 
 Query::Query(LayouterConfiguration::access_type_t type, std::vector<unsigned> qA, double parameter, int weight):
   type(type), queryAttributes(qA), parameter(parameter), weight(weight) {
@@ -1449,3 +1448,6 @@ for (subset_t t : l.raw())
   iterateThroughLayouts();
   std::sort(results.begin(), results.end());
 }
+
+} } // namespace hyrise::layouter
+

--- a/src/lib/layouter/base.h
+++ b/src/lib/layouter/base.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_LAYOUTER_BASE_H_
-#define SRC_LIB_LAYOUTER_BASE_H_
+#pragma once
 
 #include "config.h"
 #include "matrix.h"
@@ -15,6 +14,7 @@
 #include <algorithm>
 #include <unordered_map>
 
+namespace hyrise {
 namespace layouter {
 
 class Query;
@@ -382,5 +382,5 @@ class DivideAndConquerLayouter : public CandidateLayouter {
   static int numCuts;
 
 };
-}
-#endif  // SRC_LIB_LAYOUTER_BASE_H_
+
+} } // namespace hyrise::layouter

--- a/src/lib/layouter/config.h
+++ b/src/lib/layouter/config.h
@@ -1,13 +1,14 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_LAYOUTER_CONFIG_H_
-#define SRC_LIB_LAYOUTER_CONFIG_H_
+#pragma once
 
 #define CACHE_LINE_SIZE 64
 #define HYRISE_COST "HYRISECost"
 #define ROW_COST "RowCost"
 #define COL_COST "ColumnCost"
 
+namespace hyrise {
 namespace layouter {
+
 struct LayouterConfiguration {
   typedef enum {
     access_type_fullprojection,
@@ -15,5 +16,5 @@ struct LayouterConfiguration {
     access_type_default
   } access_type_t;
 };
-}
-#endif  // SRC_LIB_LAYOUTER_CONFIG_H_
+
+} } // namespace hyrise::layouter

--- a/src/lib/layouter/incremental.cpp
+++ b/src/lib/layouter/incremental.cpp
@@ -5,6 +5,7 @@
 #include <boost/foreach.hpp>
 #include <map>
 
+namespace hyrise {
 namespace layouter {
 
 void IncrementalCandidateLayouter::clearState() {
@@ -164,4 +165,6 @@ void IncrementalCandidateLayouter::incrementalLayout(Query *q) {
   results.push_back(best);
 
 }
-}
+
+} } // namespace hyrise::layouter
+

--- a/src/lib/layouter/incremental.h
+++ b/src/lib/layouter/incremental.h
@@ -1,12 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_LAYOUTER_INCREMENTAL_H_
-#define SRC_LIB_LAYOUTER_INCREMENTAL_H_
+#pragma once
 
 #include "base.h"
 
 #include <vector>
 #include <map>
 
+namespace hyrise {
 namespace layouter {
 /*
  *  This class defines an incremental layouter, based on the
@@ -57,6 +57,5 @@ class IncrementalCandidateLayouter : public CandidateLayouter {
 
 };
 
-}
+} } // namespace layouter
 
-#endif  // SRC_LIB_LAYOUTER_INCREMENTAL_H_

--- a/src/lib/layouter/layout_utils.cpp
+++ b/src/lib/layouter/layout_utils.cpp
@@ -4,8 +4,10 @@
 #include <boost/foreach.hpp>
 #include "layout_utils.h"
 
+namespace hyrise {
+namespace layouter {
 
-void layouter::print(std::vector<std::vector<unsigned> >l) {
+void print(std::vector<std::vector<unsigned> >l) {
   std::cout << "[";
   BOOST_FOREACH(std::vector<unsigned> x, l) {
     BOOST_FOREACH(unsigned e, x) {
@@ -16,53 +18,58 @@ void layouter::print(std::vector<std::vector<unsigned> >l) {
   std::cout << "]" << std::endl;;
 }
 
-void layouter::print(std::vector<unsigned> x) {
+void print(std::vector<unsigned> x) {
   BOOST_FOREACH(unsigned e, x) {
     std::cout << e << " ";
   }
   std::cout << std::endl;
 }
 
-void layouter::print(std::set<unsigned> x) {
+void print(std::set<unsigned> x) {
   BOOST_FOREACH(unsigned e, x) {
     std::cout << e << " ";
   }
   std::cout << std::endl;
 }
 
-void layouter::print(int *x, int s) {
+void print(int *x, int s) {
   for (int i = 0; i < s; ++i) {
     std::cout << x[i] << " ";
   }
   std::cout << std::endl;
 }
 
-void layouter::print(std::vector<double> d) {
+void print(std::vector<double> d) {
   BOOST_FOREACH(double e, d) {
     std::cout << e << " ";
   }
   std::cout << std::endl;
 }
 
-std::vector<layouter::subset_t> &operator += (std::vector<layouter::subset_t> &a, const std::vector<layouter::subset_t> &b) {
-  BOOST_FOREACH(layouter::subset_t i, b) {
+} } // namespace hyrise::layouter
+
+using namespace hyrise::layouter;
+
+std::vector<subset_t> &operator += (std::vector<subset_t> &a, const std::vector<subset_t> &b) {
+  BOOST_FOREACH(subset_t i, b) {
     a.push_back(i);
   }
   return a;
 }
 
-std::vector<layouter::subset_t>   operator + (const std::vector<layouter::subset_t> &a, const std::vector<layouter::subset_t> &b) {
-  std::vector<layouter::subset_t> result;
-  BOOST_FOREACH(layouter::subset_t i, a) {
+std::vector<subset_t> operator + (const std::vector<subset_t> &a,
+                                                    const std::vector<subset_t> &b) {
+  std::vector<subset_t> result;
+  BOOST_FOREACH(subset_t i, a) {
     result.push_back(i);
   }
-  BOOST_FOREACH(layouter::subset_t i, b) {
+  BOOST_FOREACH(subset_t i, b) {
     result.push_back(i);
   }
   return result;
 }
 
-bool operator== (const std::vector<layouter::subset_t> &left, const std::vector<layouter::subset_t> &right) {
+bool operator== (const std::vector<subset_t> &left, const std::vector<subset_t> &right) {
   if (left.size() != right.size())
     return false;
 
@@ -73,15 +80,15 @@ bool operator== (const std::vector<layouter::subset_t> &left, const std::vector<
   return true;
 }
 
-bool operator!= (const std::vector<layouter::subset_t> &left, const std::vector<layouter::subset_t> &right) {
+bool operator!= (const std::vector<subset_t> &left, const std::vector<subset_t> &right) {
   return !(left == right);
 }
 
-bool sort_subset_by_size(const layouter::subset_t &left, const layouter::subset_t &right) {
+bool sort_subset_by_size(const subset_t &left, const subset_t &right) {
   return left.size() > right.size();
 }
 
-bool subset_t_lt(const layouter::subset_t &left, const layouter::subset_t &right) {
+bool subset_t_lt(const subset_t &left, const subset_t &right) {
   if (left.size() < right.size())
     return true;
 
@@ -99,7 +106,7 @@ bool subset_t_lt(const layouter::subset_t &left, const layouter::subset_t &right
   return false;
 }
 
-bool subset_t_content_equal(const layouter::subset_t& left, const layouter::subset_t& right)
+bool subset_t_content_equal(const subset_t& left, const subset_t& right)
 {
     std::set<unsigned> left_set(left.begin(), left.end());
     std::set<unsigned> right_set(right.begin(), right.end());
@@ -128,3 +135,4 @@ int GCD(int a, int b) {
 int LCM(int a, int b) {
   return (a * b) / GCD(a, b);
 }
+

--- a/src/lib/layouter/layout_utils.h
+++ b/src/lib/layouter/layout_utils.h
@@ -1,11 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_LAYOUTER_LAYOUT_UTILS_H_
-#define SRC_LIB_LAYOUTER_LAYOUT_UTILS_H_
+#pragma once
 
 #include <set>
 #include <vector>
 
+namespace hyrise {
 namespace layouter {
+
 // Globale subset_t definition
 typedef std::vector<unsigned> subset_t;
 typedef std::set<unsigned> set_subset_t;
@@ -19,19 +20,19 @@ void print(std::vector<std::vector<unsigned> > x);
 void print(std::vector<double> x);
 void print(int *x, int s);
 
-}
+} } // namespace hyrise::layouter
 
 // Copy Helper
-std::vector<layouter::subset_t> &operator += (std::vector<layouter::subset_t> &a, const std::vector<layouter::subset_t> &b);
-std::vector<layouter::subset_t>   operator + (const std::vector<layouter::subset_t> &a, const std::vector<layouter::subset_t> &b);
+std::vector<hyrise::layouter::subset_t> &operator += (std::vector<hyrise::layouter::subset_t> &a, const std::vector<hyrise::layouter::subset_t> &b);
+std::vector<hyrise::layouter::subset_t>   operator + (const std::vector<hyrise::layouter::subset_t> &a, const std::vector<hyrise::layouter::subset_t> &b);
 
-bool operator== (const std::vector<layouter::subset_t> &left, const std::vector<layouter::subset_t> &right);
-bool operator!= (const std::vector<layouter::subset_t> &left, const std::vector<layouter::subset_t> &right);
+bool operator== (const std::vector<hyrise::layouter::subset_t> &left, const std::vector<hyrise::layouter::subset_t> &right);
+bool operator!= (const std::vector<hyrise::layouter::subset_t> &left, const std::vector<hyrise::layouter::subset_t> &right);
 
-bool subset_t_lt(const layouter::subset_t &left, const layouter::subset_t &right);
-bool sort_subset_by_size(const layouter::subset_t &left, const layouter::subset_t &right);
+bool subset_t_lt(const hyrise::layouter::subset_t &left, const hyrise::layouter::subset_t &right);
+bool sort_subset_by_size(const hyrise::layouter::subset_t &left, const hyrise::layouter::subset_t &right);
 
-bool subset_t_content_equal(const layouter::subset_t& left, const layouter::subset_t& right);
+bool subset_t_content_equal(const hyrise::layouter::subset_t& left, const hyrise::layouter::subset_t& right);
 
 int GCD(int a, int b);
 int LCM(int a, int b);
@@ -47,4 +48,3 @@ T sum(InputIterator first, InputIterator last, const T &value) {
   return ret;
 }
 
-#endif  // SRC_LIB_LAYOUTER_LAYOUT_UTILS_H_

--- a/src/lib/layouter/matrix.h
+++ b/src/lib/layouter/matrix.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_LAYOUTER_MATRIX_H_
-#define SRC_LIB_LAYOUTER_MATRIX_H_
+#pragma once
 
 #include <assert.h>
 #include <stdlib.h>
@@ -8,6 +7,9 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+
+namespace hyrise {
+namespace layouter {
 
 struct adj_t {
   int *xadj;
@@ -158,4 +160,5 @@ void Matrix<T>::print() const {
   std::cout << buffer.str() << std::endl;
 }
 
-#endif  // SRC_LIB_LAYOUTER_MATRIX_H_
+} } // namespace hyrise::layouter
+

--- a/src/lib/memory/MallocStrategy.h
+++ b/src/lib/memory/MallocStrategy.h
@@ -1,10 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_MEMORY_MALLOCSTRATEGY_H_
-#define SRC_LIB_MEMORY_MALLOCSTRATEGY_H_
+#pragma once
 
-#include <iostream>
 #include <cstdint>
 
+namespace hyrise {
+namespace memory {
 
 class MallocStrategy {
 public:
@@ -21,5 +21,5 @@ public:
   }
 };
 
-#endif  // SRC_LIB_MEMORY_MALLOCSTRATEGY_H_
+} } // namespace hyrise::memory
 

--- a/src/lib/net/AsyncConnection.cpp
+++ b/src/lib/net/AsyncConnection.cpp
@@ -75,9 +75,9 @@ void request_complete(ebb_request *request) {
     return;
   }
 
-  std::shared_ptr<Task> task = handler_factory->create(connection_data);
-  task->setPriority(Task::HIGH_PRIORITY); // give RequestParseTask high priority
-  SharedScheduler::getInstance().getScheduler()->schedule(task);
+  auto task = handler_factory->create(connection_data);
+  task->setPriority(taskscheduler::Task::HIGH_PRIORITY); // give RequestParseTask high priority
+  taskscheduler::SharedScheduler::getInstance().getScheduler()->schedule(task);
   connection_data->waiting_for_response = true;
 }
 

--- a/src/lib/net/Router.h
+++ b/src/lib/net/Router.h
@@ -16,7 +16,7 @@ namespace hyrise {
 namespace net {
 
 /// Base class for request handlers
-class AbstractRequestHandler : public Task {
+class AbstractRequestHandler : public taskscheduler::Task {
  public:
   typedef std::shared_ptr<AbstractRequestHandler> SharedPtr;
   virtual ~AbstractRequestHandler() {}

--- a/src/lib/storage/AbstractAttributeVector.cpp
+++ b/src/lib/storage/AbstractAttributeVector.cpp
@@ -1,3 +1,9 @@
 #include "storage/AbstractAttributeVector.h"
 
+namespace hyrise {
+namespace storage {
+
 AbstractAttributeVector::~AbstractAttributeVector() {}
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AbstractAttributeVector.h
+++ b/src/lib/storage/AbstractAttributeVector.h
@@ -1,8 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_ABSTRACTATTRIBUTEVECTOR_H_
-#define SRC_LIB_STORAGE_ABSTRACTATTRIBUTEVECTOR_H_
+#pragma once
 
 #include <cstddef>
+
+namespace hyrise {
+namespace storage {
 
 class AbstractAttributeVector {
  public:
@@ -14,4 +16,5 @@ class AbstractAttributeVector {
 
 };
 
-#endif  // SRC_LIB_STORAGE_ABSTRACTATTRIBUTEVECTOR_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AbstractDictionary.h
+++ b/src/lib/storage/AbstractDictionary.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_ABSTRACTDICTIONARY_H_
-#define SRC_LIB_STORAGE_ABSTRACTDICTIONARY_H_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -8,6 +7,8 @@
 
 #include "storage/storage_types.h"
 
+namespace hyrise {
+namespace storage {
 
 class AbstractDictionary {
 public:
@@ -25,5 +26,5 @@ public:
 
 };
 
+} } // namespace hyrise::storage
 
-#endif  // SRC_LIB_STORAGE_ABSTRACTDICTIONARY_H_

--- a/src/lib/storage/AbstractHashTable.h
+++ b/src/lib/storage/AbstractHashTable.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_ABSTRACTHASHTABLE_H_
-#define SRC_LIB_STORAGE_ABSTRACTHASHTABLE_H_
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -9,6 +8,9 @@
 #include "helper/types.h"
 #include "storage/AbstractResource.h"
 #include "storage/storage_types.h"
+
+namespace hyrise {
+namespace storage {
 
 class AbstractTable;
 
@@ -36,5 +38,6 @@ public:
   virtual uint64_t numKeys() const = 0;
 };
 
-#endif  // SRC_LIB_STORAGE_ABSTRACTHASHTABLE_H_
+} } // namespace hyrise::storage
+
 

--- a/src/lib/storage/AbstractIndex.cpp
+++ b/src/lib/storage/AbstractIndex.cpp
@@ -1,4 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include <storage/AbstractIndex.h>
 
+namespace hyrise {
+namespace storage {
+
 AbstractIndex::~AbstractIndex() {}
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AbstractIndex.h
+++ b/src/lib/storage/AbstractIndex.h
@@ -4,11 +4,12 @@
  * Contains class definition for InvertedIndex Base Class
  *
  */
-
-#ifndef SRC_LIB_STORAGE_ABSTRACTINDEX_H_
-#define SRC_LIB_STORAGE_ABSTRACTINDEX_H_
+#pragma once
 
 #include <storage/AbstractResource.h>
+
+namespace hyrise {
+namespace storage {
 
 class AbstractIndex : public AbstractResource {
 
@@ -21,5 +22,6 @@ public:
   virtual void shrink() = 0;
 };
 
-#endif  // SRC_LIB_STORAGE_ABSTRACTINDEX_H_
+} } // namespace hyrise::storage
+
 

--- a/src/lib/storage/AbstractMergeStrategy.h
+++ b/src/lib/storage/AbstractMergeStrategy.h
@@ -1,11 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-
-#ifndef SRC_LIB_STORAGE_ABSTRACTMERGESTRATEGY_H_
-#define SRC_LIB_STORAGE_ABSTRACTMERGESTRATEGY_H_
+#pragma once
 
 #include <vector>
 #include <storage/AbstractTable.h>
 #include <helper/vector_helpers.h>
+
+namespace hyrise {
+namespace storage {
 
 typedef struct _merge_tables {
 
@@ -61,4 +62,5 @@ public:
 
 };
 
-#endif  // SRC_LIB_STORAGE_ABSTRACTMERGESTRATEGY_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AbstractMerger.h
+++ b/src/lib/storage/AbstractMerger.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_ABSTRACTMERGER_H_
-#define SRC_LIB_STORAGE_ABSTRACTMERGER_H_
+#pragma once
 
 #include <vector>
 #include <unordered_map>
@@ -8,6 +7,9 @@
 #include <helper/types.h>
 #include <storage/AbstractTable.h>
 #include "storage/TableUtils.h"
+
+namespace hyrise {
+namespace storage {
 
 class AbstractMerger {
 public:
@@ -21,4 +23,5 @@ public:
   virtual AbstractMerger *copy() = 0;
 };
 
-#endif  // SRC_LIB_STORAGE_ABSTRACTMERGER_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AbstractResource.cpp
+++ b/src/lib/storage/AbstractResource.cpp
@@ -1,3 +1,9 @@
 #include "AbstractResource.h"
 
+namespace hyrise {
+namespace storage {
+
 AbstractResource::~AbstractResource() {}
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AbstractResource.h
+++ b/src/lib/storage/AbstractResource.h
@@ -1,5 +1,7 @@
-#ifndef SRC_LIB_STORAGE_ABSTRACTRESOURCE_H_
-#define SRC_LIB_STORAGE_ABSTRACTRESOURCE_H_
+#pragma once
+
+namespace hyrise {
+namespace storage {
 
 /// Base class for all storable resources to
 /// be used in plans.
@@ -8,5 +10,5 @@ class AbstractResource {
   virtual ~AbstractResource();
 };
 
-#endif
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/AbstractTable.cpp
+++ b/src/lib/storage/AbstractTable.cpp
@@ -19,7 +19,8 @@
 
 #include <iostream>
 
-using namespace hyrise::storage;
+namespace hyrise {
+namespace storage {
 
 hyrise::storage::atable_ptr_t AbstractTable::copy_structure(const field_list_t *fields, const bool reuse_dict, const size_t initial_size, const bool with_containers, const bool compressed) const {
   std::vector<const ColumnMetadata *> metadata;
@@ -320,3 +321,6 @@ void AbstractTable::setUuid(unique_id u) {
   }
   _uuid = u;
 }
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AbstractTable.h
+++ b/src/lib/storage/AbstractTable.h
@@ -4,9 +4,7 @@
  * Contains the class definition of AbstractTable.
  *
  */
-
-#ifndef SRC_LIB_STORAGE_ABSTRACTTABLE_H_
-#define SRC_LIB_STORAGE_ABSTRACTTABLE_H_
+#pragma once
 
 #include <limits>
 #include <memory>
@@ -25,6 +23,8 @@
 #include "storage/BaseDictionary.h"
 #include "storage/storage_types.h"
 
+namespace hyrise {
+namespace storage {
 
 class ColumnMetadata;
 class AbstractDictionary;
@@ -543,4 +543,5 @@ public:
   unique_id _uuid;
 };
 
-#endif  // SRC_LIB_STORAGE_ABSTRACTTABLE_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/AttributeVectorFactory.h
+++ b/src/lib/storage/AttributeVectorFactory.h
@@ -1,12 +1,14 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_ATTRIBUTEVECTORFACTORY_H_
-#define SRC_LIB_STORAGE_ATTRIBUTEVECTORFACTORY_H_
+#pragma once
 
 #include <memory>
 
 #include <storage/BaseAttributeVector.h>
 #include <storage/FixedLengthVector.h>
 #include <storage/BitCompressedVector.h>
+
+namespace hyrise {
+namespace storage {
 
 class AttributeVectorFactory {
 public:
@@ -34,4 +36,5 @@ public:
   }
 };
 
-#endif  // SRC_LIB_STORAGE_ATTRIBUTEVECTORFACTORY_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/BaseAttributeVector.h
+++ b/src/lib/storage/BaseAttributeVector.h
@@ -1,11 +1,13 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_BASEATTRIBUTEVECTOR_H_
-#define SRC_LIB_STORAGE_BASEATTRIBUTEVECTOR_H_
+#pragma once
 
 #include <memory>
 #include <stdexcept>
 #include <storage/AbstractAttributeVector.h>
 
+
+namespace hyrise {
+namespace storage {
 
 /*
 * This is the base class of the Attribute Vector that is implement in HYRISE.
@@ -55,4 +57,5 @@ public:
 
 };
 
-#endif  // SRC_LIB_STORAGE_BASEATTRIBUTEVECTOR_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/BaseDictionary.h
+++ b/src/lib/storage/BaseDictionary.h
@@ -1,10 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_BASEDICTIONARY_H_
-#define SRC_LIB_STORAGE_BASEDICTIONARY_H_
+#pragma once
 
 #include <storage/storage_types.h>
 #include <storage/AbstractDictionary.h>
 #include <storage/DictionaryIterator.h>
+
+namespace hyrise {
+namespace storage {
 
 template <typename T>
 class BaseDictionary : public AbstractDictionary {
@@ -45,5 +47,5 @@ public:
 
 };
 
-#endif  // SRC_LIB_STORAGE_BASEDICTIONARY_H_
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/BaseIterator.h
+++ b/src/lib/storage/BaseIterator.h
@@ -1,8 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_BASEITERATOR_H_
-#define SRC_LIB_STORAGE_BASEITERATOR_H_
+#pragma once
 
 #include <memory>
+
+namespace hyrise {
+namespace storage {
 
 template<typename T>
 class BaseIterator {
@@ -21,4 +23,5 @@ class BaseIterator {
 
 };
 
-#endif  // SRC_LIB_STORAGE_BASEITERATOR_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/BitCompressedVector.h
+++ b/src/lib/storage/BitCompressedVector.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_BITCOMPRESSEDVECTOR_H_
-#define SRC_LIB_STORAGE_BITCOMPRESSEDVECTOR_H_
+#pragma once
 
 #include <cassert>
 #include <cmath>
@@ -19,6 +18,9 @@
 #define WORD_LENGTH 64
 #endif
 
+namespace hyrise {
+namespace storage {
+
 // Compute the maximum number representable for n-bit width integers.
 template <typename T,
           class = typename std::enable_if<std::is_integral<T>::value>::type>
@@ -32,7 +34,7 @@ T maxValueForBits(const std::size_t bits) {
 */
 template <typename T>
 class BitCompressedVector : public BaseAttributeVector<T> {
-  using Strategy = MallocStrategy;
+  using Strategy = memory::MallocStrategy;
   // Typedef for the data
   typedef uint64_t storage_t;
   typedef std::vector<uint64_t> bit_size_list_t;
@@ -273,4 +275,5 @@ private:
 
 };
 
-#endif  // SRC_LIB_STORAGE_BITCOMPRESSEDVECTOR_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/ColumnMetadata.cpp
+++ b/src/lib/storage/ColumnMetadata.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 
-
 #include <storage/ColumnMetadata.h>
 
 #include <string>
@@ -8,6 +7,9 @@
 #include <stdexcept>
 
 #include <boost/algorithm/string.hpp>
+
+namespace hyrise {
+namespace storage {
 
 ColumnMetadata *ColumnMetadata::metadataFromString(std::string typestring, std::string name) {
   boost::trim(typestring);
@@ -27,5 +29,5 @@ ColumnMetadata *ColumnMetadata::metadataFromString(std::string typestring, std::
 
 }
 
-
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/ColumnMetadata.h
+++ b/src/lib/storage/ColumnMetadata.h
@@ -1,12 +1,13 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-
-#ifndef SRC_LIB_STORAGE_COLUMNMETADATA_H_
-#define SRC_LIB_STORAGE_COLUMNMETADATA_H_
+#pragma once
 
 #include <storage/storage_types.h>
 
 #include <string>
 #include <stdexcept>
+
+namespace hyrise {
+namespace storage {
 
 class ColumnMetaCreationException : public std::runtime_error {
  public:
@@ -52,5 +53,5 @@ class ColumnMetadata {
   }
 };
 
-#endif  // SRC_LIB_STORAGE_COLUMNMETADATA_H_
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/ConcurrentFixedLengthVector.h
+++ b/src/lib/storage/ConcurrentFixedLengthVector.h
@@ -4,7 +4,8 @@
 #include "helper/not_implemented.h"
 #include "tbb/concurrent_vector.h"
 
-
+namespace hyrise {
+namespace storage {
 
 template <typename T>
 class ConcurrentFixedLengthVector : public AbstractFixedLengthVector<T> {
@@ -61,3 +62,6 @@ class ConcurrentFixedLengthVector : public AbstractFixedLengthVector<T> {
   const std::size_t _columns;
   tbb::concurrent_vector<T> _values;
 };
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/ConcurrentUnorderedDictionary.h
+++ b/src/lib/storage/ConcurrentUnorderedDictionary.h
@@ -6,6 +6,10 @@
 #include "storage/DictionaryIterator.h"
 #include "tbb/concurrent_vector.h"
 #include "tbb/concurrent_unordered_map.h"
+
+namespace hyrise {
+namespace storage {
+
 template <typename T>
 class ConcurrentUnorderedDictionaryIterator : public BaseIterator<T> {
   typedef ConcurrentUnorderedDictionaryIterator<T> iter_type;
@@ -111,3 +115,6 @@ class ConcurrentUnorderedDictionary : public BaseDictionary<T> {
   tbb::concurrent_vector<T> _values;
   std::map<T, value_id_t> _index;
 };
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/DictionaryFactory.h
+++ b/src/lib/storage/DictionaryFactory.h
@@ -1,5 +1,4 @@
-#ifndef STORAGE_DICTIONARYFACTORY_H_
-#define STORAGE_DICTIONARYFACTORY_H_
+#pragma once
 
 #include <memory>
 
@@ -19,7 +18,7 @@ struct DictionaryCreator {
   }
 };
 
-} // ns detail
+} // namespace detail
 
 // Create dictionary for type and size,
 // Usage: makeDictionary<OrderIndifferentDictionary>(IntegerType, 10),
@@ -33,4 +32,3 @@ std::shared_ptr<AbstractDictionary> makeDictionary(DataType type, size_t size=0)
 
 }}
 
-#endif

--- a/src/lib/storage/DictionaryIterator.h
+++ b/src/lib/storage/DictionaryIterator.h
@@ -1,12 +1,14 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_DICTIONARYITERATOR_H_
-#define SRC_LIB_STORAGE_DICTIONARYITERATOR_H_
+#pragma once
 
 #include <memory>
 
 #include <storage/BaseIterator.h>
 
 #include <boost/iterator/iterator_facade.hpp>
+
+namespace hyrise {
+namespace storage {
 
 template<typename T>
 class DictionaryIterator : public boost::iterator_facade<DictionaryIterator<T>, T, boost::forward_traversal_tag> {
@@ -43,4 +45,5 @@ class DictionaryIterator : public boost::iterator_facade<DictionaryIterator<T>, 
 
 };
 
-#endif  // SRC_LIB_STORAGE_DICTIONARYITERATOR_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/FixedLengthVector.h
+++ b/src/lib/storage/FixedLengthVector.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_FIXEDLENGTHVECTOR_H_
-#define SRC_LIB_STORAGE_FIXEDLENGTHVECTOR_H_
+#pragma once
 
 #include <cerrno>
 #include <cstring>
@@ -13,9 +12,11 @@
 #include <stdexcept>
 #include <sstream>
 
-#include "memory/MallocStrategy.h"
+#include <memory/MallocStrategy.h>
 #include "storage/BaseAttributeVector.h"
 
+namespace hyrise {
+namespace storage {
 
 template <typename T>
 class AbstractFixedLengthVector : public BaseAttributeVector<T> {
@@ -32,7 +33,7 @@ class FixedLengthVector : public AbstractFixedLengthVector<T> {
   size_t _allocated_bytes;
 
   std::mutex _allocate_mtx;
-  using Strategy = MallocStrategy;
+  using Strategy = memory::MallocStrategy;
  public:
   typedef T value_type;
   
@@ -167,4 +168,5 @@ class FixedLengthVector : public AbstractFixedLengthVector<T> {
   }
 };
 
-#endif  // SRC_LIB_STORAGE_FIXEDLENGTHVECTOR_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/GroupValue.cpp
+++ b/src/lib/storage/GroupValue.cpp
@@ -9,6 +9,9 @@
 
 #include "boost/functional/hash.hpp"
 
+namespace hyrise {
+namespace storage {
+
 u_int64_t GroupValue::hash_vids(const ValueIdList &vids) {
   u_int64_t h = FNV1_64_INIT;
   for(const ValueId& v: vids) {
@@ -34,4 +37,6 @@ size_t GroupValue::hash_group_values(hyrise::storage::atable_ptr_t source, const
 
   return seed;
 }
+
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/GroupValue.h
+++ b/src/lib/storage/GroupValue.h
@@ -1,10 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_GROUPVALUE_H_
-#define SRC_LIB_STORAGE_GROUPVALUE_H_
+#pragma once
 
 #include "helper/hash.h"
 #include <storage/storage_types.h>
 #include <memory>
+
+namespace hyrise {
+namespace storage {
 
 class AbstractTable;
 
@@ -59,5 +61,5 @@ class GroupValue {
   }
 };
 
-#endif  // SRC_LIB_STORAGE_GROUPVALUE_H_
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/HashTable.cpp
+++ b/src/lib/storage/HashTable.cpp
@@ -3,8 +3,14 @@
 #include "storage/meta_storage.h"
 #include "storage/hash_functor.h"
 
+namespace hyrise {
+namespace storage {
+
 size_t hash_value(const hyrise::storage::c_atable_ptr_t &source, const size_t &f, const ValueId &vid) {
   hyrise::storage::hash_functor<size_t> fun(source.get(), f, vid);
   hyrise::storage::type_switch<hyrise_basic_types> ts;
   return ts(source->typeOfColumn(f), fun);
 }
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/HashTable.h
+++ b/src/lib/storage/HashTable.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_HASHTABLE_H_
-#define SRC_LIB_STORAGE_HASHTABLE_H_
+#pragma once
 
 #include <atomic>
 #include <algorithm>
@@ -15,6 +14,9 @@
 #include "storage/AbstractHashTable.h"
 #include "storage/AbstractTable.h"
 #include "storage/storage_types.h"
+
+namespace hyrise {
+namespace storage {
 
 template<class MAP, class KEY> class HashTableView;
 
@@ -398,4 +400,5 @@ public:
   }
 };
 
-#endif  // SRC_LIB_STORAGE_HASHTABLE_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/HorizontalTable.h
+++ b/src/lib/storage/HorizontalTable.h
@@ -5,8 +5,7 @@
  * For any undocumented method see AbstractTable.
  * @see AbstractTable
  */
-#ifndef SRC_LIB_STORAGE_HORIZONTALTABLE_H_
-#define SRC_LIB_STORAGE_HORIZONTALTABLE_H_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -47,6 +46,4 @@ class HorizontalTable : public AbstractTable {
 };
 
 }}
-
-#endif  // SRC_LIB_STORAGE_HORIZONTALTABLE_H_
 

--- a/src/lib/storage/InvertedIndex.h
+++ b/src/lib/storage/InvertedIndex.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_INVERTEDINDEX_H_
-#define SRC_LIB_STORAGE_INVERTEDINDEX_H_
+#pragma once
 
 #include <vector>
 #include <map>
@@ -14,6 +13,9 @@
 #include "storage/AbstractTable.h"
 
 #include <memory>
+
+namespace hyrise {
+namespace storage {
 
 template<typename T>
 class InvertedIndex : public AbstractIndex {
@@ -59,4 +61,6 @@ for (auto & e : _index)
   };
 
 };
-#endif  // SRC_LIB_STORAGE_INVERTEDINDEX_H_
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/MutableVerticalTable.cpp
+++ b/src/lib/storage/MutableVerticalTable.cpp
@@ -1,5 +1,8 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "storage/MutableVerticalTable.h"
+
+#include <iostream>
+
 #include "helper/vector_helpers.h"
 
 namespace hyrise { namespace storage {

--- a/src/lib/storage/MutableVerticalTable.h
+++ b/src/lib/storage/MutableVerticalTable.h
@@ -5,8 +5,7 @@
  * For any undocumented method see AbstractTable.
  * @see AbstractTable
  */
-#ifndef SRC_LIB_STORAGE_VERTICALTABLE_H_
-#define SRC_LIB_STORAGE_VERTICALTABLE_H_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -91,4 +90,3 @@ public:
 
 }}
 
-#endif  // SRC_LIB_STORAGE_VERTICALTABLE_H_

--- a/src/lib/storage/OrderIndifferentDictionary.h
+++ b/src/lib/storage/OrderIndifferentDictionary.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_ORDERINDIFFERENTDICTIONARY_H_
-#define SRC_LIB_STORAGE_ORDERINDIFFERENTDICTIONARY_H_
+#pragma once
 
 #include <exception>
 #include <vector>
@@ -13,6 +12,9 @@
 #include "storage/storage_types.h"
 #include "storage/BaseDictionary.h"
 #include "storage/DictionaryIterator.h"
+
+namespace hyrise {
+namespace storage {
 
 // FIXME should be aware of allocator
 template <typename T>
@@ -174,5 +176,5 @@ public:
 
 };
 
-#endif  // SRC_LIB_STORAGE_ORDERINDIFFERENTDICTIONARY_H_
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/OrderPreservingDictionary.h
+++ b/src/lib/storage/OrderPreservingDictionary.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_ORDERPRESERVINGDICTIONARY_H_
-#define SRC_LIB_STORAGE_ORDERPRESERVINGDICTIONARY_H_
+#pragma once
 
 #include <assert.h>
 #include <algorithm>
@@ -12,6 +11,9 @@
 #include "storage/BaseIterator.h"
 #include "storage/DictionaryIterator.h"
 #include "storage/storage_types.h"
+
+namespace hyrise {
+namespace storage {
 
 template <typename T>
 class OrderPreservingDictionaryIterator;
@@ -191,4 +193,5 @@ public:
 
 };
 
-#endif  // SRC_LIB_STORAGE_ORDERPRESERVINGDICTIONARY_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/PointerCalculator.cpp
+++ b/src/lib/storage/PointerCalculator.cpp
@@ -12,7 +12,8 @@
 #include "storage/Store.h"
 #include "storage/TableRangeView.h"
 
-using namespace hyrise::storage;
+namespace hyrise {
+namespace storage {
 
 template <typename T>
 T* copy_vec(T* orig) {
@@ -424,3 +425,6 @@ void PointerCalculator::remove(const pos_list_t& pl) {
   });
   (*pos_list).erase(res, pos_list->end());
 }
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/PointerCalculator.h
+++ b/src/lib/storage/PointerCalculator.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_POINTERCALCULATOR_H_
-#define SRC_LIB_STORAGE_POINTERCALCULATOR_H_
+#pragma once
 
 #include <vector>
 
@@ -9,6 +8,9 @@
 
 #include "storage/AbstractTable.h"
 #include "storage/MutableVerticalTable.h"
+
+namespace hyrise {
+namespace storage {
 
 class PointerCalculator : public AbstractTable,
                           public SharedFactory<PointerCalculator> {
@@ -80,5 +82,5 @@ public:
   size_t slice_count;
 };
 
-#endif  // SRC_LIB_STORAGE_POINTERCALCULATOR_H_
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/PrettyPrinter.cpp
+++ b/src/lib/storage/PrettyPrinter.cpp
@@ -167,7 +167,7 @@ void PrettyPrinter::printDiff(const storage::c_atable_ptr_t& input, const TableD
 };
 
 void PrettyPrinter::print(const AbstractTable* const input, std::ostream& outStream, const std::string tableName, const size_t& limit, const size_t& start) {
-  const RawTable* r = dynamic_cast<const RawTable*>(input);
+  auto* r = dynamic_cast<const RawTable*>(input);
   if (r) {
     special_print(r, outStream, tableName, limit, start);
   } else {

--- a/src/lib/storage/PrettyPrinter.h
+++ b/src/lib/storage/PrettyPrinter.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_PRETTYPRINTER_H_
-#define SRC_LIB_STORAGE_PRETTYPRINTER_H_
+#pragma once
 
 #include "helper/types.h"
 #include "ftprinter/FTPrinter.h"
@@ -29,4 +28,4 @@ class PrettyPrinter {
 };
 
 }}
-#endif // SRC_LIB_STORAGE_PRETTYPRINTER_H_
+

--- a/src/lib/storage/RawTable.cpp
+++ b/src/lib/storage/RawTable.cpp
@@ -7,9 +7,7 @@
 #include "storage/meta_storage.h"
 #include "storage/ColumnMetadata.h"
 
-namespace hyrise { namespace storage {
-
-namespace rawtable {
+namespace hyrise { namespace storage { namespace rawtable {
 
 RowHelper::RowHelper(const metadata_vec_t& m) : _m(m) {
   _tempData.resize(m.size(), nullptr);
@@ -71,26 +69,7 @@ void RowHelper::set(size_t index, std::string val) {
   _tempData[index] = tmp;
 }
 
-
-}
-
-
-
-}
-
-template <typename T>
-std::string to_string(T val) {
-  return std::to_string(val);
-}
-
-template <>
-std::string to_string(const std::string& val) { return val; }
-template <>
-std::string to_string(std::string& val) { return val; }
-template <>
-std::string to_string(std::string val) { return val; }
-
-}
+} // namespace rawtable
 
 RawTable::RawTable(const metadata_vec_t& m,
                    size_t initial_size) : _metadata(m), _width(m.size()), _size(0) {
@@ -149,6 +128,18 @@ RawTable::byte* RawTable::computePosition(const size_t& column, const size_t& ro
   return tuple;
 }
 
+template <typename T>
+std::string to_string(T val) {
+  return std::to_string(val);
+}
+
+template <>
+std::string to_string(const std::string& val) { return val; }
+template <>
+std::string to_string(std::string& val) { return val; }
+template <>
+std::string to_string(std::string val) { return val; }
+
 struct convert_to_string_functor {
   typedef std::string value_type;
   const RawTable& _table;
@@ -162,13 +153,12 @@ struct convert_to_string_functor {
 
   template<typename R>
   std::string operator()() {
-    return hyrise::to_string(_table.template getValue<R>(_col, _row));
+    return to_string(_table.template getValue<R>(_col, _row));
   }
 };
 
-
 std::string RawTable::printValue(const size_t col, const size_t row) const {
-  hyrise::storage::type_switch<hyrise_basic_types> ts;
+  type_switch<hyrise_basic_types> ts;
   convert_to_string_functor f(*this, col, row);
   return ts(_metadata.at(col).getType(), f);
 }
@@ -200,13 +190,13 @@ void RawTable::appendRow(byte* tuple) {
 struct type_func {
   typedef void value_type;
 
-  const hyrise::storage::atable_ptr_t& _source;
-  hyrise::storage::rawtable::RowHelper& _rh;
+  const atable_ptr_t& _source;
+  rawtable::RowHelper& _rh;
   const size_t& _col;
   const size_t& _row;
 
   type_func(const hyrise::storage::atable_ptr_t& source,
-            hyrise::storage::rawtable::RowHelper& rh,
+            rawtable::RowHelper& rh,
             const size_t& column,
             const size_t& row) : _source(source), _rh(rh), _col(column), _row(row) {}
 
@@ -219,7 +209,7 @@ struct type_func {
 void RawTable::appendRows(const hyrise::storage::atable_ptr_t& rows) {
   hyrise::storage::type_switch<hyrise_basic_types> ts;
   for(size_t row=0; row < rows->size(); ++row) {
-    hyrise::storage::rawtable::RowHelper rh(_metadata);
+   rawtable::RowHelper rh(_metadata);
     for(size_t column=0; column < _metadata.size(); ++column) {
       type_func tf(rows, rh, column, row);
       ts(rows->typeOfColumn(column), tf);
@@ -232,3 +222,5 @@ void RawTable::appendRows(const hyrise::storage::atable_ptr_t& rows) {
 void RawTable::debugStructure(size_t level) const {
   std::cout << std::string(level, '\t') << "RawTable " << this << std::endl;
 }
+
+} } // namespace hyrise::storage

--- a/src/lib/storage/RawTable.h
+++ b/src/lib/storage/RawTable.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_RAWTABLE_H_
-#define SRC_LIB_STORAGE_RAWTABLE_H_
+#pragma once
 
 #include <cassert>
 #include <cstring>
@@ -68,9 +67,7 @@ void RowHelper::set(size_t index, std::string val);
 template<>
 std::string RowHelper::convert(const byte *d, DataType t);
 
-
-}}}
-
+} // namespace rawtable
 
 class RawTable : public AbstractTable {
   typedef unsigned char byte;
@@ -162,11 +159,11 @@ public:
   
   ////////////////////////////////////////////////////////////////////////////////////////
   // Disabled Methodsw 
-  virtual hyrise::storage::atable_ptr_t copy_structure(const field_list_t *fields = nullptr, 
-                                                        const bool reuse_dict = false, 
-                                                        const size_t initial_size = 0, 
-                                                        const bool with_containers = true, 
-                                                        const bool compressed = false) const {
+  virtual atable_ptr_t copy_structure(const field_list_t *fields = nullptr, 
+                                      const bool reuse_dict = false, 
+                                      const size_t initial_size = 0, 
+                                      const bool with_containers = true, 
+                                      const bool compressed = false) const {
     STORAGE_NOT_IMPLEMENTED(RawTable, copy_structure());
   }
 
@@ -207,4 +204,6 @@ public:
 
 
 };
-#endif // SRC_LIB_STORAGE_RAWTABLE_H_
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/SequentialHeapMerger.cpp
+++ b/src/lib/storage/SequentialHeapMerger.cpp
@@ -7,6 +7,8 @@
 #include "storage/DictionaryIterator.h"
 #include "storage/ColumnMetadata.h"
 
+namespace hyrise {
+namespace storage {
 
 void SequentialHeapMerger::mergeValues(const std::vector<hyrise::storage::c_atable_ptr_t > &input_tables,
                                        hyrise::storage::atable_ptr_t merged_table,
@@ -236,3 +238,6 @@ void SequentialHeapMerger::copyValues(const std::vector<hyrise::storage::c_atabl
 AbstractMerger *SequentialHeapMerger::copy() {
   return new SequentialHeapMerger();
 }
+
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/SequentialHeapMerger.h
+++ b/src/lib/storage/SequentialHeapMerger.h
@@ -1,10 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_SEQUENTIALHEAPMERGER_H_
-#define SRC_LIB_STORAGE_SEQUENTIALHEAPMERGER_H_
+#pragma once
 
 #include <storage/ValueIdMap.hpp>
 #include <storage/AbstractTable.h>
 #include <storage/AbstractMerger.h>
+
+namespace hyrise {
+namespace storage {
 
 class SequentialHeapMerger : public AbstractMerger {
 public:
@@ -49,4 +51,5 @@ private:
 
 };
 
-#endif  // SRC_LIB_STORAGE_SEQUENTIALHEAPMERGER_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/Serial.cpp
+++ b/src/lib/storage/Serial.cpp
@@ -1,5 +1,9 @@
 #include "Serial.h"
 
+namespace hyrise {
+namespace storage {
+
+
 Serial::Serial() {
   reset();
 }
@@ -11,3 +15,5 @@ void Serial::reset() {
 Serial::serial_t Serial::next() {
   return _serial++;
 }
+
+} } // namespace hyrise::storage

--- a/src/lib/storage/Serial.h
+++ b/src/lib/storage/Serial.h
@@ -1,9 +1,11 @@
-#ifndef SRC_LIB_STORAGE_SERIAL_H_
-#define SRC_LIB_STORAGE_SERIAL_H_
+#pragma once
 
 #include "AbstractResource.h"
 
 #include <atomic>
+
+namespace hyrise {
+namespace storage {
 
 /// A Serial class that can be used to define auto_increment columns for
 //tables. For each column a serial will be stored in the resource manager
@@ -24,5 +26,5 @@ class Serial : public AbstractResource {
   serial_t next();
 };
 
-#endif
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/SimpleStore.cpp
+++ b/src/lib/storage/SimpleStore.cpp
@@ -95,3 +95,4 @@ void SimpleStore::debugStructure(size_t level) const {
 
 
 }}
+

--- a/src/lib/storage/SimpleStore.h
+++ b/src/lib/storage/SimpleStore.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_SIMPLESTORE_H_
-#define SRC_LIB_STORAGE_SIMPLESTORE_H_
+#pragma once
 
 #include <helper/types.h>
 
@@ -150,4 +149,3 @@ private:
 
 }}
 
-#endif //SRC_LIB_STORAGE_SIMPLESTORE_H_

--- a/src/lib/storage/SimpleStoreMerger.cpp
+++ b/src/lib/storage/SimpleStoreMerger.cpp
@@ -177,3 +177,4 @@ void SimpleStoreMerger::mergeValues(const std::vector<hyrise::storage::c_atable_
 }
 
 }}
+

--- a/src/lib/storage/SimpleStoreMerger.h
+++ b/src/lib/storage/SimpleStoreMerger.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_SIMPLESTOREMERGER_H_
-#define SRC_LIB_STORAGE_SIMPLESTOREMERGER_H_
+#pragma once
 
 #include "AbstractMerger.h"
 
@@ -22,4 +21,4 @@ class SimpleStoreMerger : public AbstractMerger {
 };
 
 }}
-#endif // SRC_LIB_STORAGE_SIMPLESTOREMERGER_H_
+

--- a/src/lib/storage/Store.cpp
+++ b/src/lib/storage/Store.cpp
@@ -2,7 +2,6 @@
 #include <storage/Store.h>
 #include <iostream>
 
-
 #include <io/TransactionManager.h>
 #include <storage/storage_types.h>
 #include <storage/PrettyPrinter.h>

--- a/src/lib/storage/Store.h
+++ b/src/lib/storage/Store.h
@@ -6,8 +6,7 @@
  * @see AbstractTable
  */
 
-#ifndef SRC_LIB_STORAGE_STORE_H_
-#define SRC_LIB_STORAGE_STORE_H_
+#pragma once
 
 #include <storage/MutableVerticalTable.h>
 #include <storage/AbstractTable.h>
@@ -113,5 +112,3 @@ public:
 
 }}
 
-
-#endif  // SRC_LIB_STORAGE_STORE_H_

--- a/src/lib/storage/Table.cpp
+++ b/src/lib/storage/Table.cpp
@@ -3,12 +3,14 @@
 
 #include <cassert>
 #include <cmath>
+#include <iostream>
 
 #include "storage/AttributeVectorFactory.h"
 #include "storage/DictionaryFactory.h"
 #include "storage/ValueIdMap.hpp"
 
-using namespace hyrise::storage;
+namespace hyrise {
+namespace storage {
 
 Table::Table(
   std::vector<const ColumnMetadata *> *m,
@@ -72,7 +74,7 @@ Table::Table(std::vector<ColumnMetadata> m,
 }
 
 
-hyrise::storage::atable_ptr_t Table::copy_structure(const field_list_t *fields, const bool reuse_dict, const size_t initial_size, const bool with_containers, const bool compressed) const {
+atable_ptr_t Table::copy_structure(const field_list_t *fields, const bool reuse_dict, const size_t initial_size, const bool with_containers, const bool compressed) const {
 
   std::vector<const ColumnMetadata *> metadata;
   std::vector<AbstractTable::SharedDictionaryPtr> *dictionaries = nullptr;
@@ -106,7 +108,7 @@ hyrise::storage::atable_ptr_t Table::copy_structure(const field_list_t *fields, 
 }
 
 
-hyrise::storage::atable_ptr_t Table::copy_structure_modifiable(const field_list_t *fields, const size_t initial_size, const bool with_containers) const {
+atable_ptr_t Table::copy_structure_modifiable(const field_list_t *fields, const size_t initial_size, const bool with_containers) const {
 
   std::vector<const ColumnMetadata *> metadata;
   std::vector<AbstractTable::SharedDictionaryPtr > *dictionaries = new std::vector<AbstractTable::SharedDictionaryPtr >;
@@ -131,7 +133,7 @@ hyrise::storage::atable_ptr_t Table::copy_structure_modifiable(const field_list_
 
 }
 
-hyrise::storage::atable_ptr_t Table::copy_structure(abstract_dictionary_callback ad, abstract_attribute_vector_callback aav) const {
+atable_ptr_t Table::copy_structure(abstract_dictionary_callback ad, abstract_attribute_vector_callback aav) const {
   std::vector<ColumnMetadata> metadata;
   std::vector<AbstractTable::SharedDictionaryPtr > dicts;
 
@@ -225,7 +227,7 @@ void Table::setAttributes(SharedAttributeVector doc) {
 }
 
 
-hyrise::storage::atable_ptr_t Table::copy() const {
+atable_ptr_t Table::copy() const {
   auto new_table = std::make_shared<table_type>(new std::vector<const ColumnMetadata *>(_metadata.begin(), _metadata.end()));
 
   new_table->width = width;
@@ -241,4 +243,10 @@ hyrise::storage::atable_ptr_t Table::copy() const {
 
   return new_table;
 }
+
+void Table::debugStructure(size_t level) const {
+  std::cout << std::string(level, '\t') << "Table " << this << std::endl;
+}
+
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/Table.h
+++ b/src/lib/storage/Table.h
@@ -5,8 +5,7 @@
  * For any undocumented method see AbstractTable.
  * @see AbstractTable
  */
-#ifndef SRC_LIB_STORAGE_TABLE_H_
-#define SRC_LIB_STORAGE_TABLE_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -20,6 +19,9 @@
 
 #include "storage/BaseAttributeVector.h"
 #include "storage/AttributeVectorFactory.h"
+
+namespace hyrise {
+namespace storage {
 
 /**
  * Table is the innermost entity in the table structure. It stores the actual
@@ -130,10 +132,8 @@ public:
     return { t };
   }
 
-  virtual void debugStructure(size_t level=0) const {
-    std::cout << std::string(level, '\t') << "Table " << this << std::endl;
-  }
+  virtual void debugStructure(size_t level=0) const;
 };
 
-#endif  // SRC_LIB_STORAGE_TABLE_H_
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/TableBuilder.cpp
+++ b/src/lib/storage/TableBuilder.cpp
@@ -70,3 +70,4 @@ hyrise::storage::atable_ptr_t TableBuilder::build(param_list args, const bool co
 
 
 }}
+

--- a/src/lib/storage/TableBuilder.h
+++ b/src/lib/storage/TableBuilder.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_TABLEBUILDER_H_
-#define SRC_LIB_STORAGE_TABLEBUILDER_H_
+#pragma once
 
 #include <stddef.h>
 #include <string>
@@ -120,4 +119,3 @@ private:
 
 }}
 
-#endif  // SRC_LIB_STORAGE_TABLEBUILDER_H_

--- a/src/lib/storage/TableDiff.cpp
+++ b/src/lib/storage/TableDiff.cpp
@@ -146,4 +146,5 @@ TableDiff TableDiff::diffTables(const AbstractTable* const left,
   return diff;
 }
 
-}}
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/TableDiff.h
+++ b/src/lib/storage/TableDiff.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_TABLEDIFF_H_
-#define SRC_LIB_STORAGE_TABLEDIFF_H_
+#pragma once
 
 #include <vector>
 #include <map>
@@ -8,12 +7,11 @@
 
 #include <storage/storage_types.h>
 
-class AbstractTable;
 
 namespace hyrise { namespace storage {
+class AbstractTable;
 
 class TableDiff {
-
 public:
   enum RelationEqType {RelationEq, RelationEqSorted};
   enum FieldCorrectness {FieldCorrect, FieldWrongType, FieldWrong};
@@ -40,4 +38,3 @@ public:
 
 }}
 
-#endif //SRC_LIB_STORAGE_TABLEDIFF_H_

--- a/src/lib/storage/TableFactory.cpp
+++ b/src/lib/storage/TableFactory.cpp
@@ -1,5 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include "TableFactory.h"
 
+namespace hyrise {
+namespace storage {
+
 AbstractTableFactory::~AbstractTableFactory() {}
+
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/TableFactory.h
+++ b/src/lib/storage/TableFactory.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_TABLEFACTORY_H_
-#define SRC_LIB_STORAGE_TABLEFACTORY_H_
+#pragma once
 
 #include <memory>
 
@@ -8,6 +7,9 @@
 
 #include "storage/AbstractTable.h"
 #include "storage/Table.h"
+
+namespace hyrise {
+namespace storage {
 
 class AbstractTableFactory {
 public:
@@ -30,4 +32,5 @@ class TableFactory : public AbstractTableFactory {
   }
 };
 
-#endif  // SRC_LIB_STORAGE_TABLEFACTORY_H_
+} } // namespace hyrise::storage
+

--- a/src/lib/storage/TableGenerator.cpp
+++ b/src/lib/storage/TableGenerator.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
 #include <storage/TableGenerator.h>
 
-
 #include <math.h>
 #include <assert.h>
 #include <algorithm>
@@ -972,3 +971,4 @@ hyrise::storage::atable_ptr_t TableGenerator::int_random_weighted_delta(size_t r
 
 
 }}
+

--- a/src/lib/storage/TableGenerator.h
+++ b/src/lib/storage/TableGenerator.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_TABLEGENERATOR_H_
-#define SRC_LIB_STORAGE_TABLEGENERATOR_H_
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -90,4 +89,3 @@ class TableGenerator {
 
 }}
 
-#endif  // SRC_LIB_STORAGE_TABLEGENERATOR_H_

--- a/src/lib/storage/TableMerger.cpp
+++ b/src/lib/storage/TableMerger.cpp
@@ -5,6 +5,9 @@
 
 #include "storage/AbstractMerger.h"
 
+namespace hyrise {
+namespace storage {
+
 hyrise::storage::column_mapping_t identityMap(hyrise::storage::atable_ptr_t input) {
   hyrise::storage::column_mapping_t map;
   for (size_t column_index = 0; column_index < input->columnCount(); ++column_index)
@@ -88,4 +91,7 @@ std::vector<hyrise::storage::atable_ptr_t > TableMerger::merge(std::vector<hyris
 TableMerger *TableMerger::copy() {
   return new TableMerger(_strategy->copy(), _merger->copy());
 }
+
+} } // namespace hyrise::storage
+
 

--- a/src/lib/storage/TableMerger.h
+++ b/src/lib/storage/TableMerger.h
@@ -1,13 +1,14 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-
-#ifndef SRC_LIB_STORAGE_TABLEMERGER_H_
-#define SRC_LIB_STORAGE_TABLEMERGER_H_
+#pragma once
 
 #include <vector>
 #include <helper/types.h>
 #include <storage/AbstractTable.h>
 #include <storage/AbstractMergeStrategy.h>
 #include <storage/AbstractMerger.h>
+
+namespace hyrise {
+namespace storage {
 
 class TableMerger {
 public:
@@ -36,4 +37,4 @@ private:
   const bool _compress;
 };
 
-#endif  // SRC_LIB_STORAGE_TABLEMERGER_H_
+} } // namespace hyrise::storage

--- a/src/lib/storage/TableRangeView.h
+++ b/src/lib/storage/TableRangeView.h
@@ -6,8 +6,7 @@
  *      Author: jwust
  */
 
-#ifndef TABLERANGEVIEW_H_
-#define TABLERANGEVIEW_H_
+#pragma once
 
 #include "storage/AbstractTable.h"
 #include "helper/SharedFactory.h"
@@ -64,4 +63,3 @@ public:
 
 }}
 
-#endif /* TABLERANGEVIEW_H_ */

--- a/src/lib/storage/TableUtils.cpp
+++ b/src/lib/storage/TableUtils.cpp
@@ -22,3 +22,4 @@ column_mapping_t calculateMapping(
 }
 
 }}
+

--- a/src/lib/storage/TableUtils.h
+++ b/src/lib/storage/TableUtils.h
@@ -1,14 +1,12 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_TABLEUTILS_H_
-#define SRC_LIB_STORAGE_TABLEUTILS_H_
+#pragma once
 
 #include <memory>
 #include <unordered_map>
 
-class AbstractTable;
-
 namespace hyrise {
 namespace storage {
+class AbstractTable;
 
 typedef std::unordered_map<size_t, size_t> column_mapping_t;
 
@@ -21,4 +19,3 @@ column_mapping_t calculateMapping(const AbstractTable &input,
 
 }}
 
-#endif

--- a/src/lib/storage/ValueIdMap.hpp
+++ b/src/lib/storage/ValueIdMap.hpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_VALUEIDMAP_HPP_
-#define SRC_LIB_STORAGE_VALUEIDMAP_HPP_
+#pragma once
 
 #include <storage/OrderPreservingDictionary.h>
 #include <storage/OrderIndifferentDictionary.h>
 
-#endif  // SRC_LIB_STORAGE_VALUEIDMAP_HPP_

--- a/src/lib/storage/cast_functor.h
+++ b/src/lib/storage/cast_functor.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_ACCESS_CAST_FUNCTOR_H_
-#define SRC_LIB_ACCESS_CAST_FUNCTOR_H_
+#pragma once
 
 #include <boost/lexical_cast.hpp>
 
@@ -44,4 +43,3 @@ struct cast_functor_by_row {
 
 }}
 
-#endif

--- a/src/lib/storage/hash_functor.h
+++ b/src/lib/storage/hash_functor.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_HASH_FUNCTOR_H_
-#define SRC_LIB_STORAGE_HASH_FUNCTOR_H_
+#pragma once
 
 #include <functional>
 
@@ -33,4 +32,3 @@ struct hash_functor {
 
 }}
 
-#endif

--- a/src/lib/storage/meta_storage.h
+++ b/src/lib/storage/meta_storage.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_META_STORAGE_H_
-#define SRC_LIB_STORAGE_META_STORAGE_H_
+#pragma once
 
 #include <stdexcept>
 
@@ -54,6 +53,4 @@ struct type_switch<L, N, true> {
 
 
 }}
-
-#endif  // SRC_LIB_STORAGE_META_STORAGE_H_
 

--- a/src/lib/storage/storage_types.h
+++ b/src/lib/storage/storage_types.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_STORAGE_TYPES_H_
-#define SRC_LIB_STORAGE_STORAGE_TYPES_H_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -90,10 +89,12 @@ class ValueId {
 
 typedef std::vector<ValueId> ValueIdList;
 
+namespace hyrise { namespace storage {
+
 class ColumnMetadata;
 typedef std::vector<const ColumnMetadata *> metadata_list;
 typedef std::vector<metadata_list *> compound_metadata_list;
 typedef std::vector<ColumnMetadata> metadata_vec_t;
 
-#endif  // SRC_LIB_STORAGE_STORAGE_TYPES_H_
+} } // namespace hyrise::storage
 

--- a/src/lib/storage/storage_types_helper.cpp
+++ b/src/lib/storage/storage_types_helper.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <algorithm>
 
+namespace hyrise {
+
 std::string data_type_to_string(DataType d) {
   switch (d) {
     case IntegerType:
@@ -37,4 +39,6 @@ pos_list_t *pos_list_intersection(pos_list_t *p1, pos_list_t *p2, const bool del
 
   return result;
 }
+
+} // namespace hyrise
 

--- a/src/lib/storage/storage_types_helper.h
+++ b/src/lib/storage/storage_types_helper.h
@@ -1,12 +1,13 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_STORAGE_STORAGE_TYPES_HELPER_H_
-#define SRC_LIB_STORAGE_STORAGE_TYPES_HELPER_H_
+#pragma once
 
 #include <memory>
 
 #include "storage/meta_storage.h"
 #include "storage/cast_functor.h"
 #include "storage/PointerCalculator.h"
+
+namespace hyrise {
 
 std::string data_type_to_string(DataType d);
 
@@ -21,9 +22,9 @@ struct HyriseHelper {
    * @param valueId ID of the value to be casted.
    */
   template <typename T>
-  static T castValue(const AbstractTable *table, const size_t column, const ValueId valueId) {
-    hyrise::storage::cast_functor_by_value_id<T> f(const_cast<AbstractTable *>(table), column, valueId);
-    hyrise::storage::type_switch<hyrise_basic_types> ts;
+  static T castValue(const storage::AbstractTable *table, const size_t column, const ValueId valueId) {
+    storage::cast_functor_by_value_id<T> f(const_cast<storage::AbstractTable *>(table), column, valueId);
+    storage::type_switch<hyrise_basic_types> ts;
     return ts(table->typeOfColumn(column), f);
   }
 
@@ -35,15 +36,13 @@ struct HyriseHelper {
    * @param row    Row of the cell containing the value.
    */
   template <typename T>
-  static T castValueByColumnRow(const AbstractTable *table, const size_t column, const size_t row) {
-    hyrise::storage::cast_functor_by_row<T> f(const_cast<AbstractTable *>(table), column, row);
-    hyrise::storage::type_switch<hyrise_basic_types> ts;
+  static T castValueByColumnRow(const storage::AbstractTable *table, const size_t column, const size_t row) {
+    storage::cast_functor_by_row<T> f(const_cast<storage::AbstractTable *>(table), column, row);
+    storage::type_switch<hyrise_basic_types> ts;
     return ts(table->typeOfColumn(column), f);
   }
 
 };
 
-
-
-#endif  // SRC_LIB_STORAGE_STORAGE_TYPES_HELPER_H_
+} // namespace hyrise
 

--- a/src/lib/taskscheduler/AbstractCoreBoundQueue.cpp
+++ b/src/lib/taskscheduler/AbstractCoreBoundQueue.cpp
@@ -14,6 +14,9 @@
 #include <iostream>
 #include <helper/HwlocHelper.h>
 
+namespace hyrise {
+namespace taskscheduler {
+
 log4cxx::LoggerPtr AbstractCoreBoundQueue::logger(log4cxx::Logger::getLogger("taskscheduler.AbstractCoreBoundQueue"));
 
 
@@ -81,3 +84,6 @@ void AbstractCoreBoundQueue::launchThread(int core) {
     throw std::logic_error("CPU to run thread on is larger than number of total cores; seems that TaskQueue was initialized outside of SimpleTaskScheduler, which should not happen");
   }
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/AbstractCoreBoundQueue.h
+++ b/src/lib/taskscheduler/AbstractCoreBoundQueue.h
@@ -5,11 +5,13 @@
  *      Author: jwust
  */
 
-#ifndef ABSTRACTCOREBOUNDQUEUE_H_
-#define ABSTRACTCOREBOUNDQUEUE_H_
+#pragma once
 
 #include "taskscheduler/AbstractTaskQueue.h"
 #include <atomic>
+
+namespace hyrise {
+namespace taskscheduler {
 
 class AbstractCoreBoundQueue : public AbstractTaskQueue{
 
@@ -60,5 +62,5 @@ public:
   }
 };
 
-#endif /* ABSTRACTCOREBOUNDQUEUE_H_ */
+} } // namespace hyrise::taskscheduler
 

--- a/src/lib/taskscheduler/AbstractCoreBoundQueuesScheduler.cpp
+++ b/src/lib/taskscheduler/AbstractCoreBoundQueuesScheduler.cpp
@@ -7,6 +7,9 @@
 
 #include "AbstractCoreBoundQueuesScheduler.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 log4cxx::LoggerPtr AbstractCoreBoundQueuesScheduler::_logger = log4cxx::Logger::getLogger("taskscheduler.AbstractCoreBoundQueuesScheduler");
 
 
@@ -86,3 +89,6 @@ void AbstractCoreBoundQueuesScheduler::shutdown() {
   }
   _status = STOPPED;
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/AbstractCoreBoundQueuesScheduler.h
+++ b/src/lib/taskscheduler/AbstractCoreBoundQueuesScheduler.h
@@ -5,12 +5,14 @@
  *      Author: jwust
  */
 
-#ifndef ABSTRACTCOREBOUNDQUEUESSCHEDULER_H_
-#define ABSTRACTCOREBOUNDQUEUESSCHEDULER_H_
+#pragma once
 
 #include "AbstractTaskScheduler.h"
 #include "AbstractCoreBoundQueue.h"
 #include <atomic>
+
+namespace hyrise {
+namespace taskscheduler {
 
 class AbstractCoreBoundQueuesScheduler : 
   public AbstractTaskScheduler,
@@ -84,4 +86,5 @@ class AbstractCoreBoundQueuesScheduler :
 
 };
 
-#endif /* ABSTRACTCOREBOUNDQUEUESSCHEDULER_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/AbstractTaskQueue.h
+++ b/src/lib/taskscheduler/AbstractTaskQueue.h
@@ -6,8 +6,7 @@
  *      Author: jwust
  */
 
-#ifndef SRC_LIB_TASKSCHEDULER_ABSTRACTTASKQUEUE_H_
-#define SRC_LIB_TASKSCHEDULER_ABSTRACTTASKQUEUE_H_
+#pragma once
 
 #include <memory>
 #include <thread>
@@ -17,6 +16,9 @@
 #include <taskscheduler/Task.h>
 
 #include "helper/locking.h"
+
+namespace hyrise {
+namespace taskscheduler {
 
 class AbstractTaskQueue {
 
@@ -47,4 +49,5 @@ class AbstractTaskQueue {
   virtual void join() = 0;
 };
 
-#endif  // SRC_LIB_TASKSCHEDULER_ABSTRACTTASKQUEUE_H_
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/AbstractTaskScheduler.h
+++ b/src/lib/taskscheduler/AbstractTaskScheduler.h
@@ -6,8 +6,7 @@
  *      Author: jwust
  */
 
-#ifndef SRC_LIB_TASKSCHEDULER_ABSTRACTTASKSCHEDULER_H_
-#define SRC_LIB_TASKSCHEDULER_ABSTRACTTASKSCHEDULER_H_
+#pragma once
 
 /*
  * Base class for Task Schedulers
@@ -23,6 +22,8 @@
 #include "helper/HwlocHelper.h"
 #include "helper/locking.h"
 
+namespace hyrise {
+namespace taskscheduler {
 
 class AbstractTaskScheduler {
   /*
@@ -63,4 +64,5 @@ class AbstractTaskScheduler {
   virtual size_t getNumberOfWorker() const = 0;
 };
 
-#endif  // SRC_LIB_TASKSCHEDULER_ABSTRACTTASKSCHEDULER_H_
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CentralPriorityScheduler.cpp
+++ b/src/lib/taskscheduler/CentralPriorityScheduler.cpp
@@ -7,6 +7,9 @@
 
 #include "CentralPriorityScheduler.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 log4cxx::LoggerPtr CentralPriorityScheduler::_logger = log4cxx::Logger::getLogger("taskscheduler.CentralPriorityScheduler");
 
 // register Scheduler at SharedScheduler
@@ -177,3 +180,6 @@ void CentralPriorityScheduler::notifyReady(std::shared_ptr<Task> task) {
     // should never happen, but check to identify potential race conditions
     LOG4CXX_ERROR(_logger, "Task that notified to be ready to run was not found / found more than once in waitSet! " << std::to_string(tmp));
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CentralPriorityScheduler.h
+++ b/src/lib/taskscheduler/CentralPriorityScheduler.h
@@ -5,8 +5,7 @@
  *      Author: jwust
  */
 
-#ifndef CENTRALPRIORITYSCHEDULER_H_
-#define CENTRALPRIORITYSCHEDULER_H_
+#pragma once
 
 #include "AbstractTaskScheduler.h"
 #include "helper/HwlocHelper.h"
@@ -16,6 +15,9 @@
 #include <vector>
 #include <condition_variable>
 #include <taskscheduler/SharedScheduler.h>
+
+namespace hyrise {
+namespace taskscheduler {
 
 class CentralPriorityScheduler;
 
@@ -83,4 +85,5 @@ public:
 
 };
 
-#endif /* CENTRALPRIORITYSCHEDULER_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CentralScheduler.cpp
+++ b/src/lib/taskscheduler/CentralScheduler.cpp
@@ -7,6 +7,9 @@
 
 #include "CentralScheduler.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 log4cxx::LoggerPtr CentralScheduler::_logger = log4cxx::Logger::getLogger("taskscheduler.CentralScheduler");
 
 // register Scheduler at SharedScheduler
@@ -175,3 +178,6 @@ void CentralScheduler::notifyReady(std::shared_ptr<Task> task) {
     // should never happen, but check to identify potential race conditions
     LOG4CXX_ERROR(_logger, "Task that notified to be ready to run was not found / found more than once in waitSet! " << std::to_string(tmp));
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CentralScheduler.h
+++ b/src/lib/taskscheduler/CentralScheduler.h
@@ -5,8 +5,7 @@
  *      Author: jwust
  */
 
-#ifndef CENTRALSCHEDULER_H_
-#define CENTRALSCHEDULER_H_
+#pragma once
 
 #include "AbstractTaskScheduler.h"
 #include "helper/HwlocHelper.h"
@@ -15,6 +14,9 @@
 #include <queue>
 #include <condition_variable>
 #include <taskscheduler/SharedScheduler.h>
+
+namespace hyrise {
+namespace taskscheduler {
 
 class CentralScheduler;
 
@@ -82,4 +84,5 @@ public:
 
 };
 
-#endif /* CENTRALSCHEDULER_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CoreBoundPriorityQueue.cpp
+++ b/src/lib/taskscheduler/CoreBoundPriorityQueue.cpp
@@ -13,6 +13,9 @@
 #include <algorithm>
 #include <sched.h>
 
+namespace hyrise {
+namespace taskscheduler {
+
 void CoreBoundPriorityQueue::executeTask() {
 
   //infinite thread loop
@@ -109,3 +112,6 @@ std::vector<std::shared_ptr<Task> > CoreBoundPriorityQueue::emptyQueue() {
 CoreBoundPriorityQueue::~CoreBoundPriorityQueue() {
   if (_thread != nullptr) stopQueue();
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CoreBoundPriorityQueue.h
+++ b/src/lib/taskscheduler/CoreBoundPriorityQueue.h
@@ -5,13 +5,15 @@
  *      Author: jwust
  */
 
-#ifndef COREBOUNDPRIORITYQUEUE_H_
-#define COREBOUNDPRIORITYQUEUE_H_
+#pragma once
 
 #include "AbstractCoreBoundQueue.h"
 #include <vector>
 #include <queue>
 #include "tbb/concurrent_priority_queue.h"
+
+namespace hyrise {
+namespace taskscheduler {
 
 /*
  * A queue with a dedicated worker thread; used by SimpleTaskScheduler to run tasks
@@ -51,4 +53,5 @@ class CoreBoundPriorityQueue : public AbstractCoreBoundQueue {
   }
 };
 
-#endif /* COREBOUNDPRIORITYQUEUE_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CoreBoundPriorityQueuesScheduler.cpp
+++ b/src/lib/taskscheduler/CoreBoundPriorityQueuesScheduler.cpp
@@ -10,6 +10,9 @@
 #include "SharedScheduler.h"
 #include <memory>
 
+namespace hyrise {
+namespace taskscheduler {
+
 // register Scheduler at SharedScheduler
 namespace {
 bool registered  =
@@ -58,8 +61,7 @@ size_t CoreBoundPriorityQueuesScheduler::getNextQueue(){
   return next;
 }
 
-void CoreBoundPriorityQueuesScheduler::pushToQueue(std::shared_ptr<Task> task)
-{
+void CoreBoundPriorityQueuesScheduler::pushToQueue(std::shared_ptr<Task> task) {
   count++;
   // check if task should be scheduled on specific core
   int core = task->getPreferredCore();
@@ -84,3 +86,6 @@ void CoreBoundPriorityQueuesScheduler::pushToQueue(std::shared_ptr<Task> task)
     //std::cout << "Task " <<  task->vname() << /*"; hex " << std::hex << &task << std::dec << */" pushed to queue " << _nextQueue << " count " << count << std::endl;
   }
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CoreBoundPriorityQueuesScheduler.h
+++ b/src/lib/taskscheduler/CoreBoundPriorityQueuesScheduler.h
@@ -5,8 +5,7 @@
  *      Author: jwust
  */
 
-#ifndef COREBOUNDPRIORITYQUEUESSCHEDULER_H_
-#define COREBOUNDPRIORITYQUEUESSCHEDULER_H_
+#pragma once
 
 #include "taskscheduler/Task.h"
 #include "taskscheduler/CoreBoundPriorityQueue.h"
@@ -15,6 +14,8 @@
 #include <unordered_set>
 #include <log4cxx/logger.h>
 
+namespace hyrise {
+namespace taskscheduler {
 
 /**
  * a task scheduler with thread specific queues
@@ -41,5 +42,5 @@ public:
 
 };
 
-#endif /* COREBOUNDPRIORITYQUEUESSCHEDULER_H_ */
+} } // namespace hyrise::taskscheduler
 

--- a/src/lib/taskscheduler/CoreBoundQueue.cpp
+++ b/src/lib/taskscheduler/CoreBoundQueue.cpp
@@ -13,6 +13,9 @@
 #include <algorithm>
 #include <sched.h>
 
+namespace hyrise {
+namespace taskscheduler {
+
 void CoreBoundQueue::executeTask() {
   size_t retries = 0;
   //infinite thread loop
@@ -118,3 +121,6 @@ std::vector<std::shared_ptr<Task> > CoreBoundQueue::emptyQueue() {
 CoreBoundQueue::~CoreBoundQueue() {
   if (_thread != nullptr) stopQueue();
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CoreBoundQueue.h
+++ b/src/lib/taskscheduler/CoreBoundQueue.h
@@ -5,12 +5,14 @@
  *      Author: jwust
  */
 
-#ifndef COREBOUNDQUEUE_H_
-#define COREBOUNDQUEUE_H_
+#pragma once
 
 #include "AbstractCoreBoundQueue.h"
 #include <vector>
 #include <queue>
+
+namespace hyrise {
+namespace taskscheduler {
 
 /*
  * A queue with a dedicated worker thread; used by SimpleTaskScheduler to run tasks
@@ -50,4 +52,5 @@ class CoreBoundQueue : public AbstractCoreBoundQueue {
   }
 };
 
-#endif /* COREBOUNDQUEUE_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/CoreBoundQueuesScheduler.cpp
+++ b/src/lib/taskscheduler/CoreBoundQueuesScheduler.cpp
@@ -10,6 +10,9 @@
 #include "SharedScheduler.h"
 #include <memory>
 
+namespace hyrise {
+namespace taskscheduler {
+
 // register Scheduler at SharedScheduler
 namespace {
 bool registered  =
@@ -83,4 +86,5 @@ void CoreBoundQueuesScheduler::pushToQueue(std::shared_ptr<Task> task)
   }
 }
 
+} } // namespace hyrise::taskscheduler
 

--- a/src/lib/taskscheduler/CoreBoundQueuesScheduler.h
+++ b/src/lib/taskscheduler/CoreBoundQueuesScheduler.h
@@ -5,8 +5,7 @@
  *      Author: jwust
  */
 
-#ifndef COREBOUNDQUEUESSCHEDULER_H_
-#define COREBOUNDQUEUESSCHEDULER_H_
+#pragma once
 
 #include "taskscheduler/Task.h"
 #include "taskscheduler/CoreBoundQueue.h"
@@ -15,6 +14,8 @@
 #include <unordered_set>
 #include <log4cxx/logger.h>
 
+namespace hyrise {
+namespace taskscheduler {
 
 /**
  * a task scheduler with thread specific queues
@@ -37,4 +38,5 @@ public:
 
 };
 
-#endif /* COREBOUNDQUEUESSCHEDULER_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/SharedScheduler.cpp
+++ b/src/lib/taskscheduler/SharedScheduler.cpp
@@ -1,6 +1,12 @@
 #include "taskscheduler/SharedScheduler.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 SharedScheduler& SharedScheduler::getInstance() {
   static SharedScheduler s;
   return s;
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/SharedScheduler.h
+++ b/src/lib/taskscheduler/SharedScheduler.h
@@ -6,11 +6,13 @@
  *      Author: jwust
  */
 
-#ifndef SRC_LIB_TASKSCHEDULER_SHAREDSCHEDULER_H_
-#define SRC_LIB_TASKSCHEDULER_SHAREDSCHEDULER_H_
+#pragma once
 
 #include <taskscheduler/AbstractTaskScheduler.h>
 #include <stdexcept>
+
+namespace hyrise {
+namespace taskscheduler {
 
 struct AbstractTaskSchedulerFactory {
   virtual std::shared_ptr<AbstractTaskScheduler> create(int cores) const = 0;
@@ -90,4 +92,5 @@ public:
   static SharedScheduler &getInstance();
 };
 
-#endif  // SRC_LIB_TASKSCHEDULER_SHAREDSCHEDULER_H_
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/Task.cpp
+++ b/src/lib/taskscheduler/Task.cpp
@@ -11,6 +11,9 @@
 #include <iostream>
 #include <thread>
 
+namespace hyrise {
+namespace taskscheduler {
+
 void Task::lockForNotifications() {
   _notifyMutex.lock();
 }
@@ -140,3 +143,6 @@ void SleepTask::operator()() {
 void SyncTask::operator()() {
   //do nothing
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/Task.h
+++ b/src/lib/taskscheduler/Task.h
@@ -6,8 +6,7 @@
  *      Author: jwust
  */
 
-#ifndef SRC_LIB_TASKSCHEDULER_TASK_H_
-#define SRC_LIB_TASKSCHEDULER_TASK_H_
+#pragma once
 
 #include <vector>
 #include <memory>
@@ -15,6 +14,9 @@
 #include <string>
 
 #include "helper/locking.h"
+
+namespace hyrise {
+namespace taskscheduler {
 
 class Task;
 
@@ -230,4 +232,5 @@ public:
   const std::string vname(){return "SyncTask";};
 };
 
-#endif  // SRC_LIB_TASKSCHEDULER_TASK_H_
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/ThreadPerTaskScheduler.cpp
+++ b/src/lib/taskscheduler/ThreadPerTaskScheduler.cpp
@@ -7,6 +7,8 @@
 
 #include "ThreadPerTaskScheduler.h"
 
+namespace hyrise {
+namespace taskscheduler {
 
 log4cxx::LoggerPtr ThreadPerTaskScheduler::_logger = log4cxx::Logger::getLogger("taskscheduler.ThreadPerTaskScheduler");
 
@@ -78,3 +80,6 @@ void ThreadPerTaskScheduler::notifyReady(std::shared_ptr<Task> task) {
     LOG4CXX_ERROR(_logger, "Task that notified to be ready to run was not found / found more than once in waitSet! " << std::to_string(tmp));
   }
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/ThreadPerTaskScheduler.h
+++ b/src/lib/taskscheduler/ThreadPerTaskScheduler.h
@@ -5,8 +5,7 @@
  *      Author: jwust
  */
 
-#ifndef THREADPERTASKSCHEDULER_H_
-#define THREADPERTASKSCHEDULER_H_
+#pragma once
 
 #include "AbstractTaskScheduler.h"
 #include <taskscheduler/SharedScheduler.h>
@@ -15,6 +14,8 @@
 #include <thread>
 #include <queue>
 
+namespace hyrise {
+namespace taskscheduler {
 
 // our worker thread objects
 class TaskExecutor {
@@ -64,4 +65,5 @@ public:
   void notifyReady(std::shared_ptr<Task> task);
 };
 
-#endif /* THREADPERTASKSCHEDULER_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/WSCoreBoundPriorityQueue.cpp
+++ b/src/lib/taskscheduler/WSCoreBoundPriorityQueue.cpp
@@ -7,6 +7,9 @@
 
 #include "WSCoreBoundPriorityQueue.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 WSCoreBoundPriorityQueue::WSCoreBoundPriorityQueue(int core, WSCoreBoundPriorityQueuesScheduler *scheduler): AbstractCoreBoundQueue(), _allQueues(nullptr) {
   _core = core;
   _scheduler = scheduler;
@@ -134,3 +137,6 @@ std::vector<std::shared_ptr<Task> > WSCoreBoundPriorityQueue::emptyQueue() {
 void WSCoreBoundPriorityQueue::refreshQueues(){
   _allQueues = _scheduler->getTaskQueues();
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/WSCoreBoundPriorityQueue.h
+++ b/src/lib/taskscheduler/WSCoreBoundPriorityQueue.h
@@ -5,12 +5,14 @@
  *      Author: jwust
  */
 
-#ifndef WSCOREBOUNDPRIORITYQUEUE_H_
-#define WSCOREBOUNDPRIORITYQUEUE_H_
+#pragma once
 
 #include "WSCoreBoundPriorityQueuesScheduler.h"
 #include "AbstractCoreBoundQueue.h"
 #include "tbb/concurrent_priority_queue.h"
+
+namespace hyrise {
+namespace taskscheduler {
 
 class WSCoreBoundPriorityQueuesScheduler;
 
@@ -56,4 +58,5 @@ public:
   void refreshQueues();
 };
 
-#endif /* WSCOREBOUNDPRIORITYQUEUE_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/WSCoreBoundPriorityQueuesScheduler.cpp
+++ b/src/lib/taskscheduler/WSCoreBoundPriorityQueuesScheduler.cpp
@@ -9,6 +9,9 @@
 #include "WSCoreBoundPriorityQueue.h"
 #include "SharedScheduler.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 // register Scheduler at SharedScheduler
 namespace {
 bool registered  =
@@ -85,5 +88,7 @@ void WSCoreBoundPriorityQueuesScheduler::pushToQueue(std::shared_ptr<Task> task)
 
 WSCoreBoundPriorityQueuesScheduler::task_queue_t *WSCoreBoundPriorityQueuesScheduler::createTaskQueue(int core) {
     return new WSCoreBoundPriorityQueue(core, this);
-  }
+}
+
+} } // namespace hyrise::taskscheduler
 

--- a/src/lib/taskscheduler/WSCoreBoundPriorityQueuesScheduler.h
+++ b/src/lib/taskscheduler/WSCoreBoundPriorityQueuesScheduler.h
@@ -5,11 +5,13 @@
  *      Author: jwust
  */
 
-#ifndef WSCOREBOUNDPRIORITYQUEUESSCHEDULER_H_
-#define WSCOREBOUNDPRIORITYQUEUESSCHEDULER_H_
+#pragma once
 
 #include "AbstractCoreBoundQueuesScheduler.h"
 #include "AbstractCoreBoundQueue.h"
+
+namespace hyrise {
+namespace taskscheduler {
 
 class WSCoreBoundPriorityQueuesScheduler : public AbstractCoreBoundQueuesScheduler {
 
@@ -31,5 +33,5 @@ public:
   const std::vector<AbstractCoreBoundQueue *> *getTaskQueues();
 };
 
+} } // namespace hyrise::taskscheduler
 
-#endif /* WSCOREBOUNDPRIORITYQUEUESSCHEDULER_H_ */

--- a/src/lib/taskscheduler/WSCoreBoundQueue.cpp
+++ b/src/lib/taskscheduler/WSCoreBoundQueue.cpp
@@ -7,6 +7,9 @@
 
 #include "WSCoreBoundQueue.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 WSCoreBoundQueue::WSCoreBoundQueue(int core, WSCoreBoundQueuesScheduler *scheduler): AbstractCoreBoundQueue() {
   _core = core;
   _scheduler = scheduler;
@@ -136,3 +139,6 @@ std::vector<std::shared_ptr<Task> > WSCoreBoundQueue::emptyQueue() {
     tmp.push_back(*it);
   return tmp;
 }
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/WSCoreBoundQueue.h
+++ b/src/lib/taskscheduler/WSCoreBoundQueue.h
@@ -5,12 +5,14 @@
  *      Author: jwust
  */
 
-#ifndef WSCOREBOUNDQUEUE_H_
-#define WSCOREBOUNDQUEUE_H_
+#pragma once
 
 #include <deque>
 #include "WSCoreBoundQueuesScheduler.h"
 #include "AbstractCoreBoundQueue.h"
+
+namespace hyrise {
+namespace taskscheduler {
 
 class WSCoreBoundQueuesScheduler;
 
@@ -50,4 +52,5 @@ public:
   std::shared_ptr<Task> stealTask();
 };
 
-#endif /* WSCOREBOUNDQUEUE_H_ */
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/WSCoreBoundQueuesScheduler.cpp
+++ b/src/lib/taskscheduler/WSCoreBoundQueuesScheduler.cpp
@@ -9,6 +9,9 @@
 #include "WSCoreBoundQueue.h"
 #include "SharedScheduler.h"
 
+namespace hyrise {
+namespace taskscheduler {
+
 // register Scheduler at SharedScheduler
 namespace {
 bool registered  =
@@ -79,6 +82,9 @@ void WSCoreBoundQueuesScheduler::pushToQueue(std::shared_ptr<Task> task) {
     }
   }
 
-  WSCoreBoundQueuesScheduler::task_queue_t *WSCoreBoundQueuesScheduler::createTaskQueue(int core) {
-    return new WSCoreBoundQueue(core, this);
-  }
+WSCoreBoundQueuesScheduler::task_queue_t *WSCoreBoundQueuesScheduler::createTaskQueue(int core) {
+  return new WSCoreBoundQueue(core, this);
+}
+
+} } // namespace hyrise::taskscheduler
+

--- a/src/lib/taskscheduler/WSCoreBoundQueuesScheduler.h
+++ b/src/lib/taskscheduler/WSCoreBoundQueuesScheduler.h
@@ -5,11 +5,13 @@
  *      Author: jwust
  */
 
-#ifndef WSCOREBOUNDQUEUESSCHEDULER_H_
-#define WSCOREBOUNDQUEUESSCHEDULER_H_
+#pragma once
 
 #include "AbstractCoreBoundQueuesScheduler.h"
 #include "AbstractCoreBoundQueue.h"
+
+namespace hyrise {
+namespace taskscheduler {
 
 class WSCoreBoundQueuesScheduler : public AbstractCoreBoundQueuesScheduler {
 
@@ -32,5 +34,5 @@ public:
 
 };
 
+} } // namespace hyrise::taskscheduler
 
-#endif /* WSCOREBOUNDQUEUESSCHEDULER_H_ */

--- a/src/lib/testing/TableEqualityTest.cpp
+++ b/src/lib/testing/TableEqualityTest.cpp
@@ -5,7 +5,9 @@
 #include <storage/TableDiff.h>
 #include <storage/PrettyPrinter.h>
 
-using namespace hyrise::storage;
+namespace hyrise {
+
+using namespace storage;
 
 std::string schemaErrors(TableDiff diff, const char* relationName, tblptr table) {
   std::vector<std::string> fieldError, fieldTypeError;
@@ -169,3 +171,6 @@ std::string rowPositionErrors(TableDiff diff, const char* baseRelationName, cons
 
   return ::testing::AssertionSuccess();
 }
+
+} // namespace hyrise
+

--- a/src/lib/testing/TableEqualityTest.h
+++ b/src/lib/testing/TableEqualityTest.h
@@ -1,9 +1,10 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_BIN_UNITS_STORAGE_TABLE_EQUAL_TEST_H
-#define SRC_BIN_UNITS_STORAGE_TABLE_EQUAL_TEST_H
+#pragma once
 
 #include "gtest/gtest.h"
 #include "helper/types.h"
+
+namespace hyrise {
 
 typedef const hyrise::storage::c_atable_ptr_t& tblptr;
 
@@ -59,4 +60,6 @@ typedef const hyrise::storage::c_atable_ptr_t& tblptr;
 #define EXPECT_SORTED_RELATION_EQ EXPECT_PRED_FORMAT2(SortedRelationEquals, a, b)
 #define EXPECT_SORTED_RELATION_NEQ EXPECT_PRED_FORMAT2(SortedRelationEquals, a, b)
 
-#endif //SRC_BIN_UNITS_STORAGE_TABLE_EQUAL_TEST_H
+} // namespace hyrise
+
+

--- a/src/lib/testing/base_test.h
+++ b/src/lib/testing/base_test.h
@@ -1,16 +1,16 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_TESTING_BASE_TEST_H_
-#define SRC_LIB_TESTING_BASE_TEST_H_
+#pragma once
 
 #include <gtest/gtest.h>
 
 namespace hyrise {
+
 class Test : public ::testing::Test {
  public:
   virtual ~Test() {};
   virtual void SetUp() {}
   virtual void TearDown() {}
 };
-}
 
-#endif
+} // namespace hyrise
+

--- a/src/lib/testing/test.cpp
+++ b/src/lib/testing/test.cpp
@@ -4,6 +4,8 @@
 #include "storage/AbstractTable.h"
 #include "storage/PrettyPrinter.h"
 
+namespace hyrise {
+
 ::testing::AssertionResult AssertTableContentEquals(const char *left_exp,
                                                     const char *right_exp,
                                                     const hyrise::storage::c_atable_ptr_t left,
@@ -19,3 +21,6 @@
   return ::testing::AssertionFailure() << buf.str()
                                        << "The content of " << left_exp << " does not equal the content of " << right_exp;
 }
+
+} // namespace hyrise
+

--- a/src/lib/testing/test.h
+++ b/src/lib/testing/test.h
@@ -1,15 +1,16 @@
 // Copyright (c) 2012 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#ifndef SRC_LIB_TESTING_TEST_H_
-#define SRC_LIB_TESTING_TEST_H_
+#pragma once
 
 #include <algorithm>
 
 #include "gtest/gtest.h"
 #include "testing/base_test.h"
-#include "io/StorageManager.h"
+#include "io/ResourceManager.h"
 
 #include "helper/types.h"
 #include "helper/stringhelpers.h"
+
+namespace hyrise {
 
 template<typename It1, typename It2>
 ::testing::AssertionResult contains_all(const It1 a, const It2 b) {
@@ -36,16 +37,12 @@ template<typename It1, typename It2>
 #define ASSERT_TABLE_EQUAL(a,b) EXPECT_PRED_FORMAT2(AssertTableContentEquals, a, b)
 
 
-
-namespace hyrise {
-
 class StorageManagerTest : public Test {
  public:
   virtual ~StorageManagerTest() {};
 
   virtual void SetUp() {
-    StorageManager *sm = StorageManager::getInstance();
-    sm->removeAll();
+    io::ResourceManager::getInstance().clear();
   }
 
   virtual void TearDown() {
@@ -57,14 +54,13 @@ namespace access {
 class AccessTest : public Test {
  public:
   virtual void SetUp() {
-    StorageManager *sm = StorageManager::getInstance();
-    sm->removeAll();
+    io::ResourceManager::getInstance().clear();
   }
 
   virtual void TearDown() {
   }
 };
 
-}
-}
-#endif  // SRC_LIB_TESTING_TEST_H_
+} // namespace access
+} // namespace hyrise
+


### PR DESCRIPTION
- more pragma once
- more auto (where namespaces would just have to been verbosely written)
- some lines removed (if obviously unnesessary and namespaces would have to be
  applyed)
- removed some now unnessesary namesapce references (mostly "hyrise::")
