### PR TITLE
Fixed concurrency issue in InsertScan and PosUpdateScan:

### DIFF
--- a/src/lib/access/InsertScan.cpp
+++ b/src/lib/access/InsertScan.cpp
@@ -83,16 +83,15 @@ void InsertScan::executePlanOperation() {
   if (!_data)
     _data = buildFromJson();
 
-  // Delta Table Size
-  const auto& beforSize = store->size();
-
   auto writeArea = store->appendToDelta(_data->size());
+
+  const size_t firstPosition = store->getMainTable()->size() + writeArea.first;
 
   // Get the modifications record
   auto& mods = tx::TransactionManager::getInstance()[_txContext.tid];
   for(size_t i=0, upper = _data->size(); i < upper; ++i) {
     store->copyRowToDelta(_data, i, writeArea.first+i, _txContext.tid);
-    mods.insertPos(store, beforSize+i);
+    mods.insertPos(store, firstPosition+i);
   }
 
   auto rsp = getResponseTask();

--- a/src/lib/access/PosUpdateScan.cpp
+++ b/src/lib/access/PosUpdateScan.cpp
@@ -35,12 +35,11 @@ void PosUpdateScan::executePlanOperation() {
   // Cast the constness away
   auto store = std::const_pointer_cast<storage::Store>(c_store);
 
-  // Get the current maximum size
-  const auto& beforSize = store->size();
-
   // Get the offset for inserts into the delta and the size of the delta that
   // we need to increase by the positions we are inserting
   auto writeArea = store->appendToDelta(c_pc->getPositions()->size());
+
+  const size_t firstPosition = store->getMainTable()->size() + writeArea.first;
 
   // Get the modification record for the current transaction
   auto& txmgr = tx::TransactionManager::getInstance();
@@ -71,7 +70,7 @@ void PosUpdateScan::executePlanOperation() {
     }
 
     // Insert the new one
-    modRecord.insertPos(store, beforSize+counter);
+    modRecord.insertPos(store, firstPosition+counter);
     ++counter;
   }
 


### PR DESCRIPTION
Thread A: fetch before_size
Thread B: fetch before_size
B: append_to_delta
A: append_to_delta
For A, before_size+i is not the correct way to address its new rows anymore
