### PR TITLE
Bugfixes / Improvements to DynamicPriorityScheduler

### DIFF
--- a/src/lib/access/RadixJoin.cpp
+++ b/src/lib/access/RadixJoin.cpp
@@ -72,6 +72,14 @@ size_t RadixJoin::getTotalTableSize() {
   return inputTable->size() + inputTable2->size();
 }
 
+double RadixJoin::calcMinMts(double totalTblSizeIn100k) {
+  return min_mts_a() / totalTblSizeIn100k + min_mts_b();
+}
+
+double RadixJoin::calcA(double totalTblSizeIn100k) {
+  return a_a() * std::pow(totalTblSizeIn100k, 2) + a_b();
+}
+
 // FIXME merge logic with RadixJoinTransformation.
 std::vector<taskscheduler::task_ptr_t> RadixJoin::applyDynamicParallelization(size_t dynamicCount){
 
@@ -100,7 +108,7 @@ std::vector<taskscheduler::task_ptr_t> RadixJoin::applyDynamicParallelization(si
   size_t degree = std::min(dynamicCount, RadixJoin::MaxParallelizationDegree);
 
   // create ops and edges for probe side
-  auto probe_side = build_probe_side(_operatorId + "_probe", _indexed_field_definition[0], degree, _bits1, _bits2, _dependencies[0]);
+  auto probe_side = build_probe_side(_operatorId + "_probe", _indexed_field_definition[0], dynamicCount, _bits1, _bits2, _dependencies[0]);
 
   tasks.insert(tasks.end(), probe_side.begin(), probe_side.end());
 

--- a/src/lib/access/RadixJoin.h
+++ b/src/lib/access/RadixJoin.h
@@ -24,10 +24,12 @@ protected:
   // for determineDynamicCount
   // overridden from PlanOperation
   virtual size_t getTotalTableSize();
-  virtual double min_mts_a() { return 0.208081598456783; }
-  virtual double min_mts_b() { return -5.12106533314949; }
-  virtual double a_a() { return 137.365747455395; }
-  virtual double a_b() { return -3540.54997935958; }
+  virtual double calcMinMts(double totalTblSizeIn100k);
+  virtual double calcA(double totalTblSizeIn100k);
+  virtual double min_mts_a() { return -32.7333223568781 ; }
+  virtual double min_mts_b() { return 20.6071622571548 ; }
+  virtual double a_a() { return 0.0499042793549051 ; }
+  virtual double a_b() { return 251.463168551956 ; }
 
 private:
   uint32_t _bits1;

--- a/src/lib/access/TableScan.h
+++ b/src/lib/access/TableScan.h
@@ -26,10 +26,10 @@ class TableScan : public ParallelizablePlanOperation {
 
   // for determineDynamicCount
   virtual size_t getTotalTableSize();
-  virtual double min_mts_a() { return 0.00858530861116717; }
-  virtual double min_mts_b() { return -0.0867733147921817; }
-  virtual double a_a() { return 1.18977354704548; }
-  virtual double a_b() { return -0.820926547220339; }
+  virtual double min_mts_a() { return 0.0552475752421333; }
+  virtual double min_mts_b() { return -0.0850757329978712; }
+  virtual double a_a() { return 3.38149153671817; }
+  virtual double a_b() { return 12.2562615548958; }
  private:
   std::unique_ptr<AbstractExpression> _expr;
 };

--- a/src/lib/access/system/PlanOperation.cpp
+++ b/src/lib/access/system/PlanOperation.cpp
@@ -25,6 +25,14 @@ size_t PlanOperation::getTotalTableSize(){
   return 0;
 }
 
+double PlanOperation::calcMinMts(double totalTblSizeIn100k) {
+  return min_mts_a() * totalTblSizeIn100k + min_mts_b();
+}
+
+double PlanOperation::calcA(double  totalTblSizeIn100k) {
+  return a_a() * totalTblSizeIn100k + a_b();
+}
+
 size_t PlanOperation::determineDynamicCount(size_t maxTaskRunTime) {
   // this can never be satisfied. Default to NO parallelization.
   if (maxTaskRunTime == 0) {
@@ -42,14 +50,14 @@ size_t PlanOperation::determineDynamicCount(size_t maxTaskRunTime) {
   auto totalTblSizeIn100k = totalTableSize / 100000.0;
 
   // this is the b of the mts = a / instances + b  model
-  auto minMts = min_mts_a() * totalTblSizeIn100k + min_mts_b();
+  auto minMts = calcMinMts(totalTblSizeIn100k);
   
   if (maxTaskRunTime < minMts) {
     LOG4CXX_ERROR(logger, planOperationName() << ": Could not honor MTS request. Too small.");
     return 1024;
   } 
 
-  auto a = a_a() * totalTblSizeIn100k + a_b();
+  auto a = calcA(totalTblSizeIn100k);
   size_t numTasks = std::max(1, static_cast<int>(round(a/(maxTaskRunTime - minMts))));
 
   LOG4CXX_DEBUG(logger, planOperationName() << ": tts(in 100k): " << totalTblSizeIn100k << ", numTasks: " << numTasks);

--- a/src/lib/access/system/PlanOperation.h
+++ b/src/lib/access/system/PlanOperation.h
@@ -45,10 +45,26 @@ class PlanOperation : public OutputTask {
   /* Returns all errors of dependencies as one concatenated std::string */
   std::string getDependencyErrorMessages();
 
-  /* for determineDynamicCount */
+
+  /* 
+   * The model used is based on a/x + b as an equation, whereas x
+   * is the number of instances used. The result is the mean task execution time
+   * for this operator. a and b are parameters based on the input table size.
+   * b also denotes the minimal possible mean task execution time.
+   * It thus sets the minimal achievable mts.
+   * for determineDynamicCount 
+   */
   virtual size_t getTotalTableSize();
-  // these are a and b for two straight lines y=a*x+b used in the model.
-  // override in subclasses for actual fitting parameters.
+  /* determine the b parameter also known as minimal achievable mts */
+  virtual double calcMinMts(double totalTblSizeIn100k);
+  /* determine the a parameter of the model. */
+  virtual double calcA(double totalTblSizeIn100k);
+  /*
+   * The standard implementation of the calc* method assume
+   * a straight line model with a*x + b.
+   * You can either override the following parameters in your operator
+   * or you can supply your calc* methods.
+   */
   virtual double min_mts_a() { return 0; }
   virtual double min_mts_b() { return 0; }
   virtual double a_a() { return 0; }

--- a/src/lib/taskscheduler/Task.cpp
+++ b/src/lib/taskscheduler/Task.cpp
@@ -99,6 +99,11 @@ void Task::changeDependency(std::shared_ptr<Task> from, std::shared_ptr<Task> to
     
     std::lock_guard<decltype(_depMutex)> lk(_depMutex);
     // find from dependencies
+    for(size_t i = 0, size = _dependencies.size(); i < size; i++){
+      if(_dependencies[i] == from){
+        _dependencies[i] = to;
+      }
+    }
     // add new done observer
     to->addDoneObserver(std::dynamic_pointer_cast<Task>(shared_from_this()));
 }
@@ -107,6 +112,14 @@ void Task::setDependencies(std::vector<std::shared_ptr<Task> > dependencies, int
     std::lock_guard<decltype(_depMutex)> lk(_depMutex);
     _dependencies = dependencies;
     _dependencyWaitCount = 0;
+}
+
+bool Task::isDependency(const task_ptr_t& task) {
+  std::lock_guard<decltype(_depMutex)> lk(_depMutex);
+  return std::any_of(
+      _dependencies.begin(),
+      _dependencies.end(),
+      [task](task_ptr_t t) {return t == task;});
 }
 
 void Task::addReadyObserver(const std::shared_ptr<TaskReadyObserver>& observer) {

--- a/src/lib/taskscheduler/Task.h
+++ b/src/lib/taskscheduler/Task.h
@@ -135,7 +135,10 @@ public:
    * currently used to set dependencies for a task that is ready to run (no unmet dependencies), but needs to get inputs
    */
    void setDependencies(std::vector<task_ptr_t> dependencies, int count);
-
+  /*
+   * check if the supplied task is a direct dependency of this task.
+   */
+  bool isDependency(const task_ptr_t& task);
   /*
    * adds an observer that gets notified if this task is ready to run
    */


### PR DESCRIPTION
- RadixJoin no longer caps the probe phase to 24 instances.
- A new fitting model for the TableScan has been added.
- A new fitting model for the RadixJoin has been added.
- Added missing code for changeDependency + regression tests.
