### PR TITLE
Eliminated shared_count contention in AbstractTable

### DIFF
--- a/src/lib/storage/AbstractTable.h
+++ b/src/lib/storage/AbstractTable.h
@@ -333,12 +333,12 @@ public:
    * @param valueId ID of the value to be returned.
    */
   template <typename T>
-  inline T getValueForValueId(const field_t column, const ValueId valueId) const {
+  inline T getValueForValueId(const field_t column, const ValueId valueId, const size_t row=0) const {
     typedef BaseDictionary<T> dict_t;
     if (valueId.table != 0) {
       return (static_cast<dict_t *>(dictionaryByTableId(column, valueId.table).get()))->getValueForValueId(valueId.valueId);
     } else {
-      return (static_cast<dict_t *>(dictionaryAt(column, 0, valueId.table).get()))->getValueForValueId(valueId.valueId);
+      return (static_cast<dict_t *>(dictionaryAt(column, row).get()))->getValueForValueId(valueId.valueId);
     }
   }
 
@@ -351,13 +351,8 @@ public:
    */
   template <typename T>
   T getValue(const field_t column, const size_t row) const {
-    typedef BaseDictionary<T> dict_t;
     ValueId valueId = getValueId(column, row);
-    if (valueId.table != 0) {
-        return (static_cast<dict_t *>(dictionaryByTableId(column, valueId.table).get()))->getValueForValueId(valueId.valueId);
-    } else {
-        return (static_cast<dict_t *>(dictionaryAt(column, row, valueId.table).get()))->getValueForValueId(valueId.valueId);
-    }
+    return getValueForValueId<T>(column, valueId, row);
   }
 
 


### PR DESCRIPTION
The static_pointer_cast on the AbstractDictionary implicitly creates a
shared pointer on the dictionary. This increases the shared_count for
this dictionary. Since this is an atomic operation, the lock might be
contended for heavily. This was the case in a pipelining scenario, where
multiple pointer calculators are based on the same table/dictionaries to
account for the chunks passed on to the next operator; with an
increasing number of chunks, the lock on the shared pointer became the
main bottleneck causing significant degradation in performance.

The lock has been eliminated by using raw pointers. It's not necessary
to have a shared_ptr here, since the table already owns the dictionary.
