### PR TITLE
Locking fix in DynamicTaskQueue

### DIFF
--- a/src/lib/taskscheduler/DynamicTaskQueue.h
+++ b/src/lib/taskscheduler/DynamicTaskQueue.h
@@ -40,8 +40,8 @@ class DynamicTaskQueue : public ThreadLevelQueue<QUEUE> {
           ThreadLevelQueue<QUEUE>::_queuecheck.notify_all();
         } else {
           i->addReadyObserver(ThreadLevelQueue<QUEUE>::shared_from_this());
+          i->unlockForNotifications();
         }
-        i->unlockForNotifications();
       }
     } else {  // task is not dynamic
       _runQueue.push(task);
@@ -61,8 +61,8 @@ class DynamicTaskQueue : public ThreadLevelQueue<QUEUE> {
         }
       } else {
         task->addReadyObserver(ThreadLevelQueue<QUEUE>::shared_from_this());
+        task->unlockForNotifications();
       }
-      task->unlockForNotifications();
     } else {
       ThreadLevelQueue<QUEUE>::schedule(task);
     }

--- a/src/lib/taskscheduler/ThreadLevelQueue.h
+++ b/src/lib/taskscheduler/ThreadLevelQueue.h
@@ -60,8 +60,8 @@ class ThreadLevelQueue : public AbstractTaskScheduler,
       _queuecheck.notify_all();
     } else {
       task->addReadyObserver(shared_from_this());
+      task->unlockForNotifications();
     }
-    task->unlockForNotifications();
   }
 
   /*

--- a/src/lib/taskscheduler/ThreadLevelQueuesScheduler.h
+++ b/src/lib/taskscheduler/ThreadLevelQueuesScheduler.h
@@ -79,8 +79,8 @@ class ThreadLevelQueuesScheduler : public AbstractTaskScheduler,
       pushToQueue(task);
     } else {
       task->addReadyObserver(shared_from_this());
+      task->unlockForNotifications();
     }
-    task->unlockForNotifications();
   }
   /*
    * shutdown task scheduler; makes sure all underlying threads are stopped

--- a/src/lib/taskscheduler/ThreadPerTaskScheduler.cpp
+++ b/src/lib/taskscheduler/ThreadPerTaskScheduler.cpp
@@ -43,8 +43,8 @@ void ThreadPerTaskScheduler::schedule(const std::shared_ptr<Task>& task) {
     t.detach();
   } else {
     task->addReadyObserver(shared_from_this());
+    task->unlockForNotifications();
   }
-  task->unlockForNotifications();
 }
 /*
  * shutdown task scheduler; makes sure all underlying threads are stopped


### PR DESCRIPTION
Tasks were not properly locked for notifications whilst scheduling was
in progress. Deadlocks ensued for dynamic scheduling scenarios.
