### PR TITLE
Test that default mts value of 0 works properly.

### DIFF
--- a/src/bin/units_access/TableScan_test.cpp
+++ b/src/bin/units_access/TableScan_test.cpp
@@ -57,5 +57,14 @@ TEST(TableScan, testDynamicParallelization) {
 
   ASSERT_GT(dynamicCount2, dynamicCount1);
 }
+
+// Test assures that the default MTS value of 0
+// results in a degree of 1. This ensures that applyDynamicParallelization
+// will work properly.
+TEST(TableScan, test_mts_0_results_in_degree_1) {
+  auto eq = make_unique<EqualsExpression<hyrise_string_t>>(0, 1, "Apple Inc");
+  TableScan ts(std::move(eq));
+  ASSERT_EQ(ts.determineDynamicCount(0), 1U);
+}
 }
 }

--- a/src/bin/units_access/radix_join.cpp
+++ b/src/bin/units_access/radix_join.cpp
@@ -867,5 +867,13 @@ TEST_P(RadixDynamicCountTest, execute_and_check_result) {
 }
 
 INSTANTIATE_TEST_CASE_P(RadixJoinDynamicParallelizationTest, RadixDynamicCountTest, ::testing::Values(1, 4));
+
+// Test assures that the default MTS value of 0
+// results in a degree of 1. This ensures that applyDynamicParallelization
+// will work properly.
+TEST(RadixDynamicCountTest, mts_0_results_in_degree_1) {
+  RadixJoin rj;
+  ASSERT_EQ(rj.determineDynamicCount(0), 1U);
+}
 }
 }

--- a/src/bin/units_taskscheduler/taskscheduler.cpp
+++ b/src/bin/units_taskscheduler/taskscheduler.cpp
@@ -263,5 +263,21 @@ TEST(SchedulerBlockTest, dont_block_test_with_work_stealing) {
   ASSERT_EQ(test, true);
   scheduler->shutdown();
 }
+
+class DynamicDummyTask : public Task {
+ public:
+  virtual const std::string vname() { return "DynamicDummyTask"; }
+
+ protected:
+  bool _dynamic = true;
+};
+
+// Test assures that the default MTS value of 0
+// results in a degree of 1. This ensures that applyDynamicParallelization
+// will work properly.
+TEST(DynamicParallelization, mts_0_results_in_degree_1) {
+  DynamicDummyTask task;
+  ASSERT_EQ(task.determineDynamicCount(0), 1U);
+}
 }
 }  // namespace hyrise::taskscheduler


### PR DESCRIPTION
The default value for the mts parameter is 0. The
determineDynamicCount() method has to return a degree of 1 in that case
to ensure that all operations are properly expanded (e.g. RadixJoin)
with a degree of parallelization of one.
