### PR TITLE
Fix test output on non-NUMA systems

### DIFF
--- a/src/lib/io/GroupCommitter.cpp
+++ b/src/lib/io/GroupCommitter.cpp
@@ -28,7 +28,9 @@ GroupCommitter::~GroupCommitter() {
 
 void GroupCommitter::run() {
   // bind to numa node
-  bindCurrentThreadToNumaNode(0);
+  if (getNumberOfNodesOnSystem() > 1) {
+    bindCurrentThreadToNumaNode(0);
+  }
 
   struct timeval time_start, time_cur;
   unsigned long long elapsed_usec;


### PR DESCRIPTION
The group committer will try to bind to the current NUMA-node no matter what.
This will fail on non-NUMA systems (read: the vagrant VM). Therefore, `make
test` will have a message on stderr intermingled in its output even if the test
is not failing. This is ugly.

I propose to fix this by only attempting to bind to a node, if there are
actually different nodes on the system. I found this to be the cleanest
solution.
