### PR TITLE
WIP: Added lastCore and lastNode to performance data

### DIFF
--- a/src/lib/access/system/OutputTask.h
+++ b/src/lib/access/system/OutputTask.h
@@ -36,6 +36,8 @@ typedef struct {
   epoch_t startTime;
   epoch_t endTime;
   std::string executingThread;
+  unsigned core;
+  unsigned node;
 } performance_attributes_t;
 
 typedef std::vector<std::unique_ptr<performance_attributes_t>> performance_vector_t;

--- a/src/lib/access/system/PlanOperation.cpp
+++ b/src/lib/access/system/PlanOperation.cpp
@@ -183,9 +183,11 @@ const PlanOperation* PlanOperation::execute() {
   if (recordPerformance) {
     epoch_t endTime = get_epoch_nanoseconds();
     std::string threadId = boost::lexical_cast<std::string>(std::this_thread::get_id());
-    *_performance_attr =
-        (performance_attributes_t) {pt.value("PAPI_TOT_CYC"), pt.value(getEvent()), getEvent(), planOperationName(),
-                                    _operatorId,              startTime,            endTime,    threadId};
+    unsigned core = getCurrentCore();
+    unsigned node = getCurrentNode();
+    *_performance_attr = (performance_attributes_t) {
+        pt.value("PAPI_TOT_CYC"), pt.value(getEvent()), getEvent(), planOperationName(), _operatorId,
+        startTime,                endTime,              threadId,   core,                node};
   }
 
   setState(OpSuccess);

--- a/src/lib/access/system/ResponseTask.cpp
+++ b/src/lib/access/system/ResponseTask.cpp
@@ -171,6 +171,8 @@ Json::Value ResponseTask::generateResponseJson() {
         element["startTime"] = Json::Value((double)(attr->startTime - queryStart) / 1000000);
         element["endTime"] = Json::Value((double)(attr->endTime - queryStart) / 1000000);
         element["executingThread"] = Json::Value(attr->executingThread);
+        element["lastCore"] = Json::Value(attr->core);
+        element["lastNode"] = Json::Value(attr->node);
         json_perf.append(element);
       }
 
@@ -185,6 +187,10 @@ Json::Value ResponseTask::generateResponseJson() {
 
       std::string threadId = boost::lexical_cast<std::string>(std::this_thread::get_id());
       responseElement["executingThread"] = Json::Value(threadId);
+
+      responseElement["lastCore"] = Json::Value(getCurrentCore());
+      responseElement["lastNode"] = Json::Value(getCurrentNode());
+
       json_perf.append(responseElement);
 
       response["performanceData"] = json_perf;

--- a/src/lib/helper/HwlocHelper.h
+++ b/src/lib/helper/HwlocHelper.h
@@ -12,7 +12,12 @@
 #include <vector>
 
 int getNumberOfCoresOnSystem();
-unsigned getNodeForCore(unsigned core);
+/*
+ * Get the node for the core specificed by the supplied logical index.
+ * Returns the logical index if a node was found.
+ * Returns -1 if no node was found or if system has no nodes.
+ */
+signed getNodeForCore(unsigned core);
 hwloc_topology_t getHWTopology();
 std::vector<unsigned> getCoresForNode(hwloc_topology_t topology, unsigned node);
 unsigned getNumberOfNodes(hwloc_topology_t topology);
@@ -20,3 +25,15 @@ unsigned getNumberOfCoresPerNumaNode();
 void bindCurrentThreadToCore(int core);
 void bindCurrentThreadToNumaNode(int node);
 unsigned getNumberOfNodesOnSystem();
+/*
+ * Returns the core the calling thread last ran on.
+ * The returned index can be used as a logical hwloc index for HWLOC_OBJ_CORE
+ * objects.
+ * It returns -1 if the lookup failed.
+ */
+signed getCurrentCore();
+/*
+ * Returns the last (NUMA) node the calling thread ran on.
+ * Returns -1 if the lookup failed.
+ */
+signed getCurrentNode();


### PR DESCRIPTION
Based on hwloc_get_last_cpu_location(), output the last core and last node an
operator ran on in the performance data.
In order for this to work on non-NUMA systems, functions like getNodeForCore()
will return -1 on non-NUMA systems instead of throwing an exception.
