### PR TITLE
Fix shadowed function names

### DIFF
--- a/src/lib/access/PipeliningHashProbe.cpp
+++ b/src/lib/access/PipeliningHashProbe.cpp
@@ -113,19 +113,19 @@ void PipeliningHashProbe::fetchPositions() {
     // As soon as the current n causes the output table to reach the _chunkSize threshold,
     // we will emit a chunk and reset the _buildTablePosList and _probeTablePosList.
     if (_buildTablePosList->size() > _chunkSize) {
-      emitChunk();
+      createAndEmitChunk();
     }
   }
 
   // Emit final results.
   if (_buildTablePosList->size() > 0) {
-    emitChunk();
+    createAndEmitChunk();
   }
 
   LOG4CXX_DEBUG(logger, "Done Probing");
 }
 
-void PipeliningHashProbe::emitChunk() {
+void PipeliningHashProbe::createAndEmitChunk() {
   LOG4CXX_DEBUG(pipelineLogger, _operatorId << ": Emitting chunk.");
   PipelineEmitter<PipeliningHashProbe>::emitChunk(buildResultTable());
   // reset the positions lists

--- a/src/lib/access/PipeliningHashProbe.h
+++ b/src/lib/access/PipeliningHashProbe.h
@@ -36,7 +36,7 @@ class PipeliningHashProbe : public PlanOperation,
   template <class HashTable>
   void fetchPositions();
   std::shared_ptr<PlanOperation> getHashBuildPredecessor() const { return getFirstPredecessorOf<HashBuild>(); }
-  void emitChunk();
+  void createAndEmitChunk();
   /// Constructs resulting table from given build and probe tables' rows.
   storage::atable_ptr_t buildResultTable() const;
   void resetPosLists();

--- a/src/lib/access/SimplePipeliningTableScan.cpp
+++ b/src/lib/access/SimplePipeliningTableScan.cpp
@@ -61,19 +61,19 @@ void SimplePipeliningTableScan::executePlanOperation() {
     if ((*_comparator)(row)) {
       _pos_list->push_back(row);
       if (_pos_list->size() > _chunkSize) {
-        emitChunk();
+        createAndEmitChunk();
       }
     }
   }
   if (_pos_list->size() > 0) {
     LOG4CXX_DEBUG(_pipelineLogger, "Emitting final chunk.");
-    emitChunk();
+    createAndEmitChunk();
   } else {
     LOG4CXX_DEBUG(_pipelineLogger, "No final chunk necessary.");
   }
 }
 
-void SimplePipeliningTableScan::emitChunk() {
+void SimplePipeliningTableScan::createAndEmitChunk() {
   LOG4CXX_DEBUG(_pipelineLogger, "Emitting new chunk.");
   auto chunk = storage::PointerCalculator::create(_tbl, _pos_list);
   PipelineEmitter::emitChunk(chunk);

--- a/src/lib/access/SimplePipeliningTableScan.h
+++ b/src/lib/access/SimplePipeliningTableScan.h
@@ -32,7 +32,7 @@ class SimplePipeliningTableScan : public PlanOperation,
   bool _ofDelta = false;
   storage::pos_list_t* _pos_list = new pos_list_t();
   storage::c_atable_ptr_t _tbl = nullptr;
-  void emitChunk();
+  void createAndEmitChunk();
 };
 }
 }


### PR DESCRIPTION
Clang rightfully noticed the usage of local function overloads shadowing the
name of a virtual function. This has been fixed.
