### PR TITLE
Implemented a SQLQueryTask that transforms a SQLStatement

### DIFF
--- a/src/bin/units_access/SQLTests.cpp
+++ b/src/bin/units_access/SQLTests.cpp
@@ -1,11 +1,13 @@
 // Copyright (c) 2014 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-#include "access/sql/SQLQueryParser.h"
-#include "io/shortcuts.h"
-#include "testing/test.h"
 
+#include <access/sql/SQLQueryParser.h>
+#include <access/sql/parser/SQLParser.h>
+
+#include <io/shortcuts.h>
+
+#include <testing/test.h>
 
 using namespace hsql;
-
 
 namespace hyrise {
 namespace access {

--- a/src/lib/access/sql/SQLQueryParser.h
+++ b/src/lib/access/sql/SQLQueryParser.h
@@ -1,44 +1,33 @@
 // Copyright (c) 2014 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
-
 #ifndef SRC_LIB_ACCESS_SQL_SQLQUERYPARSER_H_
 #define SRC_LIB_ACCESS_SQL_SQLQUERYPARSER_H_
 
-#include "access/system/QueryParser.h"
-#include "access/sql/parser/SQLParser.h"
-#include "access/system/PlanOperation.h"
+#include <access/sql/typedef_helper.h>
+#include <access/system/ResponseTask.h>
 
 namespace hyrise {
 namespace access {
 namespace sql {
 
-typedef std::shared_ptr<taskscheduler::Task> task_t;
-typedef std::vector<task_t> task_list_t;
 
+/**
+ * This object parses a given SQL query string and creates SQLQueryTask objects.
+ * One task for each statement will be created.
+ */
 class SQLQueryParser {
  public:
-  SQLQueryParser();
+  SQLQueryParser(const std::string& query, std::shared_ptr<ResponseTask> response_task);
 
-  /**
-   * Transforms the SQL string into a list of Hyrise Tasks.
-   * @param[in]  query      SQL query string
-   * @param[out] result  	Last task, the result of which will be the result of the query
-   * @return  List of tasks that were extracted from the query
-   */
-  task_list_t transformSQLQuery(const std::string& query, task_t* result);
-
+  task_list_t buildSQLQueryTasks();
 
  protected:
-  /**
-   * Builds the task list out of the given sql query.
-   * @param[in]  query      SQL query string
-   *
-   */
-  task_list_t buildTaskList(const std::string& query);
+  std::string _query;
+  std::shared_ptr<ResponseTask> _response_task;
+
 };
+
 
 } // namespace sql
 } // namespace access
 } // namespace hyrise
-
-
 #endif

--- a/src/lib/access/sql/SQLQueryTask.cpp
+++ b/src/lib/access/sql/SQLQueryTask.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2014 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#include "SQLQueryTask.h"
+
+#include "access/sql/SQLStatementTransformer.h"
+#include "access/sql/parser/sqllib.h"
+
+#include "taskscheduler/AbstractTaskScheduler.h"
+#include "taskscheduler/SharedScheduler.h"
+#include "io/TransactionManager.h"
+#include "access/tx/Commit.h"
+
+using namespace hsql;
+
+namespace hyrise {
+namespace access {
+namespace sql {
+
+
+SQLQueryTask::SQLQueryTask(SQLStatement* stmt) :
+  _stmt(stmt),
+  _id(0),
+  _has_commit(false),
+  _next_task(nullptr),
+  _prev_task(nullptr),
+  _response_task(nullptr) {
+
+}
+
+SQLQueryTask::~SQLQueryTask() {
+  delete _stmt;
+}
+
+void SQLQueryTask::executePlanOperation() {
+  // Transform the statement
+  SQLStatementTransformer transformer = SQLStatementTransformer(std::to_string(_id) + ".");
+  transformer.transformStatement(_stmt);
+  _has_commit = transformer.hasCommit();
+  task_list_t tasks = transformer.getTaskList();
+
+
+  // TXContext
+  // Each SQL statement will be handled as a single transaction
+  // If we are the first task in the chain, simply get the context of this SQLQueryTask
+  // If our previouse task had no commit, we can carry over its transaction context
+  // If it had a commit we begin a new transaction
+  tx::TXContext ctx;
+  if (_prev_task == nullptr) {
+    ctx = getTXContext();
+  } else if (!_prev_task->hasCommit()) {
+    ctx = _prev_task->getTXContext();
+  } else {
+    ctx = tx::TransactionManager::beginTransaction();
+  }
+
+  // Apply all parameters from query task
+  for (task_t task : tasks) {
+    if (auto plan_op = std::dynamic_pointer_cast<PlanOperation>(task)) {
+      plan_op->setPriority(getPriority());
+      plan_op->setSessionId(getSessionId());
+      plan_op->setPlanId(getPlanId());
+      plan_op->setTXContext(ctx);
+      plan_op->setId(getId());
+
+      // register at response task for output
+      if (_response_task != nullptr)
+        _response_task->registerPlanOperation(plan_op);
+    }
+  }
+
+  // Set dependency of following QueryTask/ResponseTask
+  if (_next_task != nullptr) {
+    _next_task->addDependency(tasks.back());
+  }
+
+  // Push tasks into scheduler
+  std::shared_ptr<hyrise::taskscheduler::AbstractTaskScheduler> scheduler;
+  scheduler = taskscheduler::SharedScheduler::getInstance().getScheduler();
+  scheduler->scheduleQuery(tasks);
+}
+
+
+
+} // namespace sql
+} // namespace access
+} // namespace hyrise

--- a/src/lib/access/sql/SQLQueryTask.h
+++ b/src/lib/access/sql/SQLQueryTask.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2014 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#ifndef SRC_LIB_ACCESS_SQL_SQLQUERYTASK_H_
+#define SRC_LIB_ACCESS_SQL_SQLQUERYTASK_H_
+
+#include <access/sql/parser/SQLStatement.h>
+#include <access/sql/typedef_helper.h>
+#include <access/system/PlanOperation.h>
+#include <access/system/ResponseTask.h>
+
+namespace hyrise {
+namespace access {
+namespace sql {
+
+
+/**
+ * This task handles the execution of already parsed SQL queries.
+ * The SQLQueryParser creates a list of these tasks.
+ * Within a SQLQueryTask a SQLStatement object will be transformed into tasks
+ * and the created tasks are pushed to Scheduler.
+ */ 
+class SQLQueryTask : public PlanOperation {
+ public:
+  SQLQueryTask(hsql::SQLStatement* stmt);
+  virtual ~SQLQueryTask();
+
+  void executePlanOperation();
+
+  inline void setNextTask(task_t task) { _next_task = task; }
+  inline void setPrevTask(std::shared_ptr<SQLQueryTask> task) { _prev_task = task; }
+  inline void setId(int id) { _id = id; }
+  inline void setResponseTask(std::shared_ptr<ResponseTask> task) { _response_task = task; }
+
+  inline bool hasCommit() const { return _has_commit; }
+
+  const std::string vname() { return "SQLQueryTask"; }
+
+ private:
+  hsql::SQLStatement* _stmt;
+  int _id;
+  bool _has_commit;
+
+  task_t _next_task;
+  std::shared_ptr<SQLQueryTask> _prev_task;
+
+  std::shared_ptr<ResponseTask> _response_task;
+};
+
+
+} // namespace sql
+} // namespace access
+} // namespace hyrise
+#endif

--- a/src/lib/access/sql/SQLStatementTransformer.h
+++ b/src/lib/access/sql/SQLStatementTransformer.h
@@ -3,37 +3,35 @@
 #ifndef SRC_LIB_ACCESS_SQL_SQLSTATEMENTTRANSFORMER_H_
 #define SRC_LIB_ACCESS_SQL_SQLSTATEMENTTRANSFORMER_H_
 
-#include <algorithm>
-
-#include "access/sql/SQLQueryParser.h"
+#include <access/sql/typedef_helper.h>
+#include <access/sql/SQLQueryParser.h>
+#include <access/sql/parser/SQLParser.h>
+#include <access/tx/Commit.h>
 
 namespace hyrise {
 namespace access {
 namespace sql {
 
-typedef struct TransformationResult TransformationResult;
-
+/**
+ * This object will transform a given SQLStatement object into
+ * a list of tasks that correspond to the statement.
+ * If the transformation is not possible it will throw a std::runtime_error.
+ */
 class SQLStatementTransformer {
  public:
-
   /**
    * Initializes the SQL Statement transformer with a prefix for the ids of the operator
    * @param[in]  id_prefix  Prefix that will be used for all IDs of the the operators created in this instance
    */
   SQLStatementTransformer(std::string id_prefix);
 
-
   /**
-   * Transforms the given statement into tasks and saves those in the specified task_list reference.
+   * Transforms the given statement into tasks and saves those in a task list.
+   * This list can be retrieved by calling getTaskList().
    * @param[in]  stmt       Statement that will be transformed
-   * @param[out] task_list  Reference to total task list
-   * @return  Information about the result of the transformation
+   * @return Information about the result of the transformation
    */
   TransformationResult transformStatement(hsql::SQLStatement* stmt);
-
-
-  inline task_list_t getTaskList() { return _task_list; }
-
 
   /**
    * Throws a runtime execption
@@ -42,7 +40,67 @@ class SQLStatementTransformer {
   static inline void throwError(std::string msg) { throw std::runtime_error("Error when transforming SQL: " + msg); }
   static inline void throwError(std::string msg, std::string detail) { throw std::runtime_error("Error when transforming SQL: " + msg + " (" + detail + ")"); }
 
+  /**
+   * Get the list of tasks that the transformation generated
+   * @return List of tasks
+   */
+  inline const task_list_t& getTaskList() const { return _task_list; }
+
+  inline bool hasCommit() const { return _has_commit; }
+
  protected:
+  /**
+   * Append a plan op to the given task list and set some meta information according to the parameters
+   * @param[in]  task       The operator to be added
+   * @param[in]  name       The name of the operator
+   */
+  plan_op_t addPlanOp(plan_op_t task, std::string name);
+
+  /**
+   * Create a new PlanOperator object and append to the task list
+   * @param[in]  Name that will be set on the operator
+   * @param[in]  Dependency that will be attached to the operator (ignored if null)
+   * @return  Created plan operator
+   */
+  template<typename _T>
+  std::shared_ptr<_T> addNewPlanOp(std::string name, task_t dependency);
+
+  template<typename _T>
+  std::shared_ptr<_T> addNewPlanOp(std::string name, TransformationResult& meta);
+
+  template<typename _T>
+  std::shared_ptr<_T> addNewPlanOp(std::string name) { return addNewPlanOp<_T>(name, nullptr); }
+
+
+  std::shared_ptr<Commit> addCommit(TransformationResult& meta);
+
+
+  /**
+   * Create and add a GetTable operator for the table. Validate positions if required
+   * @param[in]  Table name
+   * @param[in]  Flag indicating whether a ValidatePositions operator should be added
+   * @return  Information about the transformation
+   */
+  TransformationResult addGetTable(std::string name, bool validate);
+
+  /**
+   * Create a SimpleTableScan based on the expression.
+   * Uses meta information to set dependencies and updates the meta.
+   * @param[in]  Filter-like expression that will be transformed into predicates
+   * @param[in/out]  Information about the input. The created operator will be automatically added
+   * @return  Created PlanOperator
+   */
+  plan_op_t addFilterOpFromExpr(hsql::Expr* expr, TransformationResult& meta);
+
+  /**
+   * Returns the next ID for an operator
+   * @return  next ID for an operator
+   */
+  inline std::string nextTaskId();
+
+
+
+
   // Documentation for the protected methods can be found in the .cpp file
   TransformationResult transformCreateStatement(hsql::CreateStatement* create);
   TransformationResult transformInsertStatement(hsql::InsertStatement* insert);
@@ -52,76 +110,22 @@ class SQLStatementTransformer {
   TransformationResult transformDropStatement(hsql::DropStatement* drop);
 
   TransformationResult transformGroupByClause(hsql::SelectStatement* stmt);
-  TransformationResult transformSelectionList(hsql::SelectStatement* stmt, TransformationResult info);
+  TransformationResult transformSelectionList(hsql::SelectStatement* stmt, const TransformationResult& input);
   TransformationResult transformTableRef(hsql::TableRef* table);
   TransformationResult transformJoinTable(hsql::TableRef* table);
   TransformationResult transformScanJoin(hsql::TableRef* table);
   TransformationResult transformHashJoin(hsql::TableRef* table);
 
-  TransformationResult addGetTable(std::string name, bool validate);
-  std::shared_ptr<PlanOperation> addFilterOpFromExpr(hsql::Expr* expr);
-
-  template<typename _T>
-  std::shared_ptr<_T> addOperator(std::string id, task_t dependency);
-
-  
-  /**
-   * Returns the next ID for an operator
-   * @return  next ID for an operator
-   */
-  inline std::string nextTaskId() { return _id_prefix + std::to_string(++_last_task_id); }
-
-  /**
-   * Append a plan op to the given task list and set some meta information according to the parameters
-   * @param[in]  task       The operator to be added
-   * @param[in]  name       The name of the operator
-   */
-  inline void appendPlanOp(std::shared_ptr<PlanOperation> task, std::string name) {
-    task->setPlanOperationName(name);
-    task->setOperatorId(nextTaskId() + " " + name);
-    _task_list.push_back(task);
-  }
 
   // Members
   task_list_t _task_list;
   std::string _id_prefix;
   int _last_task_id;
+  bool _has_commit;
+
+
 
 };
-
-
-struct TableInfo {
-  // Information about the table
-  std::vector<std::string> fields;
-  std::vector<DataType> data_types;
-  std::string name;
-
-  inline void addField(std::string field) { fields.push_back(field); }
-  inline void addField(std::string field, DataType type) { addField(field); data_types.push_back(type); }
-  inline bool containsField(std::string field) { return std::find(fields.begin(), fields.end(), field) != fields.end(); }
-  inline bool hasName(std::string name2) { return name2.compare(name) == 0; }
-  inline size_t numColumns() { return fields.size(); }
-};
-
-
-struct TransformationResult : TableInfo {
-  task_t first_task;
-  task_t last_task;
-
-
-  void append(TransformationResult other) {
-    fields     = other.fields;
-    data_types = other.data_types;
-    name       = other.name;
-    last_task  = other.last_task;
-  }
-};
-
-// Zero initializes a Transformation Result struct without causing warnings
-// TransformationResult t = ALLOC_TRANSFORMATIONRESULT();
-#define ALLOC_TRANSFORMATIONRESULT() {}
-
-
 
 
 

--- a/src/lib/access/sql/transformation_helper.h
+++ b/src/lib/access/sql/transformation_helper.h
@@ -10,17 +10,14 @@ namespace hyrise {
 namespace access {
 namespace sql {
 
-
 #define LOG_META(meta) \
   printf("Columns: "); \
   for (std::string col : meta.fields) printf("%s ", col.c_str()); printf("\n");
 
-
-
 /**
  * Combines two vectors into a new single vector
  * Note: since this is a template it has to be explicitely instatiated
- * This happens in the source file. It is instatiated for std::string
+ * This happens in the source file. It is instantiated for std::string
  * @param v1	std::vector
  * @param v2	std::vector
  * @return std::vector

--- a/src/lib/access/sql/typedef_helper.h
+++ b/src/lib/access/sql/typedef_helper.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2014 Hasso-Plattner-Institut fuer Softwaresystemtechnik GmbH. All rights reserved.
+#ifndef SRC_LIB_ACCESS_SQL_TYPEDEF_H_
+#define SRC_LIB_ACCESS_SQL_TYPEDEF_H_
+
+#include <access/system/PlanOperation.h>
+#include <taskscheduler/Task.h>
+#include <storage/storage_types.h>
+
+#include <vector>
+#include <algorithm>
+
+namespace hyrise {
+namespace access {
+namespace sql {
+
+
+
+typedef std::shared_ptr<PlanOperation> plan_op_t;
+typedef std::shared_ptr<taskscheduler::Task> task_t;
+typedef std::vector<task_t> task_list_t;
+
+
+
+struct TableInfo {
+  // Information about the table
+  std::vector<std::string> fields;
+  std::vector<DataType> data_types;
+  std::string name;
+
+  inline void addField(std::string field) { fields.push_back(field); }
+  inline void addField(std::string field, DataType type) { addField(field); data_types.push_back(type); }
+  inline bool containsField(std::string field) const { return std::find(fields.begin(), fields.end(), field) != fields.end(); }
+  inline bool hasName(std::string name2) const { return name2.compare(name) == 0; }
+  inline size_t numColumns() const { return fields.size(); }
+};
+
+struct TransformationResult : TableInfo {
+  task_t first_task;
+  task_t last_task;
+
+  void append(const TransformationResult& other) {
+    fields     = other.fields;
+    data_types = other.data_types;
+    name       = other.name;
+    last_task  = other.last_task;
+  }
+
+  void addTask(const task_t& task) {
+  	if (first_task == nullptr) first_task = task;
+  	last_task = task;
+  }
+};
+
+// Zero initializes a Transformation Result struct without causing warnings
+// TransformationResult t = ALLOC_TRANSFORMATIONRESULT();
+#define ALLOC_TRANSFORMATIONRESULT() {}
+
+
+} // namespace sql
+} // namespace access
+} // namespace hyrise
+#endif

--- a/src/lib/access/system/PlanOperation.cpp
+++ b/src/lib/access/system/PlanOperation.cpp
@@ -192,10 +192,13 @@ void PlanOperation::setLimit(uint64_t l) { _limit = l; }
 void PlanOperation::setProducesPositions(bool p) { producesPositions = p; }
 
 void PlanOperation::setTXContext(tx::TXContext ctx) { _txContext = ctx; }
+tx::TXContext PlanOperation::getTXContext() { return _txContext; }
 
 void PlanOperation::addInput(storage::c_aresource_ptr_t t) { input.addResource(t); }
 
 void PlanOperation::setPlanId(std::string i) { _planId = i; }
+std::string PlanOperation::getPlanId() { return _planId; }
+
 void PlanOperation::setOperatorId(std::string i) { _operatorId = i; }
 
 const std::string& PlanOperation::getOperatorId() { return _operatorId; }

--- a/src/lib/access/system/PlanOperation.h
+++ b/src/lib/access/system/PlanOperation.h
@@ -52,6 +52,7 @@ class PlanOperation : public OutputTask {
   void setProducesPositions(bool p);
 
   void setTXContext(tx::TXContext ctx);
+  tx::TXContext getTXContext();
 
   void addInput(storage::c_aresource_ptr_t t);
 
@@ -65,6 +66,8 @@ class PlanOperation : public OutputTask {
   void addNamedField(const field_name_t& field);
 
   void setPlanId(std::string i);
+  std::string getPlanId();
+  
   void setOperatorId(std::string i);
   const std::string& getOperatorId();
   const std::string& planOperationName() const;

--- a/src/lib/access/system/ResponseTask.cpp
+++ b/src/lib/access/system/ResponseTask.cpp
@@ -104,8 +104,8 @@ void ResponseTask::registerPlanOperation(const std::shared_ptr<PlanOperation>& p
 
 std::shared_ptr<PlanOperation> ResponseTask::getResultTask() {
   // FIXME not thread safe!
-  if (getDependencyCount() > 0) {
-    return std::dynamic_pointer_cast<PlanOperation>(_dependencies[0]);
+  if (getDependencyCount() > _resultTaskIndex) {
+    return std::dynamic_pointer_cast<PlanOperation>(_dependencies[_resultTaskIndex]);
   }
   return nullptr;
 }
@@ -230,7 +230,7 @@ Json::Value ResponseTask::generateResponseJson() {
 void ResponseTask::operator()() {
   Json::Value response;
 
-  if (getDependencyCount() > 0) {
+  if (getDependencyCount() > _resultTaskIndex) {
     response = generateResponseJson();
   }
 

--- a/src/lib/access/system/ResponseTask.h
+++ b/src/lib/access/system/ResponseTask.h
@@ -25,6 +25,9 @@ class ResponseTask : public taskscheduler::Task {
   size_t _transmitLimit = 0;  // Used for serialization only
   size_t _transmitOffset = 0;  // Used for serialization only
 
+  // Indicates which dependency contains the result
+  int _resultTaskIndex = 0;
+
   std::atomic<unsigned long> _affectedRows;
   tx::TXContext _txContext;
   epoch_t queryStart = 0;
@@ -79,6 +82,8 @@ class ResponseTask : public taskscheduler::Task {
   void setTransmitLimit(size_t l) { _transmitLimit = l; }
 
   void setTransmitOffset(size_t o) { _transmitOffset = o; }
+
+  void setResultTaskIndex(int i) { _resultTaskIndex = i; }
 
   void incAffectedRows(unsigned long inc) { _affectedRows += inc; }
 

--- a/test/autosql/create_insert.json
+++ b/test/autosql/create_insert.json
@@ -1,18 +1,14 @@
 {
-    "test": [
-        "CREATE TABLE test (year INTEGER, quarter INTEGER, amount INTEGER);",
-
-        "INSERT INTO test VALUES (2009, 1, 2000);",
-        "INSERT INTO test VALUES (2009, 2, 2500);",
-        "INSERT INTO test VALUES (2009, 3, 3000);",
-        "INSERT INTO test VALUES (2009, 4, 4000);",
-        "INSERT INTO test VALUES (2010, 1, 2400);",
-        "INSERT INTO test VALUES (2010, 2, 2800);",
-        "INSERT INTO test VALUES (2010, 3, 3200);",
-        "INSERT INTO test VALUES (2010, 4, 3600);",
-
-        "SELECT * FROM test"
-    ],
+    "test": "CREATE TABLE test (year INTEGER, quarter INTEGER, amount INTEGER);
+             INSERT INTO test VALUES (2009, 1, 2000);
+             INSERT INTO test VALUES (2009, 2, 2500);
+             INSERT INTO test VALUES (2009, 3, 3000);
+             INSERT INTO test VALUES (2009, 4, 4000);
+             INSERT INTO test VALUES (2010, 1, 2400);
+             INSERT INTO test VALUES (2010, 2, 2800);
+             INSERT INTO test VALUES (2010, 3, 3200);
+             INSERT INTO test VALUES (2010, 4, 3600);
+             SELECT * FROM test",
     "reference": {
         "operators": {
             "0": {

--- a/test/autosql/delete.json
+++ b/test/autosql/delete.json
@@ -1,11 +1,8 @@
 {
-	"test": [
-    	"CREATE TABLE students FROM TBL FILE 'students.tbl';",
-    	"DELETE FROM students WHERE grade >= 3.0;",
-    	"SELECT * FROM students;"
-    ],
-    "reference": [
-    	"CREATE TABLE reference FROM TBL FILE 'students.tbl';",
-    	"SELECT * FROM reference WHERE grade < 3.0;"
-    ]
+	"test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+	    	 DELETE FROM students WHERE grade >= 3.0;
+	    	 SELECT * FROM students;",
+
+    "reference": "CREATE TABLE reference FROM TBL FILE 'students.tbl';
+    			  SELECT * FROM reference WHERE grade < 3.0;"
 }

--- a/test/autosql/drop.json
+++ b/test/autosql/drop.json
@@ -1,12 +1,9 @@
 {
-	"test": [
-    	"CREATE TABLE students FROM TBL FILE 'students.tbl';",
-    	"DROP TABLE students;",
-    	"CREATE TABLE students (name TEXT, student_number INT, city TEXT, grade DOUBLE);",
-    	"SELECT * FROM students"
-	],
-	"reference": [
-		"CREATE TABLE reference (name TEXT, student_number INT, city TEXT, grade DOUBLE);",
-    	"SELECT * FROM reference"
-	]
+	"test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+	    	 DROP TABLE students;
+	    	 CREATE TABLE students (name TEXT, student_number INT, city TEXT, grade DOUBLE);
+	    	 SELECT * FROM students",
+	    	 
+	"reference": "CREATE TABLE reference (name TEXT, student_number INT, city TEXT, grade DOUBLE);
+    			  SELECT * FROM reference"
 }

--- a/test/autosql/groupby.json
+++ b/test/autosql/groupby.json
@@ -1,6 +1,7 @@
 {
-    "prepare": "CREATE TABLE dates FROM TBL FILE 'tables/dates.tbl';",
-    "test": "SELECT year, SUM(amount) AS total_amount, COUNT(\"date\") AS count, AVG(amount) as average_amount, MIN(amount) minimum_amount, MAX(amount) maximum_amount, MIN(\"date\") first_of_year FROM dates GROUP BY year",
+    "test": "CREATE TABLE dates FROM TBL FILE 'tables/dates.tbl';
+             SELECT year, SUM(amount) AS total_amount, COUNT(\"date\") AS count, AVG(amount) as average_amount, MIN(amount) minimum_amount, MAX(amount) maximum_amount, MIN(\"date\") first_of_year FROM dates GROUP BY year",
+             
     "reference": {
         "operators": {
             "0": {

--- a/test/autosql/howto.json
+++ b/test/autosql/howto.json
@@ -11,10 +11,9 @@
  will be executed and compared with the result of "test"
  */
 {
-    "test": [
-        "CREATE TABLE students FROM TBL FILE 'students.tbl';",
-        "SELECT * FROM students"
-    ],
+    "test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+             SELECT * FROM students",
+             
     "reference": {
     	"operators": {
 	        "0": {

--- a/test/autosql/insert_values.json
+++ b/test/autosql/insert_values.json
@@ -1,9 +1,8 @@
 {
-    "test": [
-        "CREATE TABLE students FROM TBL FILE 'students.tbl';",
-        "INSERT INTO students VALUES ('Max', 42, 'Musterhausen', 2.3);",
-        "SELECT * FROM students;"
-    ],
+    "test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+             INSERT INTO students VALUES ('Max', 42, 'Musterhausen', 2.3);
+             SELECT * FROM students;",
+             
     "reference": {
         "operators": {
             "0": {

--- a/test/autosql/join.json
+++ b/test/autosql/join.json
@@ -1,6 +1,7 @@
 {
-    "prepare": "CREATE TABLE employees FROM TBL FILE 'tables/employees.tbl'; CREATE TABLE companies FROM TBL FILE 'tables/companies.tbl';",
-    "test": "SELECT * FROM employees JOIN companies ON company_id = employee_company_id;",
+    "test": "CREATE TABLE employees FROM TBL FILE 'tables/employees.tbl'; CREATE TABLE companies FROM TBL FILE 'tables/companies.tbl';
+             SELECT * FROM employees JOIN companies ON company_id = employee_company_id;",
+                
     "reference": {
         "operators": {
             "0": {

--- a/test/autosql/like_expression.json
+++ b/test/autosql/like_expression.json
@@ -1,7 +1,8 @@
 /* equivalent to autojson/like_expression.json */
 {
-    "prepare": "CREATE TABLE employees FROM TBL FILE 'tables/employees.tbl';",
-    "test": "SELECT * FROM employees WHERE employee_name LIKE '.teve .*' OR employee_name LIKE 'Jeffre. .\\. .*ley';",
+    "test": "CREATE TABLE employees FROM TBL FILE 'tables/employees.tbl';
+             SELECT * FROM employees WHERE employee_name LIKE '.teve .*' OR employee_name LIKE 'Jeffre. .\\. .*ley';",
+        
     "reference": {
         "operators": {
             "load": {

--- a/test/autosql/mult_transaction.json
+++ b/test/autosql/mult_transaction.json
@@ -1,18 +1,15 @@
 {
-	"test": [
-		"CREATE TABLE students FROM TBL FILE 'students.tbl'",
-		"DELETE FROM students WHERE NOT name LIKE 'K.*'",
-		"INSERT INTO students VALUES ('Max1', 78493, 'Potsdam', 2.0)",
-		"INSERT INTO students VALUES ('Max2', 78494, 'Potsdam', 2.3)",
-		"INSERT INTO students VALUES ('Max3', 78495, 'Potsdam', 3.0)",
-		"INSERT INTO students VALUES ('Max4', 78496, 'Potsdam', 1.3)",
-		"DELETE FROM students WHERE city = 'Berlin';",
-		"SELECT city, MIN(grade) AS best_grade FROM students GROUP BY city;"
-	],
-	"reference": [
-		"CREATE TABLE reference (city TEXT, best_grade DOUBLE);",
-		"INSERT INTO reference VALUES ('Potsdam', 1.3);",
-		"INSERT INTO reference VALUES ('Frohnau', 2.3);",
-		"SELECT * FROM reference"
-	]
+	"test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+			 DELETE FROM students WHERE NOT name LIKE 'K.*';
+			 INSERT INTO students VALUES ('Max1', 78493, 'Potsdam', 2.0);
+			 INSERT INTO students VALUES ('Max2', 78494, 'Potsdam', 2.3);
+			 INSERT INTO students VALUES ('Max3', 78495, 'Potsdam', 3.0);
+			 INSERT INTO students VALUES ('Max4', 78496, 'Potsdam', 1.3);
+			 DELETE FROM students WHERE city = 'Berlin';
+			 SELECT city, MIN(grade) AS best_grade FROM students GROUP BY city;",
+
+	"reference": "CREATE TABLE reference (city TEXT, best_grade DOUBLE);
+				  INSERT INTO reference VALUES ('Potsdam', 1.3);
+				  INSERT INTO reference VALUES ('Frohnau', 2.3);
+				  SELECT * FROM reference"
 }

--- a/test/autosql/select_star.json
+++ b/test/autosql/select_star.json
@@ -1,0 +1,5 @@
+{
+	"test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+			 SELECT *, name FROM students;",
+	"reference": "SELECT name, student_number, city, grade, name FROM students;"
+}

--- a/test/autosql/simpleselect.json
+++ b/test/autosql/simpleselect.json
@@ -1,6 +1,7 @@
 {
-    "prepare": "CREATE TABLE students FROM TBL FILE 'students.tbl';",
-    "test": "SELECT name, city FROM students WHERE grade <= 2.0",
+    "test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+             SELECT name, city FROM students WHERE grade <= 2.0",
+                
     "reference": {
         "operators": {
             "0": {

--- a/test/autosql/subselect.json
+++ b/test/autosql/subselect.json
@@ -1,5 +1,6 @@
 {
-    "prepare": "CREATE TABLE students FROM TBL FILE 'students.tbl';",
-    "test": "SELECT * FROM (SELECT name FROM (SELECT name, city FROM students) t) t;",
+    "test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+   			 SELECT * FROM (SELECT name FROM (SELECT name, city FROM students) t) t;",
+   			
     "reference": "SELECT name FROM (SELECT name, city FROM (SELECT * FROM students) t) t;"
 }

--- a/test/autosql/truncate.json
+++ b/test/autosql/truncate.json
@@ -1,11 +1,8 @@
 {
-    "test": [
-    	"CREATE TABLE students FROM TBL FILE 'students.tbl';",
-    	"TRUNCATE students;",
-    	"SELECT * FROM students;"
-    ],
-    "reference": [
-    	"CREATE TABLE empty_students (name TEXT, student_number INT, city TEXT, grade DOUBLE);",
-    	"SELECT * FROM empty_students;"
-    ]
+    "test": "CREATE TABLE students FROM TBL FILE 'students.tbl';
+	    	 TRUNCATE students;
+	    	 SELECT * FROM students;",
+	    	 
+    "reference": "CREATE TABLE empty_students (name TEXT, student_number INT, city TEXT, grade DOUBLE);
+    	 		  SELECT * FROM empty_students;"
 }

--- a/test/autosql/union.json
+++ b/test/autosql/union.json
@@ -1,6 +1,7 @@
 {
-    "prepare": "CREATE TABLE employees FROM TBL FILE 'tables/employees.tbl';",
-    "test": "SELECT * FROM employees WHERE employee_company_id > 0 AND employee_company_id < 3 UNION SELECT * FROM employees WHERE employee_company_id = 3",
+    "test": "CREATE TABLE employees FROM TBL FILE 'tables/employees.tbl';
+             SELECT * FROM employees WHERE employee_company_id > 0 AND employee_company_id < 3 UNION SELECT * FROM employees WHERE employee_company_id = 3",
+             
     "reference": {
         "operators": {
             "0": {

--- a/test/autosql/update.json
+++ b/test/autosql/update.json
@@ -1,13 +1,10 @@
 {
-	"test": [
-		"CREATE TABLE companies FROM TBL FILE 'tables/companies.tbl'",
-		"UPDATE companies SET company_id = 45 WHERE company_name = 'Microsoft';",
-		"UPDATE companies SET company_name = 'Muster' WHERE company_id = 45;",
-		"UPDATE companies SET company_name = 'Microsoft', company_id = 7 WHERE company_name = 'Muster';",
-		"SELECT * FROM companies;"
-	],
-	"reference": [
-		"CREATE TABLE reference FROM TBL FILE 'reference/companies_after_one_increments.tbl'",
-		"SELECT * FROM reference"
-	]
+	"test": "CREATE TABLE companies FROM TBL FILE 'tables/companies.tbl';
+			 UPDATE companies SET company_id = 45 WHERE company_name = 'Microsoft';
+			 UPDATE companies SET company_name = 'Muster' WHERE company_id = 45;
+			 UPDATE companies SET company_name = 'Microsoft', company_id = 7 WHERE company_name = 'Muster';
+			 SELECT * FROM companies;",
+
+	"reference": "CREATE TABLE reference FROM TBL FILE 'reference/companies_after_one_increments.tbl';
+		 		  SELECT * FROM reference;"
 }


### PR DESCRIPTION
- Added PlanOp SQLQueryTask
  Each Task handles transformation of one SQLStatement and pushes
  the generated tasks into the scheduler.
  This allows subsequent statements to be transformed after the
  previous tasks are already executed.
- Reformatted tests to use this new capability
